### PR TITLE
ajy-UID2-1789-Set-keycloak-secret-in-setup

### DIFF
--- a/KeycloakAdvancedSetup.md
+++ b/KeycloakAdvancedSetup.md
@@ -4,7 +4,9 @@ This document provides detailed instructions on more advanced Keycloak setup top
 
 ## Generating SSP_KK_SECRET
 
-You can obtain the `SSP_KK_SECRET` by generating a new client secret in the Keycloak admin portal. Here's how you can do it:
+It is preferred that you use the `SSP_KK_SECRET` that is stored in `.env`, and you set the secret in keycloak by [resetting your realm](./KeycloakAdvancedSetup.md#reset-realm). 
+
+However, if you must generate a new client secret, please do the following:
 
 1. Login to the Keycloak admin console.
 2. Ensure the realm dropdown has 'self-serve-portal' selected (rather than 'master'), then navigate to the "Clients" page and select the `self-serve-portal-apis`.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Your app is ready to be deployed! Note that builds for deployment are not made o
 
 The following steps describe the minimal steps required to successfully log in to the portal UI. If you require a fully-functional portal, please perform the following steps as well as the steps described below in [Connecting to local admin service](README.md#connecting-to-local-admin-service).
 1. Set up Docker, as described above: [Docker](README.md#docker)
-2. Update your `SSP_KK_SECRET` by following the steps above: [Generating SSP_KK_SECRET](./KeycloakAdvancedSetup.md#generating-ssp_kk_secret)
+2. Ensure your `SSP_KK_SECRET` matches the value in the Keycloak admin console. If it does not, please try [Reset your keycloak realm](./KeycloakAdvancedSetup.md#reset-realm). If all else fails, manually generate your own secret by following: [Generating SSP_KK_SECRET](./KeycloakAdvancedSetup.md#generating-ssp_kk_secret)
 3. Run the following to install dependencies:
    ```
    npm install

--- a/keycloak/realm/realm-export.json
+++ b/keycloak/realm/realm-export.json
@@ -810,7 +810,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
+      "secret": "vkmHl0pPRf2skBq0v9MTvy9AlilxPSDa",
       "redirectUris": ["http://localhost:6540/*"],
       "webOrigins": [],
       "notBefore": 0,


### PR DESCRIPTION
Set the secret for `self_serve_portal_apis` in the `realm-export.json` file to match the one that is checked into `main` in the `.env` file. 

### Why this helps
- When a dev runs the keycloak setup for the first time, it uses `realm-export.json`, so they will not have to manually generate their own `SSP_KK_SECRET` and set it in their `.env` file
- Existing devs can benefit from this by following the steps below.

### Manual testing
**Note: Only do this if you are okay with it removing all your keycloak users.**
1. Ensure you are using the `SSP_KK_SECRET` that is checked into `main`, not your own.
2. Import the keycloak realm by following the instructions in `KeycloakAdvancedSetup.md`. 
3. Go through the account creation & participant approval process in order to sign into the UI
4. Try edit/add/delete users, and it should work! 