### PR TITLE
Use participant name instead of site name

### DIFF
--- a/src/api/helpers/siteConvertingHelpers.ts
+++ b/src/api/helpers/siteConvertingHelpers.ts
@@ -1,3 +1,4 @@
+import { Participant } from '../entities/Participant';
 import { ParticipantTypeDTO } from '../entities/ParticipantType';
 import { AvailableParticipantDTO } from '../routers/participantsRouter';
 import { ClientType, SiteDTO } from '../services/adminServiceHelpers';
@@ -18,12 +19,17 @@ export const mapClientTypeToParticipantType = (
 
 export const convertSiteToAvailableParticipantDTO = (
   site: SiteDTO,
-  participantTypes: ParticipantTypeDTO[]
+  participantTypes: ParticipantTypeDTO[],
+  participants: Participant[]
 ): AvailableParticipantDTO => {
+  const matchedParticipant = participants.find((p) => p.siteId === site.id);
   return {
-    name: site.name,
+    name: matchedParticipant ? matchedParticipant.name : site.name,
     siteId: site.id,
-    types: mapClientTypeToParticipantType(site.clientTypes ?? [], participantTypes),
+    types:
+      matchedParticipant && matchedParticipant.types
+        ? matchedParticipant.types
+        : mapClientTypeToParticipantType(site.clientTypes ?? [], participantTypes),
   };
 };
 

--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -8,7 +8,7 @@ import {
 import { isApproverCheck } from '../middleware/approversMiddleware';
 import { getSiteList } from '../services/adminServiceClient';
 import { SiteDTO } from '../services/adminServiceHelpers';
-import { getAttachedSiteIDs } from '../services/participantsService';
+import { getAttachedSiteIDs, getParticipantsBySiteIds } from '../services/participantsService';
 
 export function createSitesRouter() {
   const sitesRouter = express.Router();
@@ -24,8 +24,9 @@ export function createSitesRouter() {
     const sites = await getSiteList();
     const availableSites = sites.filter(hasSharerRole);
     const participantTypes = await ParticipantType.query();
+    const matchedParticipants = await getParticipantsBySiteIds(availableSites.map((s) => s.id));
     const availableParticipants = availableSites.map((site: SiteDTO) =>
-      convertSiteToAvailableParticipantDTO(site, participantTypes)
+      convertSiteToAvailableParticipantDTO(site, participantTypes, matchedParticipants)
     );
     return res.status(200).json(availableParticipants);
   });

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -69,6 +69,10 @@ export const getAttachedSiteIDs = async (): Promise<SiteIdType[]> => {
   return sites.map((s) => s.siteId);
 };
 
+export const getParticipantsBySiteIds = async (siteIds: number[]) => {
+  return Participant.query().whereIn('siteId', siteIds).withGraphFetched('types');
+};
+
 export const addSharingParticipants = async (
   participantSiteId: number,
   siteIds: number[],

--- a/src/api/tests/siteConvertingHelpers.spec.ts
+++ b/src/api/tests/siteConvertingHelpers.spec.ts
@@ -1,3 +1,4 @@
+import { Participant } from '../entities/Participant';
 import {
   convertSiteToAvailableParticipantDTO,
   hasSharerRole,
@@ -59,9 +60,45 @@ describe('Sharing Permission Helper Tests', () => {
         // eslint-disable-next-line camelcase
         client_count: 1,
       } as SiteDTO;
-      const convertedType = convertSiteToAvailableParticipantDTO(site, participantTypes);
+      const convertedType = convertSiteToAvailableParticipantDTO(site, participantTypes, []);
       expect(convertedType).toEqual({
         name: 'Test Site',
+        siteId: 2,
+        types: [
+          {
+            id: 2,
+            typeName: 'Publisher',
+          },
+        ],
+      });
+    });
+
+    it('should return participant from db if participant has portal account', () => {
+      const site = {
+        id: 2,
+        name: 'Test Site',
+        enabled: true,
+        roles: ['SHARER'],
+        clientTypes: ['PUBLISHER'],
+        // eslint-disable-next-line camelcase
+        client_count: 1,
+      } as SiteDTO;
+      const participant = {
+        id: 100,
+        name: 'Participant Name',
+        siteId: 2,
+        types: [
+          {
+            id: 2,
+            typeName: 'Publisher',
+          },
+        ],
+      } as Participant;
+      const convertedType = convertSiteToAvailableParticipantDTO(site, participantTypes, [
+        participant,
+      ]);
+      expect(convertedType).toEqual({
+        name: 'Participant Name',
         siteId: 2,
         types: [
           {


### PR DESCRIPTION
Use Participant Name in DB instead of site name
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/68ecb1c6-3a8c-4d37-bc59-d0229fde4286)
