### PR TITLE
Kba configure secrets from env

### DIFF
--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -1,16 +1,7 @@
 FROM quay.io/keycloak/keycloak:20.0.3
 
-# TODO: Once we have a intg and prod dbs, update this
-# ENV KC_DB mssql
-# ENV KC_DB_URL jdbc:sqlserver://database:1433;DatabaseName=keycloak;encrypt=true;trustServerCertificate=true;
-# ENV KC_TRANSACTION_XA_ENABLED 'false'
-# ENV KC_DB_USERNAME sa
-# ENV KC_DB_PASSWORD D3velopmentP0
-# ENV KEYCLOAK_ADMIN admin
-# ENV KEYCLOAK_ADMIN_PASSWORD D3velopmentP0
-
 COPY keycloak/realm/ /opt/keycloak/data/import
 COPY keycloak/themes /opt/keycloak/themes
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
-CMD ["start-dev", "--import-realm", "--spi-theme-static-max-age=-1", "--spi-theme-cache-themes=false", "--spi-theme-cache-templates=false", "--spi-theme-welcome-theme=uid2-theme", "--health-enabled=true", "--metrics-enabled=true"]
+CMD ["start-dev", "--import-realm", "--spi-theme-static-max-age=-1", "--spi-theme-cache-themes=false", "--spi-theme-cache-templates=false", "--spi-theme-welcome-theme=uid2-theme", "--health-enabled=true", "--metrics-enabled=true", "--features=declarative-user-profile"]

--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -1,5 +1,7 @@
 FROM quay.io/keycloak/keycloak:20.0.3
 
+ENV KC_TRANSACTION_XA_ENABLED 'false'
+
 COPY keycloak/realm/ /opt/keycloak/data/import
 COPY keycloak/themes /opt/keycloak/themes
 

--- a/knexfile.ts
+++ b/knexfile.ts
@@ -1,13 +1,15 @@
 import type { Knex } from 'knex';
 
+import { SSP_DB_HOST, SSP_DB_PASSWORD, SSP_DB_PORT, SSP_DB_USER } from './src/api/envars';
+
 const config: Knex.Config = {
   client: 'mssql',
   connection: {
-    server: 'localhost',
-    port: 11433,
+    server: SSP_DB_HOST,
+    port: SSP_DB_PORT,
     database: 'uid2_selfserve',
-    user: 'sa',
-    password: 'D3velopmentP0',
+    user: SSP_DB_USER,
+    password: SSP_DB_PASSWORD,
   },
   migrations: {
     directory: './src/database/migrations',

--- a/src/api/envars.ts
+++ b/src/api/envars.ts
@@ -20,3 +20,9 @@ export const SSP_KK_SSL_PUBLIC_CLIENT = process.env.SSP_KK_SSL_PUBLIC_CLIENT ?? 
 export const SSP_KK_SSL_CONFIDENTIAL_PORT =
   process.env.SSP_KK_SSL_CONFIDENTIAL_PORT ?? errorMessage;
 export const SSP_WEB_BASE_URL = process.env.SSP_WEB_BASE_URL ?? 'http://localhost:3000/';
+
+// DB config
+export const SSP_DB_HOST = process.env.SSP_DB_HOST ?? 'localhost';
+export const SSP_DB_PORT = process.env.SSP_DB_PORT ? +process.env.SSP_DB_PORT : 11433;
+export const SSP_DB_USER = process.env.SSP_DB_USER ?? 'sa';
+export const SSP_DB_PASSWORD = process.env.SSP_DB_PASSWORD ?? 'D3velopmentP0';


### PR DESCRIPTION
### What does this MR do?

Enables using k8s secrets for the mssql connections. 

#### What was tested
1. Tested locally by building ssportal image and running with `-e SSP_DB_HOST=host.docker.internal -e SSP_DB_PORT=11433`. Checked that api response is returning records after connecting to mssql.
2. Negative test - used wrong values to ensure env is taken properly
3. KK image tested locally by passing env, and checking tables are created in db.
```
docker run --publish 18080:8080 -e KEYCLOAK_ADMIN=.. -e KEYCLOAK_ADMIN_PASSWORD=.. -e KC_DB=mssql -e KC_DB_URL="<jdbcurl>" -e KC_DB_USERNAME=.. -e KC_DB_PASSWORD=..  <imagename>
```