### PR TITLE
Assign api-partcipant-member when invited user accept T&C

### DIFF
--- a/keycloak/realm/realm-export.json
+++ b/keycloak/realm/realm-export.json
@@ -560,7 +560,7 @@
       "realmRoles": ["default-roles-self-serve-portal"],
       "clientRoles": {
         "self_serve_portal_apis": ["uma_protection"],
-        "realm-management": ["manage-users", "view-users", "query-users"]
+        "realm-management": ["manage-users", "view-users", "query-users", "manage-clients"]
       },
       "notBefore": 0,
       "groups": []

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -111,6 +111,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
       { url: `${BASE_REQUEST_PATH}/participants`, method: 'POST' },
       { url: `${BASE_REQUEST_PATH}/users/current`, method: 'GET' },
       { url: `${BASE_REQUEST_PATH}/users/current/participant`, method: 'GET' },
+      { url: `${BASE_REQUEST_PATH}/users/current/acceptTerms`, method: 'PUT' },
       ...BYPASS_PATHS
     )
   );

--- a/src/api/envars.ts
+++ b/src/api/envars.ts
@@ -19,6 +19,7 @@ export const SSP_KK_SSL_RESOURCE = process.env.SSP_KK_SSL_RESOURCE ?? errorMessa
 export const SSP_KK_SSL_PUBLIC_CLIENT = process.env.SSP_KK_SSL_PUBLIC_CLIENT ?? errorMessage;
 export const SSP_KK_SSL_CONFIDENTIAL_PORT =
   process.env.SSP_KK_SSL_CONFIDENTIAL_PORT ?? errorMessage;
+export const SSP_KK_API_CLIENT_ID = process.env.SSP_KK_API_CLIENT_ID ?? errorMessage;
 export const SSP_WEB_BASE_URL = process.env.SSP_WEB_BASE_URL ?? 'http://localhost:3000/';
 
 // DB config

--- a/src/api/participantsRouter.ts
+++ b/src/api/participantsRouter.ts
@@ -12,7 +12,7 @@ import {
 import { SharingAction } from './entities/SharingAuditTrail';
 import { UserRole } from './entities/User';
 import { getKcAdminClient } from './keycloakAdminClient';
-import { assignClientRoleToUser, createNewUser, sendInviteEmail } from './services/kcUsersService';
+import { createNewUser, sendInviteEmail } from './services/kcUsersService';
 import {
   addSharingParticipants,
   checkParticipantId,
@@ -103,7 +103,6 @@ export function createParticipantsRouter() {
         const { firstName, lastName, email, role } = invitationParser.parse(req.body);
         const kcAdminClient = await getKcAdminClient();
         const user = await createNewUser(kcAdminClient, firstName, lastName, email);
-        await assignClientRoleToUser(kcAdminClient, user.id!, 'api-participant-member');
         await createUserInPortal({
           email,
           role,

--- a/src/api/participantsRouter.ts
+++ b/src/api/participantsRouter.ts
@@ -12,7 +12,7 @@ import {
 import { SharingAction } from './entities/SharingAuditTrail';
 import { UserRole } from './entities/User';
 import { getKcAdminClient } from './keycloakAdminClient';
-import { createNewUser, sendInviteEmail } from './services/kcUsersService';
+import { assignClientRoleToUser, createNewUser, sendInviteEmail } from './services/kcUsersService';
 import {
   addSharingParticipants,
   checkParticipantId,
@@ -103,6 +103,7 @@ export function createParticipantsRouter() {
         const { firstName, lastName, email, role } = invitationParser.parse(req.body);
         const kcAdminClient = await getKcAdminClient();
         const user = await createNewUser(kcAdminClient, firstName, lastName, email);
+        await assignClientRoleToUser(kcAdminClient, user.id!, 'api-participant-member');
         await createUserInPortal({
           email,
           role,

--- a/src/api/services/kcUsersService.ts
+++ b/src/api/services/kcUsersService.ts
@@ -77,9 +77,12 @@ export const deleteUserByEmail = async (kcAdminClient: KeycloakAdminClient, user
 
 export const assignClientRoleToUser = async (
   kcAdminClient: KeycloakAdminClient,
-  userId: string,
+  userEmail: string,
   roleName: string
 ) => {
+  const users = await queryUsersByEmail(kcAdminClient, userEmail);
+  if (users.length !== 1) throw Error(`Unable to assign role to ${userEmail}`);
+
   const clientRole = await kcAdminClient.clients.findRole({
     id: SSP_KK_API_CLIENT_ID,
     roleName,
@@ -87,7 +90,7 @@ export const assignClientRoleToUser = async (
   if (!clientRole) throw Error(`Unable to find the client role ${roleName}`);
 
   await kcAdminClient.users.addClientRoleMappings({
-    id: userId,
+    id: users[0].id!,
     clientUniqueId: SSP_KK_API_CLIENT_ID,
     roles: [
       {

--- a/src/api/services/kcUsersService.ts
+++ b/src/api/services/kcUsersService.ts
@@ -2,7 +2,7 @@ import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
 import { RequiredActionAlias } from '@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderRepresentation';
 import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
 
-import { SSP_KK_SSL_RESOURCE, SSP_WEB_BASE_URL } from '../envars';
+import { SSP_KK_API_CLIENT_ID, SSP_KK_SSL_RESOURCE, SSP_WEB_BASE_URL } from '../envars';
 
 export const queryUsersByEmail = async (kcAdminClient: KeycloakAdminClient, email: string) => {
   return kcAdminClient.users.find({
@@ -72,5 +72,28 @@ export const deleteUserByEmail = async (kcAdminClient: KeycloakAdminClient, user
 
   await kcAdminClient.users.del({
     id: userLists[0].id!,
+  });
+};
+
+export const assignClientRoleToUser = async (
+  kcAdminClient: KeycloakAdminClient,
+  userId: string,
+  roleName: string
+) => {
+  const clientRole = await kcAdminClient.clients.findRole({
+    id: SSP_KK_API_CLIENT_ID,
+    roleName,
+  });
+  if (!clientRole) throw Error(`Unable to find the client role ${roleName}`);
+
+  await kcAdminClient.users.addClientRoleMappings({
+    id: userId,
+    clientUniqueId: SSP_KK_API_CLIENT_ID,
+    roles: [
+      {
+        id: clientRole.id!,
+        name: clientRole.name!,
+      },
+    ],
   });
 };

--- a/src/api/usersRouter.ts
+++ b/src/api/usersRouter.ts
@@ -5,6 +5,7 @@ import { UserRole } from './entities/User';
 import { getLoggers } from './helpers/loggingHelpers';
 import { getKcAdminClient } from './keycloakAdminClient';
 import {
+  assignClientRoleToUser,
   deleteUserByEmail,
   queryUsersByEmail,
   sendInviteEmail,
@@ -26,7 +27,12 @@ export function createUsersRouter() {
   });
 
   usersRouter.put('/current/acceptTerms', async (req: UserRequest, res) => {
-    await req.user!.$query().patch({ acceptedTerms: true });
+    const kcAdminClient = await getKcAdminClient();
+    const promises = [
+      req.user!.$query().patch({ acceptedTerms: true }),
+      assignClientRoleToUser(kcAdminClient, req.user?.email!, 'api-participant-member'),
+    ];
+    await Promise.all(promises);
     return res.sendStatus(200);
   });
 

--- a/src/web/screens/dashboard.tsx
+++ b/src/web/screens/dashboard.tsx
@@ -1,3 +1,4 @@
+import { useKeycloak } from '@react-keycloak/web';
 import { useContext, useEffect, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
@@ -39,6 +40,7 @@ function Dashboard() {
   const { participant } = useContext(ParticipantContext);
   const { LoggedInUser, loadUser } = useContext(CurrentUserContext);
   const [showMustAccept, setShowMustAccept] = useState(false);
+  const { keycloak } = useKeycloak();
   const navigate = useNavigate();
   const adminMenu = LoggedInUser?.user?.isApprover ? AdminRoutes.filter((r) => r.description) : [];
   const visibleMenu = standardMenu.concat(adminMenu);
@@ -47,6 +49,8 @@ function Dashboard() {
 
   const handleAccept = async () => {
     await SetTermsAccepted();
+    // Force token refresh after role updated
+    await keycloak.updateToken(10000);
     await loadUser();
   };
   const handleCancel = () => {


### PR DESCRIPTION
Deployment steps
- [ ] update k8s-deployment file with client id 
- [ ] Assign `manage-clients` to `self_serve_portal_apis` service account

