### PR TITLE
ajy-Add-condition-to-audit-trail-migration

### DIFF
--- a/src/database/migrations/20230803014224_CreateAuditTrailsTableAndMigrateData.ts
+++ b/src/database/migrations/20230803014224_CreateAuditTrailsTableAndMigrateData.ts
@@ -76,7 +76,7 @@ async function migrateSharingAuditTrails(knex: Knex) {
     .select(knex.raw(`string_agg(sharingParticipantSiteId, ',') siteIds`), ...groupByColumns)
     .groupBy(groupByColumns);
   const auditTrails = sharingAuditTrails.map(mapSharingAuditTrailToAuditTrails);
-  await knex('auditTrails').insert(auditTrails);
+  if (auditTrails.length > 0) await knex('auditTrails').insert(auditTrails);
 }
 
 function mapAuditTrailsToSharingAuditTrails(


### PR DESCRIPTION
Discovered that this migration will fail if auditTrails is empty, and the error was hard to identify. Was pairing with Lionell at the time - it is a safe change so am just going to merge,