### PR TITLE
kba: Use web base url as the redirect url for auth

### DIFF
--- a/src/web/axios.ts
+++ b/src/web/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 let requestInterceptor: number;
 
-axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL;
+axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL ?? '/api';
 
 export const ejectHeader = () => {
   axios.interceptors.request.eject(requestInterceptor);

--- a/src/web/screens/login.tsx
+++ b/src/web/screens/login.tsx
@@ -8,11 +8,11 @@ import './login.scss';
 function Login() {
   const { keycloak } = useKeycloak();
   const login = useCallback(() => {
-    keycloak?.login({ redirectUri: 'http://localhost:3000' });
+    keycloak?.login({ redirectUri: window.location.origin });
   }, [keycloak]);
 
   const logout = useCallback(() => {
-    keycloak?.logout({ redirectUri: 'http://localhost:3000' });
+    keycloak?.logout({ redirectUri: window.location.origin });
   }, [keycloak]);
 
   return (


### PR DESCRIPTION
### What does this PR do ? 

1. For the front-end, we don't have process.env available. This sets up the api url default that nginx proxy handles later
2. Currently the redirect url is meant for development purposes, and is hard-coded to localhost. Changing this to redirect the user back to the base url. This also makes sure that the front-end doesn't rely on any env variables.