### PR TITLE
Fix participants search bug

### DIFF
--- a/src/web/components/SharingPermission/ParticipantSearchBar.scss
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.scss
@@ -1,6 +1,6 @@
 .search-icon {
   color: var(--theme-search-border);
-  height: 23px;
+  height: 1.4375rem;
 }
 
 .search-bar-input-container {
@@ -30,8 +30,8 @@
   outline: none;
   color: var(--theme-button-text);
   font-weight: 400;
-  font-size: 30px;
-  line-height: 36px;
+  font-size: 1.875rem;
+  line-height: 2.25rem;
   background: none;
   width: 100%;
 }
@@ -53,11 +53,11 @@
   th,
   td {
     background: none !important;
-    padding: 0 0 1rem !important;
+    padding: 0 0 16px !important;
   }
 
   th {
-    padding-top: 1.2rem !important;
+    padding-top: 19px !important;
   }
 
   th:first-of-type,
@@ -66,19 +66,19 @@
   }
 
   tr:last-of-type td {
-    padding-bottom: 1.2rem !important;
+    padding-bottom: 19px !important;
   }
 }
 
 .search-bar-footer {
   background-color: var(--theme-search-bar-background);
-  padding: 0.5rem;
+  padding: 8px;
   text-align: center;
 }
 
 .search-bar-footer a {
-  font-size: 15px;
-  line-height: 18px;
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
   font-weight: 500;
   text-decoration: none;
   color: var(--theme-action);
@@ -86,6 +86,6 @@
 
 .select-all {
   font-weight: 700;
-  font-size: 14px;
-  line-height: 17px;
+  font-size: 0.875rem;
+  line-height: 1.0625rem;
 }

--- a/src/web/components/SharingPermission/ParticipantSearchBar.scss
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.scss
@@ -9,18 +9,19 @@
   border-bottom: 2px solid var(--theme-search-border);
   padding: 10px;
   justify-content: space-between;
+
   ::placeholder {
     /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: var(--theme-button-text);
     opacity: 1; /* Firefox */
   }
 
-  :-ms-input-placeholder {
+  :input-placeholder {
     /* Internet Explorer 10-11 */
     color: var(--theme-button-text);
   }
 
-  ::-ms-input-placeholder {
+  ::input-placeholder {
     /* Microsoft Edge */
     color: var(--theme-button-text);
   }
@@ -28,7 +29,7 @@
 
 .clicked .search-bar-input-container {
   background: var(--theme-search-bar-background);
-  border-radius: 10px 10px 0px 0px;
+  border-radius: 10px 10px 0 0;
 }
 
 .search-bar-type-filter-title {
@@ -48,36 +49,36 @@
 
 .search-bar-dropdown {
   background: var(--theme-background-content);
-  box-shadow: 0px 4px 8px var(--theme-box-shadow);
-  border-radius: 0px 0px 10px 10px;
+  box-shadow: 0 4px 8px var(--theme-box-shadow);
+  border-radius: 0 0 10px 10px;
 }
 
 .search-bar-type-filter {
-  padding: 20px 20px 15px 20px;
+  padding: 20px 20px 15px;
   border-bottom: 1px solid var(--theme-table-border);
 }
 
 .search-bar-participants {
   padding: 20px;
-}
 
-.search-bar-participants th,
-td {
-  background: none !important;
-  padding: 0 0 1rem 0 !important;
-}
+  th,
+  td {
+    background: none !important;
+    padding: 0 0 1rem !important;
+  }
 
-.search-bar-participants th:first-of-type,
-.search-bar-participants td:first-of-type {
-  padding-left: 10px !important;
-}
+  th {
+    padding-top: 1.2rem !important;
+  }
 
-.search-bar-participants th {
-  padding-top: 1.2rem !important;
-}
+  th:first-of-type,
+  td:first-of-type {
+    padding-left: 10px !important;
+  }
 
-.search-bar-participants tr:last-of-type td {
-  padding-bottom: 1.2rem !important;
+  tr:last-of-type td {
+    padding-bottom: 1.2rem !important;
+  }
 }
 
 .search-bar-footer {

--- a/src/web/components/SharingPermission/ParticipantSearchBar.scss
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.scss
@@ -11,19 +11,8 @@
   justify-content: space-between;
 
   ::placeholder {
-    /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: var(--theme-button-text);
     opacity: 1; /* Firefox */
-  }
-
-  :input-placeholder {
-    /* Internet Explorer 10-11 */
-    color: var(--theme-button-text);
-  }
-
-  ::input-placeholder {
-    /* Microsoft Edge */
-    color: var(--theme-button-text);
   }
 }
 


### PR DESCRIPTION
There was a bug in the CSS causing the td padding on the participants search bar to apply to all td elements site-wide. This refactors the file to make better use of SCSS nesting and removes some unnecessary vendor-specific rules.