### PR TITLE
ajy-UID2-1595-Implement-feedback-regarding-sharing-permissions-page

### DIFF
--- a/src/web/components/BusinessContacts/BusinessContactsTable.scss
+++ b/src/web/components/BusinessContacts/BusinessContactsTable.scss
@@ -1,10 +1,10 @@
 .business-contacts-table-container {
   .add-new-item {
-    margin-top: 16px;
+    margin-top: 24px;
   }
 
   .business-contacts-table {
-    margin-top: 32px;
+    margin-top: 28px;
 
     .name {
       width: 25%;

--- a/src/web/components/SharingPermission/SharingPermissionsTable.scss
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.scss
@@ -1,9 +1,6 @@
 .sharing-permissions-table {
   margin-top: 30px;
-  border: 1px solid var(--theme-border);
   border-radius: 5px;
-  padding: 0 20px 20px 20px;
-  box-shadow: 0px 4px 4px var(--theme-box-shadow);
 
   .sharing-permissions-table-header-container {
     display: flex;
@@ -72,7 +69,7 @@
     margin-top: 16px;
     border: 1px solid var(--theme-border);
     border-radius: 5px;
-    padding: 36px;
+    padding: 20px 20px 36px;
     width: 100%;
     display: flex;
     box-sizing: border-box;

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -19,7 +19,7 @@ function NoParticipant() {
     <div className='no-participants-container'>
       <img src='/group-icon.svg' alt='group-icon' />
       <div className='no-participants-text'>
-        <h1>No Participants</h1>
+        <h2>No Participants</h2>
         <span>You don&apos;t have any sharing permissions yet.</span>
       </div>
     </div>

--- a/src/web/components/TeamMember/TeamMembersTable.scss
+++ b/src/web/components/TeamMember/TeamMembersTable.scss
@@ -4,12 +4,12 @@
   align-items: stretch;
 
   .add-team-member {
-    margin-top: 10px;
+    margin-top: 24px;
     margin-right: 30px;
   }
 
   .portal-team-table {
-    margin-top: 32px;
+    margin-top: 28px;
     font-size: 0.875rem;
 
     thead {

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -15,7 +15,9 @@ function ManageParticipants() {
   return (
     <div>
       <h1>Manage Participants</h1>
-      <p>View and manage UID2 Portal participant requests and information.</p>
+      <p className='heading-details'>
+        View and manage UID2 Portal participant requests and information.
+      </p>
       <h2>Participant Requests</h2>
       <Suspense fallback={<Loading />}>
         <Await resolve={participantsAwaitingApproval}>

--- a/src/web/screens/sharingPermissions.scss
+++ b/src/web/screens/sharingPermissions.scss
@@ -2,4 +2,8 @@
   .dialog-title {
     margin-right: 36px;
   }
+  
+  .search-and-add-permissions-collapsible {
+    margin-top: 30px;
+  }
 }

--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -87,7 +87,7 @@ function SharingPermissions() {
   return (
     <div className='sharingPermissions'>
       <h1>Sharing Permissions</h1>
-      <p>
+      <p className='heading-details'>
         Adding a sharing permission allows the participant you’re sharing with to decrypt your UID2
         tokens.
         <br />
@@ -97,17 +97,20 @@ function SharingPermissions() {
       <Suspense fallback={<Loading />}>
         <Await resolve={participants}>
           {(resolvedParticipants: AvailableParticipantDTO[]) => (
-            <Collapsible
-              title='Search and Add Permissions'
-              content={
-                <SearchAndAddParticipants
-                  onSharingPermissionsAdded={handleSharingPermissionsAdded}
-                  sharingParticipants={sharingParticipants}
-                  availableParticipants={resolvedParticipants}
-                  participantTypes={participantTypes}
-                />
-              }
-            />
+            <div className='search-and-add-permissions-collapsible'>
+              <Collapsible
+                title='Search and Add Permissions'
+                content={
+                  <SearchAndAddParticipants
+                    onSharingPermissionsAdded={handleSharingPermissionsAdded}
+                    sharingParticipants={sharingParticipants}
+                    availableParticipants={resolvedParticipants}
+                    participantTypes={participantTypes}
+                  />
+                }
+                defaultOpen
+              />
+            </div>
           )}
         </Await>
       </Suspense>

--- a/src/web/styles/text.scss
+++ b/src/web/styles/text.scss
@@ -10,6 +10,7 @@ h2 {
   font-size: 1.125rem;
   line-height: 1.375;
   margin-top: 20px;
+  font-weight: 600;
 }
 
 h3 {


### PR DESCRIPTION
- Make the search and add permissions collapsible open by default
- Reduce some gaps between heading details and body 
- Add a gap between sharing permissions heading details and the search and add permissions collapsible
- Reduce font weight of h2 from bold (700) to 600
- Remove border from sharing permissions table
- Align styling of "No Participants" to use h2 and less padding
- Adjust gap between buttons and tables for email contacts and team members

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/1d7f6306-6af4-4b9c-836f-b9dc90bd6f01)

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/a31ae50c-b596-4a73-8884-65ba1a005ed7)

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ae5cade4-5b42-4b7c-a1a2-a60d9d96d1c2)


