### PR TITLE
ajy-UID2-Fix-bulk-add-still-checking-recommended-types

### DIFF
--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 
-import { ParticipantType } from '../entities/ParticipantType';
 import {
   canBeSharedWith,
   convertSiteToSharingSiteDTO,

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -56,13 +56,13 @@ export function BulkAddPermissions({
   const { register, handleSubmit, watch, setValue } = formMethods;
 
   useEffect(() => {
-    if (sharedTypes && sharedTypes.length > 0) {
+    if (participant?.completedRecommendations) {
       setValue('publisherChecked', sharedTypes.includes('PUBLISHER'));
       setValue('advertiserChecked', sharedTypes.includes('ADVERTISER'));
       setValue('DSPChecked', sharedTypes.includes('DSP'));
       setValue('dataProviderChecked', sharedTypes.includes('DATA_PROVIDER'));
     }
-  }, [sharedTypes, setValue]);
+  }, [sharedTypes, setValue, participant?.completedRecommendations]);
 
   const watchPublisherChecked = watch('publisherChecked');
   const watchAdvertiserChecked = watch('advertiserChecked');


### PR DESCRIPTION
Use the `completedRecommendations` flag to determine if the current sharing types should be used to populate checkboxes, rather than just checking if there are shared types.

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/6e5b01bb-f51f-4bbf-b697-cf4797e0e5ab

