### PR TITLE
ajy-UID2-List-participants-by-type-in-bulk-add

### DIFF
--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -41,6 +41,23 @@
     .bulk-add-permissions-view-recommendations-button {
       padding-top: 20px;
     }
+
+    .bulk-add-permissions-participants-table {
+      display: flex;
+      padding: 10px 0;
+      margin-top: 20px;
+      border: 1px solid var(--theme-border);
+      border-radius: 5px;
+      max-height: 410px;
+      overflow: auto;
+
+      td:first-of-type {
+        padding-left: 32px;
+      }
+      tr {
+        background-color: white;
+      }
+    }
   }
 
   .bulk-add-permissions-footer {

--- a/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
@@ -14,6 +14,114 @@ const Template: ComponentStory<typeof BulkAddPermissions> = (args) => (
 
 const onBulkAddSharingPermission = (types: string[]) => Promise.resolve(console.log(types));
 
+const availableParticipants = [
+  {
+    id: 1,
+    siteId: 1,
+    name: 'Participant 1',
+    types: [{ id: 1, typeName: 'DSP' }],
+  },
+  {
+    id: 2,
+    siteId: 2,
+    name: 'Participant 2',
+    types: [{ id: 2, typeName: 'Publisher' }],
+  },
+  {
+    id: 3,
+    siteId: 3,
+    name: 'Participant 3',
+    types: [{ id: 3, typeName: 'Advertiser' }],
+  },
+  {
+    id: 4,
+    siteId: 4,
+    name: 'Participant 4',
+    types: [{ id: 4, typeName: 'Data Provider' }],
+  },
+  {
+    id: 5,
+    siteId: 5,
+    name: 'Participant 5',
+    types: [
+      { id: 1, typeName: 'DSP' },
+      { id: 2, typeName: 'Publisher' },
+      { id: 3, typeName: 'Advertiser' },
+      { id: 4, typeName: 'Data Provider' },
+    ],
+  },
+  {
+    id: 6,
+    siteId: 6,
+    name: 'Participant 6',
+    types: [{ id: 6, typeName: 'DSP' }],
+  },
+  {
+    id: 7,
+    siteId: 7,
+    name: 'Participant 7',
+    types: [{ id: 7, typeName: 'Publisher' }],
+  },
+  {
+    id: 8,
+    siteId: 8,
+    name: 'Participant 8',
+    types: [{ id: 8, typeName: 'Advertiser' }],
+  },
+  {
+    id: 9,
+    siteId: 9,
+    name: 'Participant 9',
+    types: [{ id: 9, typeName: 'Data Provider' }],
+  },
+  {
+    id: 10,
+    siteId: 10,
+    name: 'Participant 10',
+    types: [
+      { id: 1, typeName: 'DSP' },
+      { id: 2, typeName: 'Publisher' },
+      { id: 3, typeName: 'Advertiser' },
+      { id: 4, typeName: 'Data Provider' },
+    ],
+  },
+  {
+    id: 11,
+    siteId: 11,
+    name: 'Participant 11',
+    types: [{ id: 11, typeName: 'DSP' }],
+  },
+  {
+    id: 12,
+    siteId: 12,
+    name: 'Participant 12',
+    types: [{ id: 12, typeName: 'Publisher' }],
+  },
+  {
+    id: 13,
+    siteId: 13,
+    name: 'Participant 13',
+    types: [{ id: 13, typeName: 'Advertiser' }],
+  },
+  {
+    id: 14,
+    siteId: 14,
+    name: 'Participant 14',
+    types: [{ id: 14, typeName: 'Data Provider' }],
+  },
+  {
+    id: 15,
+    siteId: 15,
+    name: 'Participant 15',
+    types: [
+      { id: 1, typeName: 'DSP' },
+      { id: 2, typeName: 'Publisher' },
+      { id: 3, typeName: 'Advertiser' },
+      { id: 4, typeName: 'Data Provider' },
+    ],
+  },
+];
+
 export const Publisher = Template.bind({});
 Publisher.args = {
   participant: {
@@ -25,6 +133,7 @@ Publisher.args = {
   },
   onBulkAddSharingPermission,
   sharedTypes: [],
+  availableParticipants,
 };
 
 export const AdvertiserAndDSP = Template.bind({});
@@ -34,13 +143,14 @@ AdvertiserAndDSP.args = {
     name: 'Participant 1',
     types: [
       { id: 3, typeName: 'Advertiser' },
-      { id: 4, typeName: 'DSP' },
+      { id: 1, typeName: 'DSP' },
     ],
     allowSharing: true,
     status: ParticipantStatus.Approved,
   },
   onBulkAddSharingPermission,
   sharedTypes: [],
+  availableParticipants,
 };
 
 export const AllTypes = Template.bind({});
@@ -51,14 +161,15 @@ AllTypes.args = {
     types: [
       { id: 2, typeName: 'Publisher' },
       { id: 3, typeName: 'Advertiser' },
-      { id: 4, typeName: 'DSP' },
-      { id: 5, typeName: 'Data Provider' },
+      { id: 1, typeName: 'DSP' },
+      { id: 4, typeName: 'Data Provider' },
     ],
     allowSharing: true,
     status: ParticipantStatus.Approved,
   },
   onBulkAddSharingPermission,
   sharedTypes: [],
+  availableParticipants,
 };
 
 export const HasSharedWithPublisher = Template.bind({});
@@ -69,7 +180,7 @@ HasSharedWithPublisher.args = {
     types: [
       { id: 2, typeName: 'Publisher' },
       { id: 3, typeName: 'Advertiser' },
-      { id: 4, typeName: 'DSP' },
+      { id: 1, typeName: 'DSP' },
     ],
     allowSharing: true,
     status: ParticipantStatus.Approved,
@@ -77,4 +188,5 @@ HasSharedWithPublisher.args = {
   onBulkAddSharingPermission,
   hasSharingParticipants: true,
   sharedTypes: ['publisher'],
+  availableParticipants,
 };

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { ParticipantDTO } from '../../../api/entities/Participant';
@@ -39,7 +39,6 @@ export function BulkAddPermissions({
   onBulkAddSharingPermission,
 }: BulkAddPermissionsProps) {
   const [showRecommendedParticipants, setShowRecommendedParticipants] = useState(false);
-  const [filteredParticipants, setFilteredParticipants] = useState(availableParticipants);
   const currentParticipantTypeNames = participant?.types
     ? participant.types.map((p) => p.typeName ?? '')
     : [];
@@ -83,15 +82,13 @@ export function BulkAddPermissions({
     );
   }, [watchPublisherChecked, watchAdvertiserChecked, watchDSPChecked, watchDataProviderChecked]);
 
-  useEffect(() => {
-    setFilteredParticipants(
-      getFilteredParticipantsByType(
-        availableParticipants,
-        watchPublisherChecked,
-        watchAdvertiserChecked,
-        watchDSPChecked,
-        watchDataProviderChecked
-      )
+  const filteredParticipants = useMemo(() => {
+    return getFilteredParticipantsByType(
+      availableParticipants,
+      watchPublisherChecked,
+      watchAdvertiserChecked,
+      watchDSPChecked,
+      watchDataProviderChecked
     );
   }, [
     availableParticipants,

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { ParticipantDTO } from '../../../api/entities/Participant';
+import { AvailableParticipantDTO } from '../../../api/routers/participantsRouter';
 import { Banner } from '../Core/Banner';
 import { Collapsible } from '../Core/Collapsible';
+import { withoutRef } from '../Core/Form';
 import { FormStyledCheckbox } from '../Input/StyledCheckbox';
 import {
   BulkAddPermissionsForm,
@@ -12,16 +14,19 @@ import {
   getDefaultDataProviderCheckboxState,
   getDefaultDSPCheckboxState,
   getDefaultPublisherCheckboxState,
+  getFilteredParticipantsByType,
   getRecommendationMessageFromTypeNames,
   getRecommendedTypeFromParticipant,
   hasUncheckedASharedType,
 } from './bulkAddPermissionsHelpers';
+import { ParticipantItemSimple } from './ParticipantItem';
 
 import './BulkAddPermissions.scss';
 
 type BulkAddPermissionsProps = {
   participant: ParticipantDTO | null;
   hasSharingParticipants: boolean;
+  availableParticipants: AvailableParticipantDTO[];
   onBulkAddSharingPermission: (selectedTypes: string[]) => Promise<void>;
   sharedTypes: string[];
 };
@@ -29,11 +34,12 @@ type BulkAddPermissionsProps = {
 export function BulkAddPermissions({
   participant,
   hasSharingParticipants,
+  availableParticipants,
   sharedTypes,
   onBulkAddSharingPermission,
 }: BulkAddPermissionsProps) {
   const [showRecommendedParticipants, setShowRecommendedParticipants] = useState(false);
-
+  const [filteredParticipants, setFilteredParticipants] = useState(availableParticipants);
   const currentParticipantTypeNames = participant?.types
     ? participant.types.map((p) => p.typeName ?? '')
     : [];
@@ -71,19 +77,42 @@ export function BulkAddPermissions({
   const watchDSPChecked = watch('DSPChecked');
   const watchDataProviderChecked = watch('dataProviderChecked');
 
+  const hasCheckedType = useCallback(() => {
+    return (
+      watchPublisherChecked || watchAdvertiserChecked || watchDSPChecked || watchDataProviderChecked
+    );
+  }, [watchPublisherChecked, watchAdvertiserChecked, watchDSPChecked, watchDataProviderChecked]);
+
+  useEffect(() => {
+    setFilteredParticipants(
+      getFilteredParticipantsByType(
+        availableParticipants,
+        watchPublisherChecked,
+        watchAdvertiserChecked,
+        watchDSPChecked,
+        watchDataProviderChecked
+      )
+    );
+  }, [
+    availableParticipants,
+    watchPublisherChecked,
+    watchAdvertiserChecked,
+    watchDSPChecked,
+    watchDataProviderChecked,
+  ]);
+
+  useEffect(() => {
+    if (!hasCheckedType()) setShowRecommendedParticipants(false);
+  }, [hasCheckedType]);
+
   const handleSave = (data: BulkAddPermissionsForm) => {
     onBulkAddSharingPermission(getCheckedParticipantTypeNames(data));
   };
 
-  const onToggleViewRecommendedParticipants = () => {
-    setShowRecommendedParticipants((prevToggle) => !prevToggle);
-    // TODO: show/hide the actual participants
-  };
-
-  const saveRecommendationsButton = (
+  const savePermissionsButton = (
     <div className='bulk-add-permissions-footer'>
       <button type='submit' className='primary-button bulk-add-permissions-submit-button'>
-        Save Recommendations
+        Save Permissions
       </button>
     </div>
   );
@@ -96,26 +125,40 @@ export function BulkAddPermissions({
         tokens.
       </p>
       <div className='participant-type-checkbox-section'>
-        <FormStyledCheckbox {...register('publisherChecked')} data-testid='publisher' />
+        <FormStyledCheckbox {...withoutRef(register('publisherChecked'))} data-testid='publisher' />
         <span className='checkbox-label'>Publisher</span>
-        <FormStyledCheckbox {...register('advertiserChecked')} data-testid='advertiser' />
+        <FormStyledCheckbox
+          {...withoutRef(register('advertiserChecked'))}
+          data-testid='advertiser'
+        />
         <span className='checkbox-label'>Advertiser</span>
-        <FormStyledCheckbox {...register('DSPChecked')} data-testid='dsp' />
+        <FormStyledCheckbox {...withoutRef(register('DSPChecked'))} data-testid='dsp' />
         <span className='checkbox-label'>DSP</span>
-        <FormStyledCheckbox {...register('dataProviderChecked')} data-testid='data-provider' />
+        <FormStyledCheckbox
+          {...withoutRef(register('dataProviderChecked'))}
+          data-testid='data-provider'
+        />
         <span className='checkbox-label'>Data Provider</span>
       </div>
-      {(watchPublisherChecked ||
-        watchAdvertiserChecked ||
-        watchDSPChecked ||
-        watchDataProviderChecked) && (
+      {hasCheckedType() && (
         <button
           type='button'
           className='text-button bulk-add-permissions-view-recommendations-button'
-          onClick={onToggleViewRecommendedParticipants}
+          onClick={() => setShowRecommendedParticipants((prevToggle) => !prevToggle)}
         >
           {showRecommendedParticipants ? 'Hide Participants' : 'View Participants'}
         </button>
+      )}
+      {showRecommendedParticipants && hasCheckedType() && (
+        <table className='bulk-add-permissions-participants-table'>
+          <tbody>
+            {filteredParticipants.map((p) => (
+              <tr key={p.id}>
+                <ParticipantItemSimple participant={p} />
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </>
   );
@@ -123,7 +166,7 @@ export function BulkAddPermissions({
   const recommendationContent = (
     <div className='bulk-add-permissions'>
       <div className='bulk-add-permissions-body'>{commonContent}</div>
-      {saveRecommendationsButton}
+      {savePermissionsButton}
     </div>
   );
 
@@ -146,7 +189,7 @@ export function BulkAddPermissions({
           </div>
         )}
       </div>
-      {isDirty && saveRecommendationsButton}
+      {isDirty && savePermissionsButton}
     </div>
   );
 

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -1,3 +1,4 @@
+import { AvailableParticipantDTO } from '../../../api/routers/participantsRouter';
 import { formatStringsWithSeparator, getArticle } from '../../utils/textHelpers';
 
 export type BulkAddPermissionsForm = {
@@ -89,4 +90,25 @@ export const getRecommendationMessageFromTypeNames = (
   return `As ${getArticle(participantTypeNames[0])} ${formatStringsWithSeparator(
     participantTypeNames
   )}, we recommend you share with all ${getParticipantTypeNamesMessage(recommendedTypes)}.`;
+};
+
+export const getFilteredParticipantsByType = (
+  participants: AvailableParticipantDTO[],
+  publisherChecked: boolean,
+  advertiserChecked: boolean,
+  DSPChecked: boolean,
+  dataProviderChecked: boolean
+) => {
+  return participants.filter((p) => {
+    const selectedTypes = p.types!.map((type) => type.typeName);
+    if (
+      (publisherChecked && selectedTypes.includes('Publisher')) ||
+      (advertiserChecked && selectedTypes.includes('Advertiser')) ||
+      (DSPChecked && selectedTypes.includes('DSP')) ||
+      (dataProviderChecked && selectedTypes.includes('Data Provider'))
+    ) {
+      return true;
+    }
+    return false;
+  });
 };


### PR DESCRIPTION
* Show participants according to checked types
* Show the "View Participants" button when a type is checked
* Some copy changes

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/53754bd1-c519-4abc-bea4-cf42ef9a7801

**Future work**
* Pass the participants into this component, will need to come from the Sites from Admin. We will need to use siteId to map from a SiteDTO to an AvailableParticipantDTO.

