### PR TITLE
ajy-UID2-1475-Component-changes-for-adjusting-sharing-delete-behaviour

### DIFF
--- a/src/web/components/Core/TriStateCheckbox.scss
+++ b/src/web/components/Core/TriStateCheckbox.scss
@@ -20,4 +20,8 @@
   &-icon {
     color: var(--theme-radio-active);
   }
+
+  button[data-disabled] {
+    background-color: var(--theme-disabled-button);
+  }
 }

--- a/src/web/components/Core/TriStateCheckbox.stories.tsx
+++ b/src/web/components/Core/TriStateCheckbox.stories.tsx
@@ -33,3 +33,12 @@ Unchecked.args = {
     console.log('checkbox clicked');
   },
 };
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  status: TriStateCheckboxState.unchecked,
+  onClick: () => {
+    console.log('checkbox clicked');
+  },
+  disabled: true,
+};

--- a/src/web/components/Core/TriStateCheckbox.tsx
+++ b/src/web/components/Core/TriStateCheckbox.tsx
@@ -14,9 +14,10 @@ type TriStateCheckboxProps = {
   status: Checkbox.CheckedState;
   onClick: () => void;
   className?: string;
+  disabled?: boolean;
 };
 
-export function TriStateCheckbox({ status, onClick, className }: TriStateCheckboxProps) {
+export function TriStateCheckbox({ status, onClick, className, disabled }: TriStateCheckboxProps) {
   const getCheckboxIcon = () => {
     switch (status) {
       case TriStateCheckboxState.checked:
@@ -35,6 +36,7 @@ export function TriStateCheckbox({ status, onClick, className }: TriStateCheckbo
         className={clsx(className, {
           uncheck: status === TriStateCheckboxState.unchecked,
         })}
+        disabled={disabled}
       >
         <Checkbox.Indicator>{getCheckboxIcon()}</Checkbox.Indicator>
       </Checkbox.Root>

--- a/src/web/components/SharingPermission/ParticipantItem.scss
+++ b/src/web/components/SharingPermission/ParticipantItem.scss
@@ -1,31 +1,37 @@
-.participant-type-label {
-  background: var(--theme-label-background);
-  border-radius: 3px;
-  padding: 4px 8px;
-  margin-right: 8px;
-}
+.participant-item {
+  button[role='checkbox'] {
+    width: 21px;
+    height: 21px;
+  }
+  .participant-type-label {
+    background: var(--theme-label-background);
+    border-radius: 3px;
+    padding: 4px 8px;
+    margin-right: 8px;
+  }
 
-.participant-checkbox {
-  margin-right: 16px;
-}
+  .participant-checkbox {
+    margin-right: 16px;
+  }
 
-.participant-logo {
-  width: 50px;
-  margin-right: 16px;
-}
+  .participant-logo {
+    width: 50px;
+    margin-right: 16px;
+  }
 
-.participant-types {
-  display: flex;
-  align-items: center;
-  font-size: 0.625rem;
-  line-height: 0.75rem;
-}
+  .participant-types {
+    display: flex;
+    align-items: center;
+    font-size: 0.625rem;
+    line-height: 0.75rem;
+  }
 
-.participant-name-cell {
-  display: flex;
-  align-items: center;
+  .participant-name-cell {
+    display: flex;
+    align-items: center;
 
-  .checkbox-label {
-    padding-right: 16px;
+    .checkbox-label {
+      padding-right: 16px;
+    }
   }
 }

--- a/src/web/components/SharingPermission/ParticipantItem.stories.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.stories.tsx
@@ -39,3 +39,48 @@ Unchecked.args = {
   onClick: () => {},
   checked: false,
 };
+
+export const AddedByManual = Template.bind({});
+AddedByManual.args = {
+  participant: {
+    id: 2,
+    name: 'Participant 2',
+    types: [
+      { id: 3, typeName: 'Type 3' },
+      { id: 4, typeName: 'Type 4' },
+    ],
+  },
+  onClick: () => {},
+  checked: false,
+  addedBy: 'Manual',
+};
+
+export const AddedByAuto = Template.bind({});
+AddedByAuto.args = {
+  participant: {
+    id: 2,
+    name: 'Participant 2',
+    types: [
+      { id: 3, typeName: 'Type 3' },
+      { id: 4, typeName: 'Type 4' },
+    ],
+  },
+  onClick: () => {},
+  checked: false,
+  addedBy: 'Auto',
+};
+
+export const AddedByAutoAndManual = Template.bind({});
+AddedByAutoAndManual.args = {
+  participant: {
+    id: 2,
+    name: 'Participant 2',
+    types: [
+      { id: 3, typeName: 'Type 3' },
+      { id: 4, typeName: 'Type 4' },
+    ],
+  },
+  onClick: () => {},
+  checked: false,
+  addedBy: 'Auto/Manual',
+};

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -26,9 +26,14 @@ export function ParticipantItem({ participant, onClick, checked, addedBy }: Part
   // TODO: update this when we have login uploading
   const logo = '/default-logo.svg';
   return (
-    <tr onClick={onClick}>
+    <tr className='participant-item'>
       <td>
-        <TriStateCheckbox onClick={onClick} status={checked} className='participant-checkbox' />
+        <TriStateCheckbox
+          onClick={onClick}
+          status={checked}
+          className='participant-checkbox'
+          disabled={addedBy === 'Auto'} //addedBy is currently hardcoded to 'Manual'
+        />
       </td>
       <td className='participant-name-cell'>
         <img src={logo} alt={participant.name} className='participant-logo' />

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -32,7 +32,7 @@ export function ParticipantItem({ participant, onClick, checked, addedBy }: Part
           onClick={onClick}
           status={checked}
           className='participant-checkbox'
-          disabled={addedBy === 'Auto'} //addedBy is currently hardcoded to 'Manual'
+          disabled={addedBy === 'Auto'} // addedBy is currently hardcoded to 'Manual'
         />
       </td>
       <td className='participant-name-cell'>

--- a/src/web/components/SharingPermission/ParticipantSearchBar.scss
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.scss
@@ -52,6 +52,10 @@
   .search-bar-participants {
     padding: 20px;
 
+    tr {
+      background: none !important;
+    }
+
     th,
     td {
       background: none;

--- a/src/web/components/SharingPermission/ParticipantsTable.spec.tsx
+++ b/src/web/components/SharingPermission/ParticipantsTable.spec.tsx
@@ -12,12 +12,12 @@ describe('ParticipantsTable', () => {
     expect(screen.getByText('Participant 2')).toBeInTheDocument();
   });
 
-  it('calls onSelectedChange when a participant is clicked', () => {
+  it('calls onSelectedChange when a participant is selected', () => {
     const mockOnSelectedChange = jest.fn();
     render(<Default onSelectedChange={mockOnSelectedChange} />);
 
-    const firstParticipantItem = screen.getByText('Participant 1');
-    fireEvent.click(firstParticipantItem);
+    const firstCheckbox = screen.getAllByRole('checkbox')[0];
+    fireEvent.click(firstCheckbox);
 
     expect(mockOnSelectedChange).toHaveBeenCalled();
   });

--- a/src/web/components/SharingPermission/SharingPermissionsTable.scss
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.scss
@@ -2,6 +2,10 @@
   margin-top: 30px;
   border-radius: 5px;
 
+  .dialog-body-section {
+    font-weight: 400;
+  }
+
   .sharing-permissions-table-header-container {
     display: flex;
     justify-content: space-between;
@@ -47,7 +51,7 @@
     tr th {
       background-color: var(--theme-background-sidepanel);
       font-size: 0.875rem;
-      line-height: 1rem;
+      line-height: 1.5;
     }
 
     &.selected tr th {

--- a/src/web/components/SharingPermission/SharingPermissionsTable.spec.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.spec.tsx
@@ -28,11 +28,11 @@ describe('SharingPermissionsTable', () => {
     expect(searchInput).toHaveValue('Participant 1');
   });
 
-  it('renders delete permissions button when there are permission select', () => {
+  it('renders delete permissions button when there are permissions selected', () => {
     render(<SharedWithParticipants />);
 
-    const firstParticipantItem = screen.getByText('Participant 1');
-    fireEvent.click(firstParticipantItem);
+    const firstCheckbox = screen.getAllByRole('checkbox')[0];
+    fireEvent.click(firstCheckbox);
 
     expect(screen.getByText('Delete Permissions')).toBeInTheDocument();
   });

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -25,6 +25,7 @@ function NoParticipant() {
     </div>
   );
 }
+
 export function SharingPermissionsTable({
   sharingParticipants,
   onDeleteSharingPermission,
@@ -56,7 +57,7 @@ export function SharingPermissionsTable({
     ) : (
       <th colSpan={3}>
         <Dialog
-          title='Are you sure you want to Delete these Permissions'
+          title='Are you sure you want to delete these permissions?'
           triggerButton={
             <button className='transparent-button sharing-permission-delete-button' type='button'>
               <FontAwesomeIcon
@@ -69,11 +70,16 @@ export function SharingPermissionsTable({
           open={openConfirmation}
           onOpenChange={setOpenConfirmation}
         >
-          <ul className='dot-list'>
-            {selectedParticipantList.map((participant) => (
-              <li key={participant.id}>{participant.name}</li>
-            ))}
-          </ul>
+          <div className='dialog-body-section'>
+            <ul className='dot-list'>
+              {selectedParticipantList.map((participant) => (
+                <li key={participant.id}>{participant.name}</li>
+              ))}
+            </ul>
+            <p>
+              Note: Sharing will continue with participants that are shared via &quot;Auto&quot;.
+            </p>
+          </div>
           <div className='dialog-footer-section'>
             <button type='button' className='primary-button' onClick={handleDeletePermissions}>
               I want to Remove Permissions

--- a/src/web/styles/tables.scss
+++ b/src/web/styles/tables.scss
@@ -33,7 +33,7 @@ table {
   }
   tbody {
     tr:nth-of-type(2n) {
-      background-color: var(--theme-background-table-header);
+      background-color: var(--theme-background-row);
     }
   }
 }

--- a/src/web/styles/themes.scss
+++ b/src/web/styles/themes.scss
@@ -9,6 +9,7 @@
   --theme-background-sidepanel: #f2f2f3;
   --theme-background-content: #fff;
   --theme-background-table-header: #f2f2f3;
+  --theme-background-row: #F2F2F3B2;
   --theme-table-border: #d9d9d9;
   --theme-border: #dcdee1;
   --theme-button-text: #030a40;


### PR DESCRIPTION
Making some component changes to prepare for adjusting the delete behaviour depending on the 'addedBy' field. Full functionality is currently blocked since the APIs are not ready.
- Add TriStateCheckbox disabled prop
- Some logic to disable the participant item when addedBy is 'Auto', though it is currently hardcoded to 'Manual' (awaiting APIs)
- Add copy for the delete dialog
- Other styling changes:
  - Adjusting the background colour of every second row in the tables
  - Fix font weight and line-height within delete dialog
  - Fix styling of participants within the search and add dropdown (remove the background)

**TriStateCheckbox storybook**

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/fc347e5b-37ac-4e99-96d8-a82ac50bb099)

**Selection enabled for 'Manual' addedBy**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/aeb0f95e-1db3-44a6-9fe4-e749fbb8d55b

**Selection disabled for 'Auto' addedBy**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/624fc894-6c73-459b-9247-0cb76bb278d0

**Remove sharing permissions dialog**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/04f7a67d-ebf9-4381-a7f1-0d502665e516

**Remove background for participants in search & add**
  
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/adbbb2c3-3eb8-439e-9dd4-005d9d69f762)

**Future work**

- Disabling selection of 'Auto' sharing permissions when using the select all checkbox - this is a bit hard to do without the APIs so will be done in the future.