### PR TITLE
Fix nginx reload for app

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,9 +5,16 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+
+    location /api/ {
+        proxy_pass $scheme://$server_addr:6540;
+    }
+
+
     location / {
         root   /usr/src/app/build;
-        index  index.html index.htm;
+        try_files $uri /index.html;
+        # index  index.html index.htm;
     }
 
     #error_page  404              /404.html;
@@ -42,9 +49,6 @@ server {
     #    deny  all;
     #}
 
-    location /api/ {
-        proxy_pass $scheme://$server_addr:6540;
-    }
 }
 
 server {


### PR DESCRIPTION
### What does this PR do ? 

Currently, the app does not work if the user is on a non-root url and hits refresh. Examples. portal.integ.unifiedid.com/login

This enables the routing using try_files and fixes the order. 