### PR TITLE
UID2-1516 setup role check on endpoint

### DIFF
--- a/KeycloakAdvancedSetup.md
+++ b/KeycloakAdvancedSetup.md
@@ -1,0 +1,43 @@
+# Keycloak Advanced Setup
+
+This document provides detailed instructions on more advanced Keycloak setup topics such as generating the SSP_KK_SECRET, resetting the realm, and enabling blocking account creation by free email providers.
+
+## Generating SSP_KK_SECRET
+
+You can obtain the `SSP_KK_SECRET` by generating a new client secret in the Keycloak admin portal. Here's how you can do it:
+
+1. Login to the Keycloak admin console.
+2. Ensure the realm dropdown has 'self-serve-portal' selected (rather than 'master'), then navigate to the "Clients" page and select the `self-serve-portal-apis`.
+3. Go to the "Credentials" tab and regenerate the Client secret by clicking "Regenerate".
+4. Copy the new client secret and use it as the value of the `SSP_KK_SECRET` environment variable in your `.env` file.
+
+## Reset Realm
+
+You might need to do this if the realm configuration has been updated by someone on another branch. If you update your own Keycloak realm configuration, make sure you include the changes in your PR by exporting the realm and updating `keycloak\realm\realm-export.json`.
+
+```
+docker exec -it uid2_selfserve_keycloak /bin/sh -c "/opt/keycloak/bin/kc.sh import --file /opt/keycloak/data/import/realm-export.json --override true;exit 0"
+docker compose restart keycloak
+```
+
+This script imports the [realm-export.json](https://github.com/IABTechLab/uid2-self-serve-portal/blob/main/keycloak/realm/realm-export.json) to the keycloak and override realm if exists.\
+It is important to note that all the users in the realm will be removed. You may also need to re-generate your client secrets (see the main Keycloak setup entry above).
+
+## Enable blocking account creation by free email providers
+
+> Declarative User Profile is Technology Preview and is not fully supported.
+
+1. Click on the `Realm Settings` on the left side menu and click the `User Profile` tab.
+2. Click on `email`, scroll down to `validators` and click `create validator`.
+3. Select `pattern` from the list and add `^(?!.*@(gmail|hotmail|yahoo)\.com$).+@.+\..+$` as pattern and `errorPatternNoMatch` as error message key
+4. Click on the `Save` button
+
+## Assign Role to a Particular User
+
+The following instructions detail how to assign a specific role to a user in Keycloak:
+
+1. From the Keycloak admin console, select `Users` from the left side menu.
+2. Locate the user from the user list. You can use the search bar if necessary.
+3. Click on the desired username to open the user's detail page. Then, select the `Role Mapping` tab.
+4. Click Assign role. If the role you want to assign isn't immediately visible, select `Filter by realm roles` to open the dropdown menu, and then switch to `Filter by clients`.
+5. Locate the role in the client roles list. Tick the checkbox next to the role, and then click `Assign`.

--- a/README.md
+++ b/README.md
@@ -97,35 +97,7 @@ Focus on testing functionality, not implementation. For example, if you have a b
 - To access [keycloak admin console](http://localhost:18080/admin/), you can find the username and password in the `docker-compose.yml`
 - If you set an email address for the admin account, you will need to use that email address to log into the Keycloak admin console
 
-### Generating SSP_KK_SECRET
-
-You can obtain the `SSP_KK_SECRET` by generating a new client secret in the Keycloak admin portal. Here's how you can do it:
-
-1. Login to the Keycloak admin console.
-2. Ensure the realm dropdown has 'self-serve-portal' selected (rather than 'master'), then navigate to the "Clients" page and select the `self-serve-portal-apis`.
-3. Go to the "Credentials" tab and regenerate the Client secret by clicking "Regenerate".
-4. Copy the new client secret and use it as the value of the `SSP_KK_SECRET` environment variable in your `.env` file.
-
-### Reset Realm
-
-You might need to do this if the realm configuration has been updated by someone on another branch. If you update your own Keycloak realm configuration, make sure you include the changes in your PR by exporting the realm and updating `keycloak\realm\realm-export.json`.
-
-```
-docker exec -it uid2_selfserve_keycloak /bin/sh -c "/opt/keycloak/bin/kc.sh import --file /opt/keycloak/data/import/realm-export.json --override true;exit 0"
-docker compose restart keycloak
-```
-
-This script imports the [realm-export.json](https://github.com/IABTechLab/uid2-self-serve-portal/blob/main/keycloak/realm/realm-export.json) to the keycloak and override realm if exists.\
-It is important to note that all the users in the realm will be removed. You may also need to re-generate your client secrets (see the main Keycloak setup entry above).
-
-### Enable blocking account creation by free email providers
-
-> Declarative User Profile is Technology Preview and is not fully supported.
-
-1. Click on the `Realm Settings` on the left side menu and click the `User Profile` tab.
-2. Click on `email`, scroll down to `validators` and click `create validator`.
-3. Select `pattern` from the list and add `^(?!.*@(gmail|hotmail|yahoo)\.com$).+@.+\..+$` as pattern and `errorPatternNoMatch` as error message key
-4. Click on the `Save` button
+For more advanced setup, see [Keycloak Advanced Setup](./KeycloakAdvancedSetup.md).
 
 ## Logging stack
 
@@ -189,6 +161,7 @@ This action should be triggered after adding or updating any templates and befor
 In the project directory, you can run:
 
 ### `npm install`
+
 Installs the dependencies for the project. You will need to run this before running any of the following commands.
 
 ### `npm run dev`
@@ -223,31 +196,32 @@ Your app is ready to be deployed! Note that builds for deployment are not made o
 ## Setting up UI Dev Environment
 
 1. Set up Docker, as described above: [Docker](README.md#docker)
-2. Update your `SSP_KK_SECRET` by following the steps above: [Generating SSP_KK_SECRET](README.md#generating-ssp_kk_secret)
+2. Update your `SSP_KK_SECRET` by following the steps above: [Generating SSP_KK_SECRET](./KeycloakAdvancedSetup.md#generating-ssp_kk_secret)
 3. Run the following to install dependencies:
-    ```
-    npm install
-    ```
+   ```
+   npm install
+   ```
 4. Run the following to start the API and React front-end:
-    ```
-    npm run dev
-    ``` 
-    Successfully running this will result in the self-serve-portal opening in the browser.
+   ```
+   npm run dev
+   ```
+   Successfully running this will result in the self-serve-portal opening in the browser.
 5. Run the following to build the database schema:
-    ```
-    npm run knex:migrate:latest
-    ``` 
+   ```
+   npm run knex:migrate:latest
+   ```
 6. Run the following to populate test data:
-    ```
-    npm run knex:seed:run
-    ``` 
+   ```
+   npm run knex:seed:run
+   ```
 7. Create an account in the UI by clicking `Create Account`. You can use a fake email address since we use [MailHog](https://github.com/mailhog/MailHog) to capture emails and store them locally.
 8. Go to local MailHog at http://localhost:18025/ and you will see an email from `test@self-serve-portal.com` with the subject `Verify email`
 9. Open the email and Click `Verify Email`
 10. Fill in the form however you want and submit the form
 11. Connect to the database server `localhost,11433` using the credentials in [docker-compose.yml](docker-compose.yml)
 12. In the `uid2_selfserve` database, observe that `dbo.users` now contains a row with with the details you just filled out.
-13. Approve your account by updating the `status` of the row in `dbo.participants` that corresponds to your new user, i.e. 
+13. Approve your account by updating the `status` of the row in `dbo.participants` that corresponds to your new user, i.e.
+
     ```
     declare @email as nvarchar(256) = '<Enter your email here>'
 
@@ -258,4 +232,5 @@ Your app is ready to be deployed! Note that builds for deployment are not made o
       on p.id = u.participantId
     where u.email = @email
     ```
+
 14. Return to the UI and you should be good to go!

--- a/keycloak/realm/realm-export.json
+++ b/keycloak/realm/realm-export.json
@@ -109,7 +109,7 @@
         "composite": true,
         "composites": {
           "client": {
-            "self_serve_portal_apis": ["api-participant-member"],
+            "self_serve_portal_apis": ["api-user"],
             "self_serve_portal_web": ["participant-user"]
           }
         },
@@ -129,6 +129,14 @@
     ],
     "client": {
       "self_serve_portal_apis": [
+        {
+          "id": "7ee4e371-b426-476b-85a7-dc7c02faad8d",
+          "name": "api-user",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "fe765b74-a8dc-4da3-ac1f-cd5a71573807",
+          "attributes": {}
+        },
         {
           "id": "82530f66-a8b6-4554-a97b-62997298a8d1",
           "name": "uma_protection",

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -107,6 +107,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
         const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
         return roles.includes('api-participant-member');
       }),
+      { url: `${BASE_REQUEST_PATH}/participantTypes`, method: 'GET' },
       { url: `${BASE_REQUEST_PATH}/participants`, method: 'POST' },
       { url: `${BASE_REQUEST_PATH}/users/current`, method: 'GET' },
       { url: `${BASE_REQUEST_PATH}/users/current/participant`, method: 'GET' },

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -86,7 +86,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
         audience: SSP_KK_AUDIENCE,
         issuerBaseURL: SSP_KK_ISSUER_BASE_URL,
       }),
-      BYPASS_PATHS
+      ...BYPASS_PATHS
     )
   );
 

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -26,6 +26,14 @@ import { createParticipantsRouter } from './participantsRouter';
 import { createUsersRouter } from './usersRouter';
 
 const BASE_REQUEST_PATH = '/api';
+const BYPASS_PATHS = [
+  `/favicon.ico`,
+  `${BASE_REQUEST_PATH}/`,
+  `${BASE_REQUEST_PATH}/metrics`,
+  `${BASE_REQUEST_PATH}/health`,
+  `${BASE_REQUEST_PATH}/keycloak-config`,
+];
+
 function bypassHandlerForPaths(middleware: express.Handler, ...paths: (string | string[])[]) {
   return function (req, res, next) {
     const bypassPath = paths.find((path) =>
@@ -78,11 +86,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
         audience: SSP_KK_AUDIENCE,
         issuerBaseURL: SSP_KK_ISSUER_BASE_URL,
       }),
-      `/favicon.ico`,
-      `${BASE_REQUEST_PATH}/`,
-      `${BASE_REQUEST_PATH}/metrics`,
-      `${BASE_REQUEST_PATH}/health`,
-      `${BASE_REQUEST_PATH}/keycloak-config`
+      BYPASS_PATHS
     )
   );
 
@@ -101,15 +105,10 @@ export function configureAndStartApi(useMetrics: boolean = true) {
         const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
         return roles.includes('api-participant-member');
       }),
-      `/favicon.ico`,
-      `${BASE_REQUEST_PATH}/`,
-      `${BASE_REQUEST_PATH}/metrics`,
-      `${BASE_REQUEST_PATH}/health`,
-      `${BASE_REQUEST_PATH}/keycloak-config`,
-      `${BASE_REQUEST_PATH}/participantTypes`,
       [`${BASE_REQUEST_PATH}/participants`, 'POST'],
       `${BASE_REQUEST_PATH}/users/current`,
-      `${BASE_REQUEST_PATH}/users/current/participant`
+      `${BASE_REQUEST_PATH}/users/current/participant`,
+      ...BYPASS_PATHS
     )
   );
 

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -89,11 +89,23 @@ export function configureAndStartApi(useMetrics: boolean = true) {
       };
     };
   };
+
   app.use(
-    claimCheck((claim: Claim) => {
-      const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
-      return roles.includes('api-participant-member');
-    })
+    bypassHandlerForPaths(
+      claimCheck((claim: Claim) => {
+        console.log('In claim check', claim);
+        const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
+        return roles.includes('api-participant-member');
+      }),
+      `/favicon.ico`,
+      `${BASE_REQUEST_PATH}/`,
+      `${BASE_REQUEST_PATH}/metrics`,
+      `${BASE_REQUEST_PATH}/health`,
+      `${BASE_REQUEST_PATH}/keycloak-config`,
+      `${BASE_REQUEST_PATH}/participantTypes`,
+      `${BASE_REQUEST_PATH}/participants`,
+      `${BASE_REQUEST_PATH}/users`
+    )
   );
 
   app.use(async (_req, _res, next) => {

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -29,7 +29,7 @@ const BASE_REQUEST_PATH = '/api';
 function bypassHandlerForPaths(middleware: express.Handler, ...paths: (string | string[])[]) {
   return function (req, res, next) {
     const bypassPath = paths.find((path) =>
-      Array.isArray(path) ? path.includes(req.path) : path === req.path
+      Array.isArray(path) ? path[0] === req.path : path === req.path
     );
     if (bypassPath) {
       if (typeof bypassPath === 'string' || bypassPath[1] === req.method) {

--- a/src/api/usersRouter.ts
+++ b/src/api/usersRouter.ts
@@ -19,25 +19,26 @@ import {
 
 export function createUsersRouter() {
   const usersRouter = express.Router();
-  usersRouter.get('/current', enrichCurrentUser, async (req: UserRequest, res) => {
+  usersRouter.use('/current', enrichCurrentUser);
+  usersRouter.get('/current', async (req: UserRequest, res) => {
     const userWithIsApprover = await enrichUserWithIsApprover(req.user!);
     return res.json(userWithIsApprover);
   });
 
-  usersRouter.put('/current/acceptTerms', enrichCurrentUser, async (req: UserRequest, res) => {
+  usersRouter.put('/current/acceptTerms', async (req: UserRequest, res) => {
     await req.user!.$query().patch({ acceptedTerms: true });
     return res.sendStatus(200);
+  });
+
+  usersRouter.get('/current/participant', async (req: UserRequest, res) => {
+    const participant = await req.user!.$relatedQuery('participant').withGraphFetched('types');
+    return res.status(200).json(participant);
   });
 
   usersRouter.use('/:userId', enrichWithUserFromParams);
 
   usersRouter.get('/:userId', async (req: UserRequest, res) => {
     return res.status(200).json(req.user);
-  });
-
-  usersRouter.get('/:userId/participant', async (req: UserRequest, res) => {
-    const participant = await req.user!.$relatedQuery('participant').withGraphFetched('types');
-    return res.status(200).json(participant);
   });
 
   usersRouter.post('/:userId/resendInvitation', async (req: UserRequest, res) => {

--- a/src/web/contexts/ParticipantProvider.tsx
+++ b/src/web/contexts/ParticipantProvider.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ParticipantStatus } from '../../api/entities/Participant';
 import { Loading } from '../components/Core/Loading';
-import { GetParticipantByUserId, ParticipantResponse } from '../services/participant';
+import { GetCurrentUsersParticipant, ParticipantResponse } from '../services/participant';
 import { ApiError } from '../utils/apiError';
 import { useAsyncError } from '../utils/errorHandler';
 import { CurrentUserContext } from './CurrentUserProvider';
@@ -41,7 +41,7 @@ function ParticipantProvider({ children }: { children: ReactNode }) {
       setIsLoading(true);
       try {
         if (user) {
-          const p = await GetParticipantByUserId(user!.id);
+          const p = await GetCurrentUsersParticipant();
           setParticipant(p);
         }
       } catch (e: unknown) {

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -69,9 +69,9 @@ export async function CreateParticipant(formData: CreateParticipantForm, user: K
   }
 }
 
-export async function GetParticipantByUserId(id: number) {
+export async function GetCurrentUsersParticipant() {
   try {
-    const result = await axios.get<ParticipantResponse>(`/users/${id}/participant`, {
+    const result = await axios.get<ParticipantResponse>(`/users/current/participant`, {
       validateStatus: (status) => status === 200,
     });
     return result.data;


### PR DESCRIPTION
- Add claimCheck to check if user has api-participant-user role
- Update keycloak to assign api-user by default
- Update bypassHandlerForPaths to be able to check method
- Update getParticipantByUserId to getCurrentUsersParticipant, which use `users/current/participant instead`

Required steps
- [ ] Import realm settings to keycloak
- [ ] Manually assign api-participant-user to existing users with approved participant
- [ ] Before we have approval in portal, we need to manually assign roles every time we approve a participant