### PR TITLE
ajy-UID2-1596-Make-handleOnBlur-optional-in-SearchBar

### DIFF
--- a/src/web/components/Search/SearchBar.tsx
+++ b/src/web/components/Search/SearchBar.tsx
@@ -6,24 +6,26 @@ import './SearchBar.scss';
 
 type SearchBarContainerProps = React.PropsWithChildren<{
   className?: string;
-  handleOnBlur: () => void;
+  handleOnBlur?: () => void;
 }>;
 export function SearchBarContainer({ children, className, handleOnBlur }: SearchBarContainerProps) {
   const componentRef = useRef<HTMLDivElement>(null);
-  const handleClick = (event: MouseEvent) => {
-    if (componentRef.current && !componentRef.current.contains(event.target as Node)) {
-      handleOnBlur();
-    }
-  };
 
   useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (componentRef.current && !componentRef.current.contains(event.target as Node)) {
+        if (handleOnBlur) {
+          handleOnBlur();
+        }
+      }
+    };
+
     document.addEventListener('click', handleClick);
 
     return () => {
       document.removeEventListener('click', handleClick);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [handleOnBlur]);
 
   return (
     <div ref={componentRef} className={clsx('search-bar', className)}>

--- a/src/web/components/Search/SearchBar.tsx
+++ b/src/web/components/Search/SearchBar.tsx
@@ -12,11 +12,13 @@ export function SearchBarContainer({ children, className, handleOnBlur }: Search
   const componentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!handleOnBlur) {
+      return;
+    }
+
     const handleClick = (event: MouseEvent) => {
       if (componentRef.current && !componentRef.current.contains(event.target as Node)) {
-        if (handleOnBlur) {
-          handleOnBlur();
-        }
+        handleOnBlur();
       }
     };
 

--- a/src/web/components/SharingPermission/ParticipantSearchBar.tsx
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { AvailableParticipantDTO } from '../../../api/routers/participantsRouter';
@@ -50,7 +50,7 @@ export function ParticipantSearchBar({
   return (
     <SearchBarContainer
       className={clsx('participants-search-bar')}
-      handleOnBlur={() => onToggleOpen(false)}
+      handleOnBlur={useCallback(() => onToggleOpen(false), [onToggleOpen])}
     >
       <SearchBarInput
         className='participants-search-input'


### PR DESCRIPTION
Managed to break main (https://github.com/IABTechLab/uid2-self-serve-portal/actions/runs/5922755162/job/16057208608) by having a `SearchBarContainer` that did not provide a `handleOnBlur` method. It probably makes the most sense to set this as optional for now.

In this version, the event listener is added only if `handleOnBlur` is provided and is used as a dependency in the `useEffect` hook. This ensures that the event listener is added and removed properly when `handleOnBlur` changes.