### PR TITLE
ajy-UID2-1617-Bulk-add-component-improvements

### DIFF
--- a/src/web/components/SharingPermission/BulkAddPermissions.spec.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.spec.tsx
@@ -1,0 +1,38 @@
+import { composeStories } from '@storybook/testing-react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import * as stories from './BulkAddPermissions.stories';
+
+const { Publisher, HasSharedWithPublisher } = composeStories(stories);
+
+describe('BulkAddPermissions', () => {
+  it('Renders "View Participants" button when there are checkboxes selected', () => {
+    render(<Publisher />);
+    expect(screen.getByRole('button', { name: 'View Participants' })).toBeInTheDocument();
+  });
+  it('Hides "View Participants" button when no checkboxes selected', () => {
+    render(<Publisher />);
+    const dspCheckbox = screen.getByTestId('dsp');
+
+    // uncheck DSP
+    fireEvent.click(dspCheckbox);
+
+    expect(screen.queryByRole('button', { name: 'View Participants' })).not.toBeInTheDocument();
+  });
+  it('Shows warning when removing a shared type', () => {
+    render(<HasSharedWithPublisher />);
+
+    // Expand collapsible
+    fireEvent.click(screen.getByRole('button'));
+    const publisherCheckbox = screen.getByTestId('publisher');
+
+    // uncheck Publisher
+    fireEvent.click(publisherCheckbox);
+
+    expect(
+      screen.getByText(
+        'If you remove the sharing permissions for a participant type, all sharing permissions of that type are removed, including future participants of that type.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
@@ -12,7 +12,7 @@ const Template: ComponentStory<typeof BulkAddPermissions> = (args) => (
   <BulkAddPermissions {...args} />
 );
 
-const onBulkAddSharingPermission = (ids: number[]) => Promise.resolve(console.log(ids));
+const onBulkAddSharingPermission = (types: string[]) => Promise.resolve(console.log(types));
 
 export const Publisher = Template.bind({});
 Publisher.args = {
@@ -24,12 +24,7 @@ Publisher.args = {
     status: ParticipantStatus.Approved,
   },
   onBulkAddSharingPermission,
-  participantTypes: [
-    { id: 2, typeName: 'Publisher' },
-    { id: 3, typeName: 'Advertiser' },
-    { id: 4, typeName: 'DSP' },
-    { id: 5, typeName: 'Data Provider' },
-  ],
+  sharedTypes: [],
 };
 
 export const AdvertiserAndDSP = Template.bind({});
@@ -45,12 +40,7 @@ AdvertiserAndDSP.args = {
     status: ParticipantStatus.Approved,
   },
   onBulkAddSharingPermission,
-  participantTypes: [
-    { id: 2, typeName: 'Publisher' },
-    { id: 3, typeName: 'Advertiser' },
-    { id: 4, typeName: 'DSP' },
-    { id: 5, typeName: 'Data Provider' },
-  ],
+  sharedTypes: [],
 };
 
 export const AllTypes = Template.bind({});
@@ -68,16 +58,11 @@ AllTypes.args = {
     status: ParticipantStatus.Approved,
   },
   onBulkAddSharingPermission,
-  participantTypes: [
-    { id: 2, typeName: 'Publisher' },
-    { id: 3, typeName: 'Advertiser' },
-    { id: 4, typeName: 'DSP' },
-    { id: 5, typeName: 'Data Provider' },
-  ],
+  sharedTypes: [],
 };
 
-export const HasSharingParticipants = Template.bind({});
-HasSharingParticipants.args = {
+export const HasSharedWithPublisher = Template.bind({});
+HasSharedWithPublisher.args = {
   participant: {
     id: 1,
     name: 'Participant 1',
@@ -90,11 +75,6 @@ HasSharingParticipants.args = {
     status: ParticipantStatus.Approved,
   },
   onBulkAddSharingPermission,
-  participantTypes: [
-    { id: 2, typeName: 'Publisher' },
-    { id: 3, typeName: 'Advertiser' },
-    { id: 4, typeName: 'DSP' },
-    { id: 5, typeName: 'Data Provider' },
-  ],
   hasSharingParticipants: true,
+  sharedTypes: ['publisher'],
 };

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -1,4 +1,3 @@
-import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { formatStringsWithSeparator, getArticle } from '../../utils/textHelpers';
 
 export type BulkAddPermissionsForm = {
@@ -31,40 +30,63 @@ export const getDefaultDataProviderCheckboxState = (participantTypeNames: string
 export const getRecommendedTypeFromParticipant = (participantTypeNames: string[]) => {
   const uniqueTypes = new Set<string>();
   if (getDefaultPublisherCheckboxState(participantTypeNames)) {
-    uniqueTypes.add('Publishers');
+    uniqueTypes.add('publisher');
   }
   if (getDefaultAdvertiserCheckboxState(participantTypeNames)) {
-    uniqueTypes.add('Advertisers');
+    uniqueTypes.add('advertiser');
   }
   if (getDefaultDSPCheckboxState(participantTypeNames)) {
-    uniqueTypes.add('DSPs');
+    uniqueTypes.add('dsp');
   }
   if (getDefaultDataProviderCheckboxState(participantTypeNames)) {
-    uniqueTypes.add('Data Providers');
+    uniqueTypes.add('data_provider');
   }
-  const result = Array.from(uniqueTypes);
-  if (result.length === 4) return 'participants';
-
-  return formatStringsWithSeparator(result);
+  return Array.from(uniqueTypes);
 };
 
-export const getCheckedParticipantTypeIds = (
-  data: BulkAddPermissionsForm,
-  participantTypes: ParticipantTypeDTO[]
+const getParticipantTypeNamesMessage = (recommendedTypes: string[]) => {
+  if (recommendedTypes.length === 4) return 'participants';
+  const friendlyNames: Record<string, string> = {
+    publisher: 'Publishers',
+    advertiser: 'Advertisers',
+    dsp: 'DSPs',
+    // eslint-disable-next-line camelcase
+    data_provider: 'Data Providers',
+  };
+
+  const formattedNames = recommendedTypes.map((type) => friendlyNames[type]);
+  return formatStringsWithSeparator(formattedNames);
+};
+
+export const hasUncheckedASharedType = (
+  sharedTypes: string[],
+  publisherChecked: boolean,
+  advertiserChecked: boolean,
+  DSPChecked: boolean,
+  dataProviderChecked: boolean
 ) => {
+  if (!publisherChecked && sharedTypes.includes('publisher')) return true;
+  if (!advertiserChecked && sharedTypes.includes('advertiser')) return true;
+  if (!DSPChecked && sharedTypes.includes('dsp')) return true;
+  if (!dataProviderChecked && sharedTypes.includes('data_provider')) return true;
+  return false;
+};
+
+export const getCheckedParticipantTypeNames = (data: BulkAddPermissionsForm) => {
   const ids = [];
-  if (data.publisherChecked)
-    ids.push(participantTypes.find((x) => x.typeName === 'Publisher')?.id!);
-  if (data.advertiserChecked)
-    ids.push(participantTypes.find((x) => x.typeName === 'Advertiser')?.id!);
-  if (data.DSPChecked) ids.push(participantTypes.find((x) => x.typeName === 'DSP')?.id!);
-  if (data.dataProviderChecked)
-    ids.push(participantTypes.find((x) => x.typeName === 'Data Provider')?.id!);
+  if (data.publisherChecked) ids.push('publisher');
+  if (data.advertiserChecked) ids.push('advertiser');
+
+  if (data.DSPChecked) ids.push('dsp');
+  if (data.dataProviderChecked) ids.push('data_provider');
   return ids;
 };
 
-export const getRecommendationMessageFromTypeNames = (participantTypeNames: string[]) => {
+export const getRecommendationMessageFromTypeNames = (
+  participantTypeNames: string[],
+  recommendedTypes: string[]
+) => {
   return `As ${getArticle(participantTypeNames[0])} ${formatStringsWithSeparator(
     participantTypeNames
-  )}, we recommend you share with all ${getRecommendedTypeFromParticipant(participantTypeNames)}.`;
+  )}, we recommend you share with all ${getParticipantTypeNamesMessage(recommendedTypes)}.`;
 };


### PR DESCRIPTION
- Populate checkboxes by using the sharedTypes prop, if there are already types that have been shared with
- Render the "View Participants button only when there is a checkbox selected
- Show the warning when unchecking a type that has already been shared with (regardless of what the actual recommendations are)
- Added some tests
- Some refactoring

**Pre-populate checkboxes when the participant has already shared with a type**

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/f8fce8c8-eace-46a3-9aa0-420a510f5921)

**Hide "View Participants" button when there are no checkboxes selected**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/5c6eaa01-004a-46b9-aab4-f86f828f21f2

**Show warning when unchecking a type that has already been shared with**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/7ef4ff49-ee7e-4ef7-87ee-5e1d3520ffed


