### PR TITLE
Enable substituting the localhost values in keycloak docker

### DIFF
--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -2,8 +2,13 @@ FROM quay.io/keycloak/keycloak:20.0.3
 
 ENV KC_TRANSACTION_XA_ENABLED 'false'
 
-COPY keycloak/realm/ /opt/keycloak/data/import
+
+COPY keycloak/realm/realm-export.json /opt/keycloak/data/import/realm-export.json
 COPY keycloak/themes /opt/keycloak/themes
 
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
-CMD ["start-dev", "--import-realm", "--spi-theme-static-max-age=-1", "--spi-theme-cache-themes=false", "--spi-theme-cache-templates=false", "--spi-theme-welcome-theme=uid2-theme", "--health-enabled=true", "--metrics-enabled=true", "--features=declarative-user-profile"]
+USER root
+RUN chmod -R 775 /opt/keycloak/data/import
+USER keycloak
+
+ENTRYPOINT sed -i -E "s/http:\/\/localhost:[0-9]{4}/https:\/\/$SSP_WEB_HOST/g" opt/keycloak/data/import/realm-export.json && \
+/opt/keycloak/bin/kc.sh start-dev --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --spi-theme-welcome-theme=uid-theme --health-enabled=true --metrics-enabled=true --features=declarative-user-profile

--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -11,4 +11,4 @@ RUN chmod -R 775 /opt/keycloak/data/import
 USER keycloak
 
 ENTRYPOINT sed -i -E "s/http:\/\/localhost:[0-9]{4}/https:\/\/$SSP_WEB_HOST/g" opt/keycloak/data/import/realm-export.json && \
-/opt/keycloak/bin/kc.sh start-dev --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --spi-theme-welcome-theme=uid-theme --health-enabled=true --metrics-enabled=true --features=declarative-user-profile
+/opt/keycloak/bin/kc.sh start --hostname=$SSP_AUTH_HOST --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --spi-theme-welcome-theme=uid-theme --health-enabled=true --metrics-enabled=true --features=declarative-user-profile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       KC_DB_PASSWORD: D3velopmentP0
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: D3velopmentP0
+      SSP_WEB_HOST: localhost:3000
     ports:
       - 18080:8080
       - 19990:9990


### PR DESCRIPTION
### What does this PR do ? 

We use realms-export.json for setting up keycloak configurations, but currently it only has development setting by default. 

For integration and prod environments, urls will have to change. To enable this without having to build images that change for each environment, this PR uses ENV variables to modify the realms-export before running the container. 
This ensures we can re-use the same image across environments.