### PR TITLE
ajy-UID2-1443-Collapsible-component-improvements

### DIFF
--- a/src/web/components/Core/Collapsible.scss
+++ b/src/web/components/Core/Collapsible.scss
@@ -1,30 +1,32 @@
-.collapsible-root{
+.collapsible-root {
   display: flex;
   border: 1px solid var(--theme-border);
   border-radius: 5px;
   flex-direction: column;
   width: 100%;
 
-  .collapsible-header {
+  .collapsible-trigger {
     display: flex;
     justify-content: space-between;
-    padding-left: 20px;
+    border: none;
+    border-radius: 5px;
 
-    .collapsible-trigger {
-      border: none;
-      border-radius: 5px;
+    .collapsible-header {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
       align-items: center;
 
       .chevron-icon {
         color: var(--theme-action);
       }
     }
-
-    .collapsible-trigger[data-state='open'] > .chevron-icon {
-      transform: rotate(180deg);
-    }
   }
 
+  .collapsible-trigger[data-state='open'] > .collapsible-header > .chevron-icon {
+    transform: rotate(180deg);
+  }
+  
   .collapsible-content {
     display: flex;
     padding: 0 0 20px 20px;

--- a/src/web/components/Core/Collapsible.scss
+++ b/src/web/components/Core/Collapsible.scss
@@ -17,16 +17,32 @@
       width: 100%;
       align-items: center;
 
-      .chevron-icon {
-        color: var(--theme-action);
+      .collapsible-header-label-and-icon {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+
+        .label {
+          background: var(--theme-label-background);
+          border-radius: 3px;
+          padding: 4px 8px;
+          display: flex;
+          align-items: center;
+          font-size: 0.75rem;
+          height: 18px;
+        }
+
+        .chevron-icon {
+          color: var(--theme-action);
+        }
       }
     }
   }
 
-  .collapsible-trigger[data-state='open'] > .collapsible-header > .chevron-icon {
+  .collapsible-trigger[data-state='open'] > .collapsible-header > .collapsible-header-label-and-icon > .chevron-icon {
     transform: rotate(180deg);
   }
-  
+
   .collapsible-content {
     display: flex;
     padding: 0 0 20px 20px;

--- a/src/web/components/Core/Collapsible.stories.tsx
+++ b/src/web/components/Core/Collapsible.stories.tsx
@@ -22,3 +22,11 @@ Collapsed.args = {
   content: 'Test Collapsible Content',
   defaultOpen: false,
 };
+
+export const WithLabel = Template.bind({});
+WithLabel.args = {
+  title: 'Test Collapsible Title',
+  content: 'Test Collapsible Content',
+  defaultOpen: true,
+  label: 'TEST LABEL',
+};

--- a/src/web/components/Core/Collapsible.tsx
+++ b/src/web/components/Core/Collapsible.tsx
@@ -13,16 +13,16 @@ export type CollapsibleProps = {
 export function Collapsible({ title, content, defaultOpen }: CollapsibleProps) {
   return (
     <RadixCollapsible.Root className='collapsible-root' defaultOpen={defaultOpen}>
-      <div className='collapsible-header'>
-        <h2>{title}</h2>
-        <RadixCollapsible.Trigger className='collapsible-trigger'>
+      <RadixCollapsible.Trigger className='collapsible-trigger'>
+        <div className='collapsible-header'>
+          <h2>{title}</h2>
           <FontAwesomeIcon
             icon='chevron-down'
             data-testid='chevron-icon'
             className='chevron-icon'
           />
-        </RadixCollapsible.Trigger>
-      </div>
+        </div>
+      </RadixCollapsible.Trigger>
       <RadixCollapsible.Content>
         <div className='collapsible-content'>{content}</div>
       </RadixCollapsible.Content>

--- a/src/web/components/Core/Collapsible.tsx
+++ b/src/web/components/Core/Collapsible.tsx
@@ -8,19 +8,23 @@ export type CollapsibleProps = {
   title: string;
   content: ReactNode;
   defaultOpen?: boolean;
+  label?: string;
 };
 
-export function Collapsible({ title, content, defaultOpen }: CollapsibleProps) {
+export function Collapsible({ title, content, defaultOpen, label }: CollapsibleProps) {
   return (
     <RadixCollapsible.Root className='collapsible-root' defaultOpen={defaultOpen}>
       <RadixCollapsible.Trigger className='collapsible-trigger'>
         <div className='collapsible-header'>
           <h2>{title}</h2>
-          <FontAwesomeIcon
-            icon='chevron-down'
-            data-testid='chevron-icon'
-            className='chevron-icon'
-          />
+          <div className='collapsible-header-label-and-icon'>
+            {label && <span className='label'>{label}</span>}
+            <FontAwesomeIcon
+              icon='chevron-down'
+              data-testid='chevron-icon'
+              className='chevron-icon'
+            />
+          </div>
         </div>
       </RadixCollapsible.Trigger>
       <RadixCollapsible.Content>


### PR DESCRIPTION
Now the whole header is clickable to collapse/expand the Collapsible component. Before, the trigger was just a small box around the chevron icon.

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/aca24764-3842-4558-b6ae-d11b8b27376e

Also, a label string can be passed to the collapsible component:

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ad624768-e31e-4237-acd4-95252a5c4954)


