### PR TITLE
kba: Fix the default loki host and update app name to reflect uid2 pr…

### DIFF
--- a/src/api/envars.ts
+++ b/src/api/envars.ts
@@ -1,12 +1,12 @@
 const errorMessage = 'Unable to get envar value';
 
 // General Config
-export const SSP_APP_NAME = process.env.SSP_APP_NAME ?? 'ssportal';
+export const SSP_APP_NAME = process.env.SSP_APP_NAME ?? 'uid2-ssportal';
 export const SSP_IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 export const SSP_IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 // Loki Config
-export const SSP_LOKI_HOST = process.env.SSP_LOKI_HOST ?? 'http://localhost:3100';
+export const SSP_LOKI_HOST = process.env.SSP_LOKI_HOST ?? 'http://loki:3100';
 
 // Keycloak Config
 export const SSP_KK_AUDIENCE = process.env.SSP_KK_AUDIENCE ?? errorMessage;


### PR DESCRIPTION
### What does this MR do?

Fixes the loki url used in k8s environments, and updates the app name to reflect uid2 prefix convention followed

Post this change, logs can be queried in the dashboard for any UI errors via the traceID as so:-

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/1330389/a5de6105-9a2d-49c9-a164-8b4cba7ad98d)

