### PR TITLE
Tweak the t&c dialog CSS to make it work on small-height browser windows.

### DIFF
--- a/src/web/components/Account/CreateAccountForm.tsx
+++ b/src/web/components/Account/CreateAccountForm.tsx
@@ -95,6 +95,7 @@ export function CreateAccountForm({ resolvedParticipantTypes, onSubmit }: Create
             open={showTermsDialog}
             onOpenChange={setShowTermsDialog}
             title='Accept Terms and Conditions'
+            className='terms-conditions-dialog'
           >
             <TermsAndConditionsForm
               onAccept={handleAccept}

--- a/src/web/components/Account/CreateAccountForm.tsx
+++ b/src/web/components/Account/CreateAccountForm.tsx
@@ -94,7 +94,6 @@ export function CreateAccountForm({ resolvedParticipantTypes, onSubmit }: Create
           <Dialog
             open={showTermsDialog}
             onOpenChange={setShowTermsDialog}
-            title='Accept Terms and Conditions'
             className='terms-conditions-dialog'
           >
             <TermsAndConditionsForm

--- a/src/web/components/Core/TermsAndConditions.scss
+++ b/src/web/components/Core/TermsAndConditions.scss
@@ -33,6 +33,12 @@
   height: 100%;
   display: flex;
 
+  & > h1 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    align-self: flex-start;
+  }
+
   .text-button {
     margin-top: 10px;
   }

--- a/src/web/components/Core/TermsAndConditions.scss
+++ b/src/web/components/Core/TermsAndConditions.scss
@@ -21,10 +21,17 @@
   }
 }
 
+.terms-conditions-dialog {
+  box-sizing: border-box;
+  height: 100%;
+  max-width: 910px;
+}
+
 .terms-and-conditions-form {
-  display: flex;
   flex-direction: column;
   align-items: center;
+  height: 100%;
+  display: flex;
 
   .text-button {
     margin-top: 10px;
@@ -34,7 +41,6 @@
     border: 1px solid var(--theme-border);
     border-radius: 5px;
     padding: 16px;
-    height: 468px;
     overflow: scroll;
     max-width: 910px;
   }

--- a/src/web/components/Core/TermsAndConditions.stories.tsx
+++ b/src/web/components/Core/TermsAndConditions.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { Dialog } from './Dialog';
 import { TermsAndConditions, TermsAndConditionsForm } from './TermsAndConditions';
 
 export default {
@@ -8,11 +9,13 @@ export default {
 } as ComponentMeta<typeof TermsAndConditionsForm | typeof TermsAndConditions>;
 
 const Template: ComponentStory<typeof TermsAndConditionsForm> = (args) => (
-  <TermsAndConditionsForm {...args} />
+  <Dialog open className='terms-conditions-dialog'>
+    <TermsAndConditionsForm {...args} />
+  </Dialog>
 );
 
-export const Dialog = Template.bind({});
-Dialog.args = {
+export const AsDialog = Template.bind({});
+AsDialog.args = {
   onAccept: () => {},
   onCancel: () => {},
 };

--- a/src/web/components/Core/TermsAndConditions.tsx
+++ b/src/web/components/Core/TermsAndConditions.tsx
@@ -1,4 +1,4 @@
-import { UIEvent, UIEventHandler, useCallback, useState } from 'react';
+import { PropsWithChildren, UIEvent, UIEventHandler, useCallback, useState } from 'react';
 
 import './TermsAndConditions.scss';
 
@@ -228,16 +228,20 @@ export function TermsAndConditions({ onScroll }: TermsAndConditionsProps) {
   );
 }
 
-type TermsAndConditionsFormProps = {
+type TermsAndConditionsFormProps = PropsWithChildren<{
   onAccept: () => void;
   onCancel: () => void;
-};
+}>;
 
 export type AcceptTermForm = {
   acceptConditions: boolean;
 };
 
-export function TermsAndConditionsForm({ onAccept, onCancel }: TermsAndConditionsFormProps) {
+export function TermsAndConditionsForm({
+  onAccept,
+  onCancel,
+  children,
+}: TermsAndConditionsFormProps) {
   const [scrolledToBottom, setScrolledToBottom] = useState(false);
   const handleScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
     const { scrollHeight, scrollTop, clientHeight } = event.currentTarget;
@@ -258,6 +262,7 @@ export function TermsAndConditionsForm({ onAccept, onCancel }: TermsAndCondition
       <button type='button' className='text-button' onClick={onCancel}>
         Cancel
       </button>
+      {children}
     </div>
   );
 }

--- a/src/web/components/Core/TermsAndConditions.tsx
+++ b/src/web/components/Core/TermsAndConditions.tsx
@@ -250,6 +250,7 @@ export function TermsAndConditionsForm({
   }, []);
   return (
     <div className='terms-and-conditions-form'>
+      <h1>Accept Terms and Conditions</h1>
       <TermsAndConditions onScroll={handleScroll} />
       <button
         type='button'

--- a/src/web/screens/dashboard.tsx
+++ b/src/web/screens/dashboard.tsx
@@ -64,14 +64,15 @@ function Dashboard() {
       <div className='dashboard-content'>
         <SnailTrail location={currentLocationDescription} />
         {!LoggedInUser?.user?.acceptedTerms ? (
-          <Dialog open>
-            <TermsAndConditionsForm onAccept={handleAccept} onCancel={handleCancel} />
-            {showMustAccept && (
-              <div className='accept-error'>
-                You will not be able to access the portal unless you accept the terms of service.
-                You must scroll to the bottom of the terms of service before you can accept them.
-              </div>
-            )}
+          <Dialog open className='terms-conditions-dialog'>
+            <TermsAndConditionsForm onAccept={handleAccept} onCancel={handleCancel}>
+              {showMustAccept && (
+                <div className='accept-error'>
+                  You will not be able to access the portal unless you accept the terms of service.
+                  You must scroll to the bottom of the terms of service before you can accept them.
+                </div>
+              )}
+            </TermsAndConditionsForm>
           </Dialog>
         ) : (
           <Outlet />


### PR DESCRIPTION
Even with a very small browser window, the accept button is now available.
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/111951647/12948101-03d2-45a7-afdf-2e7007937d01)
