### PR TITLE
UID2-1338 Send email to TAM based on the participant types

### DIFF
--- a/src/api/entities/Approver.ts
+++ b/src/api/entities/Approver.ts
@@ -1,0 +1,24 @@
+import { Model } from 'objection';
+import { z } from 'zod';
+
+import { BaseModel } from './BaseModel';
+
+export class Approver extends BaseModel {
+  static get tableName() {
+    return 'approvers';
+  }
+  static relationMappings = {
+    type: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: 'ParticipantType',
+      join: {
+        from: 'approvers.participantTypeId',
+        to: 'participantsToTypes.id',
+      },
+    },
+  };
+  id!: number;
+  email!: string;
+  participantTypeId!: number;
+  displayName!: string;
+}

--- a/src/api/envars.ts
+++ b/src/api/envars.ts
@@ -30,6 +30,3 @@ export const SSP_SEND_GRID_API_KEY = process.env.SSP_SEND_GRID_API_KEY ?? '';
 export const SSP_EMAIL_SENDER = process.env.SSP_EMAIL_SENDER ?? 'noreply@unifiedid.com';
 export const SSP_EMAIL_SENDER_NAME =
   process.env.SSP_EMAIL_SENDER_NAME ?? 'UID2 Service (do not reply)';
-
-export const SSP_TAM_EMAIL = process.env.SSP_TAM_EMAIL ?? errorMessage;
-export const SSP_TAM_EMAIL_DISPLAY_NAME = process.env.SSP_TAM_EMAIL ?? 'TAMs';

--- a/src/api/participantsRouter.ts
+++ b/src/api/participantsRouter.ts
@@ -2,7 +2,6 @@ import express, { NextFunction, Request, Response } from 'express';
 import { z } from 'zod';
 
 import { Participant, ParticipantCreationPartial, ParticipantSchema } from './entities/Participant';
-import { ParticipantType } from './entities/ParticipantType';
 import { UserRole } from './entities/User';
 import { getKcAdminClient } from './keycloakAdminClient';
 import { createNewUser, sendInviteEmail } from './services/kcUsersService';
@@ -51,8 +50,10 @@ participantsRouter.post('/', async (req, res) => {
       relate: true,
     });
 
-    const participantTypes = await ParticipantType.query().findByIds(data.types!.map((t) => t.id));
-    sendNewParticipantEmail(data, participantTypes);
+    sendNewParticipantEmail(
+      data,
+      data.types.map((t) => t.id)
+    );
     return res.status(201).json(newParticipant);
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/src/api/services/approversService.ts
+++ b/src/api/services/approversService.ts
@@ -1,0 +1,5 @@
+import { Approver } from '../entities/Approver';
+
+export const findApproversByType = async (typeIds: number[]) => {
+  return Approver.query().distinct('email').whereIn('participantTypeId', typeIds);
+};

--- a/src/api/services/emailTypes.ts
+++ b/src/api/services/emailTypes.ts
@@ -6,7 +6,7 @@ export type EmailArgs = {
   subject: string;
   templateData: { [key: string]: unknown };
   template: string;
-  to: EmailData;
+  to: EmailData | EmailData[];
 };
 
 export const UID2Sender: EmailData = {

--- a/src/api/services/nodemailerService.ts
+++ b/src/api/services/nodemailerService.ts
@@ -38,7 +38,7 @@ export const sendEmail = async ({
 }: EmailArgs): Promise<void> => {
   const mailOptions = {
     from: convertEmailDataToAddress(UID2Sender),
-    to: convertEmailDataToAddress(to),
+    to: Array.isArray(to) ? to.map(convertEmailDataToAddress) : convertEmailDataToAddress(to),
     subject,
     template,
     context: templateData,

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -2,14 +2,16 @@ import { z } from 'zod';
 
 import { ParticipantCreationPartial } from '../entities/Participant';
 import { ParticipantType } from '../entities/ParticipantType';
-import { SSP_TAM_EMAIL, SSP_TAM_EMAIL_DISPLAY_NAME, SSP_WEB_BASE_URL } from '../envars';
+import { SSP_WEB_BASE_URL } from '../envars';
+import { findApproversByType } from './approversService';
 import { createEmailService } from './emailService';
 import { EmailArgs } from './emailTypes';
 
 export const sendNewParticipantEmail = async (
   newParticipant: z.infer<typeof ParticipantCreationPartial>,
-  participantTypes: ParticipantType[]
+  typeIds: number[]
 ) => {
+  const participantTypes = await ParticipantType.query().findByIds(typeIds);
   const emailService = createEmailService();
   const requestor = newParticipant.users![0];
   const templateData = {
@@ -21,11 +23,13 @@ export const sendNewParticipantEmail = async (
     jobFunction: requestor.role,
     link: SSP_WEB_BASE_URL,
   };
+
+  const approvers = await findApproversByType(typeIds);
   const emailArgs: EmailArgs = {
     subject: 'New Participant Request',
     templateData,
     template: 'newParticipantReadyForReview',
-    to: { name: SSP_TAM_EMAIL_DISPLAY_NAME, email: SSP_TAM_EMAIL },
+    to: approvers.map((a) => ({ name: a.displayName, email: a.email })),
   };
   emailService.sendEmail(emailArgs);
 };

--- a/src/database/migrations/20230621045435_CreateApproversTable.ts
+++ b/src/database/migrations/20230621045435_CreateApproversTable.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('approvers', (table) => {
+    table.increments('id').primary();
+    table.string('displayName', 256);
+    table.string('email', 256).notNullable();
+    table
+      .integer('participantTypeId')
+      .references('id')
+      .inTable('participantTypes')
+      .onDelete('CASCADE');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('approvers');
+}

--- a/src/database/seeds/Approvers.ts
+++ b/src/database/seeds/Approvers.ts
@@ -1,0 +1,78 @@
+import { Knex } from 'knex';
+import { ModelObject } from 'objection';
+import { Optional } from 'utility-types';
+
+import { Approver } from '../../api/entities/Approver';
+
+type ApproverType = ModelObject<Approver>;
+const sampleData: Optional<ApproverType & { type: string }, 'id' | 'participantTypeId'>[] = [
+  {
+    email: 'dsp_approver@example.com',
+    displayName: 'DSP Approver',
+    type: 'DSP',
+  },
+  {
+    email: 'advertiser_approver@example.com',
+    displayName: 'Advertiser Approver',
+    type: 'Advertiser',
+  },
+  {
+    email: 'publisher_approver@example.com',
+    displayName: 'Publisher Approver',
+    type: 'Publisher',
+  },
+  {
+    email: 'dp_approver@example.com',
+    displayName: 'Data Provider Approver',
+    type: 'Data Provider',
+  },
+  {
+    email: 'test@example.com',
+    displayName: 'Test Admin',
+    type: 'DSP',
+  },
+  {
+    email: 'test@example.com',
+    displayName: 'Test Admin',
+    type: 'Advertiser',
+  },
+  {
+    email: 'test@example.com',
+    displayName: 'Test Admin',
+    type: 'Publisher',
+  },
+  {
+    email: 'test@example.com',
+    displayName: 'Test Admin',
+    type: 'Data Provider',
+  },
+];
+
+export async function CreateApprover(
+  knex: Knex,
+  details: Optional<ApproverType & { type: string }, 'id' | 'participantTypeId'>
+) {
+  const participantType = await knex('participantTypes').where('typeName', details.type);
+  return knex('approvers').insert<{
+    email: number;
+    participantTypeId: number;
+    displayName: string;
+  }>({
+    email: details.email,
+    participantTypeId: participantType[0].id as number,
+    displayName: details.displayName,
+  });
+}
+
+export async function seed(knex: Knex): Promise<void> {
+  // Deletes ALL existing entries
+  await knex('approvers')
+    .whereIn(
+      'email',
+      sampleData.map((d) => d.email)
+    )
+    .del();
+  // Inserts seed entries
+  const promises = sampleData.map((sample) => CreateApprover(knex, sample));
+  await Promise.all(promises);
+}


### PR DESCRIPTION
ticket: [UID2-1338](https://atlassian.thetradedesk.com/jira/browse/UID2-1338)

Rather than set up a particular email in the env variable to resolve approval requests, this PR introduces a new mapping table that maps the approver with participant types. 

In dev environment,  data seed is required to insert approvers for testing purposes, you can do it by running`npm run knex:seed:run`

Test Screenshot:
![Screenshot 2023-06-21 at 5 28 08 pm](https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/7fd6f10a-59b5-46cc-86cd-259e304b49c0)
