### PR TITLE
hide logout link

### DIFF
--- a/src/web/components/Core/SideNav.scss
+++ b/src/web/components/Core/SideNav.scss
@@ -22,6 +22,10 @@
     margin: 0;
   }
 
+  .hidden {
+    display: none;
+  }
+
   .side-nav-item {
     padding: 5px 10px;
   }

--- a/src/web/components/Core/SideNav.tsx
+++ b/src/web/components/Core/SideNav.tsx
@@ -14,9 +14,10 @@ function MenuItem({
   path,
   description,
   linkClass,
-}: Pick<PortalRoute, 'path' | 'description'> & { linkClass?: string }) {
+  isHidden,
+}: Pick<PortalRoute, 'path' | 'description' | 'isHidden'> & { linkClass?: string }) {
   return (
-    <NavigationMenuItem key={path} className='side-nav-item'>
+    <NavigationMenuItem key={path} className={`side-nav-item ${isHidden ? 'hidden' : ''}`}>
       <NavLink to={path} className={linkClass}>
         {description}
       </NavLink>

--- a/src/web/screens/logout.tsx
+++ b/src/web/screens/logout.tsx
@@ -13,4 +13,5 @@ export const LogoutRoute: PortalRoute = {
   path: '/logout',
   description: 'Logout',
   element: <Logout />,
+  isHidden: true,
 };

--- a/src/web/screens/routeUtils.tsx
+++ b/src/web/screens/routeUtils.tsx
@@ -13,6 +13,7 @@ export type PortalRoute = RouteObject & {
   element: JSX.Element;
   description: string;
   location?: 'default' | 'footer';
+  isHidden?: boolean;
 };
 
 export const makePrivateRoute = (route: PortalRoute | RouteObject): PortalRoute => {


### PR DESCRIPTION
Hide the logout link.  The route needs to be rendered for it to work, but we don't want it displayed in the UI.