### PR TITLE
ajy-UID2-1443-Bulk-add-permissions-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uid2-ssportal",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "uid2-ssportal",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/roboto-mono": "^4.5.10",

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -1,0 +1,49 @@
+.bulk-add-permissions {
+  display: flex;
+  flex-direction: column;
+  border: 2px solid var(--theme-action);
+  border-radius: 5px;
+  line-height: 1;
+  box-shadow: 0px 4px 14px var(--theme-box-shadow);
+
+  .bulk-add-permissions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    flex-direction: row;
+
+    .recommendation-label {
+      background: var(--theme-label-background);
+      border-radius: 3px;
+      padding: 4px 8px;
+      margin-right: 8px;
+      display: flex;
+      align-items: center;
+      font-size: 0.75rem;
+      width: 115px;
+      height: 18px;
+    }
+  }
+
+  .bulk-add-permissions-body {
+    padding: 0 40px;
+
+    .participant-type-checkbox-section {
+      display: flex;
+      align-items: center;
+
+      .checkbox-label {
+        padding-right: 25px;
+      }
+    }
+
+    .bulk-add-permissions-view-recommendations-button {
+      padding-top: 20px;
+    }
+  }
+
+  .bulk-add-permissions-footer {
+    padding: 20px 20px;
+  }
+}

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -13,6 +13,10 @@
     padding: 0 20px;
     flex-direction: row;
 
+    h2 {
+      margin-top: 20px;
+    }
+
     .recommendation-label {
       background: var(--theme-label-background);
       border-radius: 3px;
@@ -27,7 +31,7 @@
   }
 
   .bulk-add-permissions-body {
-    padding: 0 40px;
+    padding: 10px 40px 0 40px;
 
     .participant-type-checkbox-section {
       display: flex;
@@ -44,6 +48,6 @@
   }
 
   .bulk-add-permissions-footer {
-    padding: 20px 20px;
+    padding: 20px;
   }
 }

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -12,7 +12,6 @@
     justify-content: space-between;
     padding: 0 20px;
     flex-direction: row;
-    margin-top: 10px;
 
     .recommendation-label {
       background: var(--theme-label-background);

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -12,20 +12,15 @@
     justify-content: space-between;
     padding: 0 20px;
     flex-direction: row;
-
-    h2 {
-      margin-top: 20px;
-    }
+    margin-top: 10px;
 
     .recommendation-label {
       background: var(--theme-label-background);
       border-radius: 3px;
       padding: 4px 8px;
-      margin-right: 8px;
       display: flex;
       align-items: center;
       font-size: 0.75rem;
-      width: 115px;
       height: 18px;
     }
   }

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -13,6 +13,10 @@
     padding: 0 20px;
     flex-direction: row;
 
+    h2 {
+      margin-top: 22px;
+    }
+
     .recommendation-label {
       background: var(--theme-label-background);
       border-radius: 3px;

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -10,7 +10,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 20px;
+    padding: 0 16px 0 20px;
     flex-direction: row;
 
     h2 {

--- a/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
@@ -1,0 +1,54 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ParticipantStatus } from '../../../api/entities/Participant';
+import { BulkAddPermissions } from './BulkAddPermissions';
+
+export default {
+  title: 'Sharing Permissions/BulkAddPermissions',
+  component: BulkAddPermissions,
+} as ComponentMeta<typeof BulkAddPermissions>;
+
+const Template: ComponentStory<typeof BulkAddPermissions> = (args) => (
+  <BulkAddPermissions {...args} />
+);
+
+export const Publisher = Template.bind({});
+Publisher.args = {
+  participant: {
+    id: 1,
+    name: 'Participant 1',
+    types: [{ id: 2, typeName: 'Publisher' }],
+    allowSharing: true,
+    status: ParticipantStatus.Approved,
+  },
+};
+
+export const AdvertiserAndDSP = Template.bind({});
+AdvertiserAndDSP.args = {
+  participant: {
+    id: 1,
+    name: 'Participant 1',
+    types: [
+      { id: 3, typeName: 'Advertiser' },
+      { id: 4, typeName: 'DSP' },
+    ],
+    allowSharing: true,
+    status: ParticipantStatus.Approved,
+  },
+};
+
+export const AllTypes = Template.bind({});
+AllTypes.args = {
+  participant: {
+    id: 1,
+    name: 'Participant 1',
+    types: [
+      { id: 2, typeName: 'Publisher' },
+      { id: 3, typeName: 'Advertiser' },
+      { id: 4, typeName: 'DSP' },
+      { id: 5, typeName: 'Data Provider' },
+    ],
+    allowSharing: true,
+    status: ParticipantStatus.Approved,
+  },
+};

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { ParticipantDTO } from '../../../api/entities/Participant';
+import { FormStyledCheckbox } from '../Input/StyledCheckbox';
+import {
+  getDefaultAdvertiserCheckboxState,
+  getDefaultDataProviderCheckboxState,
+  getDefaultDSPCheckboxState,
+  getDefaultPublisherCheckboxState,
+  getRecommendationMessageFromTypeNames,
+} from './bulkAddPermissionsHelpers';
+
+import './BulkAddPermissions.scss';
+
+type BulkAddPermissionsProps = {
+  participant: ParticipantDTO | null;
+  onBulkAddSharingPermission: (selectedTypes: number[]) => Promise<void>;
+};
+
+export type BulkAddPermissionsForm = {
+  publisherChecked: boolean;
+  advertiserChecked: boolean;
+  DSPChecked: boolean;
+  dataProviderChecked: boolean;
+};
+
+export function BulkAddPermissions({
+  participant,
+  onBulkAddSharingPermission,
+}: BulkAddPermissionsProps) {
+  const [showRecommendedParticipants, setShowRecommendedParticipants] = useState(false);
+  const currentParticipantTypeNames = participant?.types
+    ? participant.types.map((p) => p.typeName ?? '')
+    : [];
+  const formMethods = useForm<BulkAddPermissionsForm>({
+    defaultValues: {
+      publisherChecked: getDefaultPublisherCheckboxState(currentParticipantTypeNames),
+      advertiserChecked: getDefaultAdvertiserCheckboxState(currentParticipantTypeNames),
+      DSPChecked: getDefaultDSPCheckboxState(currentParticipantTypeNames),
+      dataProviderChecked: getDefaultDataProviderCheckboxState(currentParticipantTypeNames),
+    },
+  });
+
+  const { register, handleSubmit } = formMethods;
+
+  const handleSave = (data: BulkAddPermissionsForm) => {
+    // TODO: call onBulkAddSharingPermission with the appropriate data
+  };
+
+  const onToggleShowRecommendedParticipants = () => {
+    setShowRecommendedParticipants((prevToggle) => !prevToggle);
+    // TODO: show the actual participants
+  };
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <FormProvider {...formMethods}>
+      <form onSubmit={handleSubmit(handleSave)}>
+        <div className='bulk-add-permissions'>
+          <div className='bulk-add-permissions-header'>
+            <h2>Bulk Add Permissions</h2>
+            <div className='recommendation-label'>RECOMMENDATION</div>
+          </div>
+          <div className='bulk-add-permissions-body'>
+            <b>{getRecommendationMessageFromTypeNames(currentParticipantTypeNames)}</b>
+            <p>
+              Allow all current and future participants within a participation type to decrypt your
+              UID2 tokens.
+            </p>
+            <div className='participant-type-checkbox-section'>
+              <FormStyledCheckbox
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('publisherChecked')}
+              />
+              <span className='checkbox-label'>Publisher</span>
+              <FormStyledCheckbox
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('advertiserChecked')}
+              />
+              <span className='checkbox-label'>Advertiser</span>
+              <FormStyledCheckbox
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('DSPChecked')}
+              />
+              <span className='checkbox-label'>DSP</span>
+              <FormStyledCheckbox
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...register('dataProviderChecked')}
+              />
+              <span className='checkbox-label'>Data Provider</span>
+            </div>
+            <button
+              type='button'
+              className='text-button bulk-add-permissions-view-recommendations-button'
+              onClick={onToggleShowRecommendedParticipants}
+            >
+              {showRecommendedParticipants
+                ? 'Hide Recommended Participants'
+                : 'View Recommended Participants'}
+            </button>
+          </div>
+          <div className='bulk-add-permissions-footer'>
+            <button type='submit' className='primary-button bulk-add-permissions-submit-button'>
+              Save Recommendations
+            </button>
+          </div>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -1,0 +1,57 @@
+import { formatStringsWithSeparator, getArticle } from '../../utils/textHelpers';
+
+export const getDefaultPublisherCheckboxState = (participantTypeNames: string[]) => {
+  if (participantTypeNames?.includes('Data Provider')) return true;
+  return false;
+};
+
+export const getDefaultAdvertiserCheckboxState = (participantTypeNames: string[]) => {
+  if (participantTypeNames?.includes('Data Provider') || participantTypeNames?.includes('DSP')) {
+    return true;
+  }
+  return false;
+};
+
+export const getDefaultDSPCheckboxState = (participantTypeNames: string[]) => {
+  if (
+    participantTypeNames?.includes('Data Provider') ||
+    participantTypeNames?.includes('Advertiser') ||
+    participantTypeNames?.includes('Publisher')
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const getDefaultDataProviderCheckboxState = (participantTypeNames: string[]) => {
+  if (participantTypeNames?.includes('Advertiser') || participantTypeNames?.includes('DSP')) {
+    return true;
+  }
+  return false;
+};
+
+export const getRecommendedTypeFromParticipant = (participantTypeNames: string[]) => {
+  const uniqueTypes = new Set<string>();
+  if (getDefaultPublisherCheckboxState(participantTypeNames)) {
+    uniqueTypes.add('Publishers');
+  }
+  if (getDefaultAdvertiserCheckboxState(participantTypeNames)) {
+    uniqueTypes.add('Advertisers');
+  }
+  if (getDefaultDSPCheckboxState(participantTypeNames)) {
+    uniqueTypes.add('DSPs');
+  }
+  if (getDefaultDataProviderCheckboxState(participantTypeNames)) {
+    uniqueTypes.add('Data Providers');
+  }
+  const result = Array.from(uniqueTypes);
+  if (result.length === 4) return 'participants';
+
+  return formatStringsWithSeparator(result);
+};
+
+export const getRecommendationMessageFromTypeNames = (participantTypeNames: string[]) => {
+  return `As ${getArticle(participantTypeNames[0])} ${formatStringsWithSeparator(
+    participantTypeNames
+  )}, we recommend you share with all ${getRecommendedTypeFromParticipant(participantTypeNames)}.`;
+};

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -1,33 +1,23 @@
 import { formatStringsWithSeparator, getArticle } from '../../utils/textHelpers';
 
 export const getDefaultPublisherCheckboxState = (participantTypeNames: string[]) => {
-  if (participantTypeNames?.includes('Data Provider')) return true;
-  return false;
+  const publisherRelatedTypes = ['Data Provider'];
+  return participantTypeNames.some((type) => publisherRelatedTypes.includes(type));
 };
 
 export const getDefaultAdvertiserCheckboxState = (participantTypeNames: string[]) => {
-  if (participantTypeNames?.includes('Data Provider') || participantTypeNames?.includes('DSP')) {
-    return true;
-  }
-  return false;
+  const advertiserRelatedTypes = ['Data Provider', 'DSP'];
+  return participantTypeNames.some((type) => advertiserRelatedTypes.includes(type));
 };
 
 export const getDefaultDSPCheckboxState = (participantTypeNames: string[]) => {
-  if (
-    participantTypeNames?.includes('Data Provider') ||
-    participantTypeNames?.includes('Advertiser') ||
-    participantTypeNames?.includes('Publisher')
-  ) {
-    return true;
-  }
-  return false;
+  const DSPRelatedTypes = ['Data Provider', 'Advertiser', 'Publisher'];
+  return participantTypeNames.some((type) => DSPRelatedTypes.includes(type));
 };
 
 export const getDefaultDataProviderCheckboxState = (participantTypeNames: string[]) => {
-  if (participantTypeNames?.includes('Advertiser') || participantTypeNames?.includes('DSP')) {
-    return true;
-  }
-  return false;
+  const dataProviderRelatedTypes = ['Advertiser', 'DSP'];
+  return participantTypeNames.some((type) => dataProviderRelatedTypes.includes(type));
 };
 
 export const getRecommendedTypeFromParticipant = (participantTypeNames: string[]) => {

--- a/src/web/utils/textHelpers.ts
+++ b/src/web/utils/textHelpers.ts
@@ -1,0 +1,18 @@
+export const isVowel = (letter: string): boolean =>
+  ['a', 'e', 'i', 'o', 'u'].includes(letter.toLowerCase());
+
+export const getArticle = (word: string): string => {
+  const firstLetter = word.charAt(0);
+  return isVowel(firstLetter) ? 'an' : 'a';
+};
+
+export const formatStringsWithSeparator = (strings: string[]) => {
+  if (strings.length === 2) {
+    return strings.join(' and ');
+  }
+  if (strings.length > 2) {
+    const lastCommaIndex = strings.length - 1;
+    return `${strings.slice(0, lastCommaIndex).join(', ')} and ${strings[lastCommaIndex]}`;
+  }
+  return strings;
+};


### PR DESCRIPTION
**Build bulk add permissions component.**

This is not fully functional yet (doesn't call any APIs). 
However, it should populate the recommendation message and select default checkboxes based on the recommended types listed in the ticket. Clicking the "View" button will just change the text to "Hide", and vice versa.

Here is a screen recording from storybook (minor css adjustments have been made since):

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/a0b4037d-bb6a-4b1c-9207-d1f57e488f3f

Screenshot with updated padding:

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/f7da9ad6-b838-4813-b400-c5ec45cef06e)

