### PR TITLE
ajy-UID2-1617-Participant-item-simple

### DIFF
--- a/src/web/components/SharingPermission/ParticipantItem.scss
+++ b/src/web/components/SharingPermission/ParticipantItem.scss
@@ -1,37 +1,37 @@
-.participant-item {
+.participant-item-with-checkbox {
   button[role='checkbox'] {
     width: 21px;
     height: 21px;
   }
-  .participant-type-label {
-    background: var(--theme-label-background);
-    border-radius: 3px;
-    padding: 4px 8px;
-    margin-right: 8px;
-  }
-
   .participant-checkbox {
     margin-right: 16px;
   }
+}
 
-  .participant-logo {
-    width: 50px;
-    margin-right: 16px;
-  }
+.participant-type-label {
+  background: var(--theme-label-background);
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin-right: 8px;
+}
 
-  .participant-types {
-    display: flex;
-    align-items: center;
-    font-size: 0.625rem;
-    line-height: 0.75rem;
-  }
+.participant-logo {
+  width: 50px;
+  margin-right: 16px;
+}
 
-  .participant-name-cell {
-    display: flex;
-    align-items: center;
+.participant-types {
+  display: flex;
+  align-items: center;
+  font-size: 0.625rem;
+  line-height: 0.75rem;
+}
 
-    .checkbox-label {
-      padding-right: 16px;
-    }
+.participant-name-cell {
+  display: flex;
+  align-items: center;
+
+  .checkbox-label {
+    padding-right: 16px;
   }
 }

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -6,35 +6,24 @@ import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 
 import './ParticipantItem.scss';
 
-type ParticipantItemProps = {
+function getParticipantTypes(participantTypes?: z.infer<typeof ParticipantTypeSchema>[]) {
+  if (!participantTypes) return null;
+  return participantTypes.map((pt) => (
+    <div className='participant-type-label' key={pt.typeName}>
+      {pt.typeName}
+    </div>
+  ));
+}
+
+type ParticipantItemSimpleProps = {
   participant: AvailableParticipantDTO;
-  onClick: () => void;
-  checked: boolean;
-  addedBy?: string;
 };
 
-export function ParticipantItem({ participant, onClick, checked, addedBy }: ParticipantItemProps) {
-  function getParticipantTypes(participantTypes?: z.infer<typeof ParticipantTypeSchema>[]) {
-    if (!participantTypes) return null;
-    return participantTypes.map((pt) => (
-      <div className='participant-type-label' key={pt.typeName}>
-        {pt.typeName}
-      </div>
-    ));
-  }
-
-  // TODO: update this when we have login uploading
+export function ParticipantItemSimple({ participant }: ParticipantItemSimpleProps) {
   const logo = '/default-logo.svg';
+
   return (
-    <tr className='participant-item'>
-      <td>
-        <TriStateCheckbox
-          onClick={onClick}
-          status={checked}
-          className='participant-checkbox'
-          disabled={addedBy === 'Auto'} // addedBy is currently hardcoded to 'Manual'
-        />
-      </td>
+    <>
       <td className='participant-name-cell'>
         <img src={logo} alt={participant.name} className='participant-logo' />
         <label htmlFor={`checkbox-${participant.id}`} className='checkbox-label'>
@@ -44,6 +33,33 @@ export function ParticipantItem({ participant, onClick, checked, addedBy }: Part
       <td>
         <div className='participant-types'>{getParticipantTypes(participant.types)}</div>
       </td>
+    </>
+  );
+}
+
+type ParticipantItemProps = ParticipantItemSimpleProps & {
+  onClick: () => void;
+  checked: boolean;
+  addedBy?: string;
+};
+
+export function ParticipantItem({
+  participant,
+  onClick,
+  checked,
+  addedBy,
+}: ParticipantItemProps) {
+  return (
+    <tr className='participant-item-with-checkbox'>
+      <td>
+        <TriStateCheckbox
+          onClick={onClick}
+          status={checked}
+          className='participant-checkbox'
+          disabled={addedBy === 'Auto'} // addedBy is currently hardcoded to 'Manual'
+        />
+      </td>
+      <ParticipantItemSimple participant={participant} />
       {addedBy && <td>{addedBy}</td>}
     </tr>
   );

--- a/src/web/components/SharingPermission/ParticipantItemSimple.stories.tsx
+++ b/src/web/components/SharingPermission/ParticipantItemSimple.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ParticipantItemSimple } from './ParticipantItem';
+
+export default {
+  title: 'Sharing Permissions/ParticipantItemSimple',
+  component: ParticipantItemSimple,
+} as ComponentMeta<typeof ParticipantItemSimple>;
+
+const Template: ComponentStory<typeof ParticipantItemSimple> = (args) => (
+  <table>
+    <tbody>
+      <tr>
+        <ParticipantItemSimple {...args} />
+      </tr>
+    </tbody>
+  </table>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  participant: {
+    id: 1,
+    name: 'Participant 1',
+    types: [{ id: 2, typeName: 'Type 2' }],
+  },
+};


### PR DESCRIPTION
* ParticipantItem currently has a checkbox as well as an `addedBy` prop that is not needed in all use cases (e.g. Bulk Add Permissions control). 
* The new ParticipantItemSimple component just has the logo, name and associated types, and ParticipantItem now has a ParticipantItemSimple.

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/5a5f6403-3b50-422b-a93f-1f7f4ac21b13)
