### PR TITLE
ajy-UID2-1969-Various-changes-to-sharing-screen

### DIFF
--- a/src/web/components/Core/Collapsible.scss
+++ b/src/web/components/Core/Collapsible.scss
@@ -46,6 +46,7 @@
 
   .collapsible-content {
     display: flex;
+    flex-direction: column;
     padding: 0 0 20px 20px;
   }
 }

--- a/src/web/components/Core/Collapsible.tsx
+++ b/src/web/components/Core/Collapsible.tsx
@@ -13,13 +13,7 @@ export type CollapsibleProps = {
   className?: string;
 };
 
-export function Collapsible({
-  title,
-  children: content,
-  defaultOpen,
-  label,
-  className,
-}: CollapsibleProps) {
+export function Collapsible({ title, children, defaultOpen, label, className }: CollapsibleProps) {
   return (
     <RadixCollapsible.Root
       className={clsx('collapsible-root', className)}
@@ -39,7 +33,7 @@ export function Collapsible({
         </div>
       </RadixCollapsible.Trigger>
       <RadixCollapsible.Content>
-        <div className='collapsible-content'>{content}</div>
+        <div className='collapsible-content'>{children}</div>
       </RadixCollapsible.Content>
     </RadixCollapsible.Root>
   );

--- a/src/web/components/Core/Tooltip.scss
+++ b/src/web/components/Core/Tooltip.scss
@@ -1,7 +1,10 @@
 .tooltip-trigger {
-  color: var(--theme-info-icon);
   border: none !important;
   padding: 0 5px !important;
+
+  .default-trigger {
+    color: var(--theme-info-icon);
+  }
 }
 
 .tooltip-content {

--- a/src/web/components/Core/Tooltip.scss
+++ b/src/web/components/Core/Tooltip.scss
@@ -13,8 +13,8 @@
   background-color: var(--theme-background-sidepanel);
   padding: 10px;
   font-weight: 400;
-  font-size: 0.625rem;
-  line-height: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.125;
   max-width: 190px;
   box-shadow: 0px 4px 4px var(--theme-box-shadow);
 }

--- a/src/web/components/Core/Tooltip.scss
+++ b/src/web/components/Core/Tooltip.scss
@@ -1,25 +1,31 @@
-.tooltip-trigger {
-  border: none !important;
-  padding: 0 !important;
+.tooltip {
+  display: flex;
   width: inherit;
-  
-  .default-trigger {
-    color: var(--theme-info-icon);
+  align-self: center;
+
+  button.tooltip-trigger {
+    border: none;
+    padding: 0;
+    width: inherit;
+
+    .default-trigger {
+      color: var(--theme-info-icon);
+    }
   }
-}
 
-.tooltip-content {
-  color: var(--theme-button-text);
-  border-radius: 4px;
-  background-color: var(--theme-background-sidepanel);
-  padding: 10px;
-  font-weight: 400;
-  font-size: 0.75rem;
-  line-height: 1.125;
-  max-width: 190px;
-  box-shadow: 0px 4px 4px var(--theme-box-shadow);
-}
+  .tooltip-content {
+    color: var(--theme-button-text);
+    border-radius: 4px;
+    background-color: var(--theme-background-sidepanel);
+    padding: 10px;
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1.125;
+    max-width: 190px;
+    box-shadow: 0px 4px 4px var(--theme-box-shadow);
+  }
 
-.tooltip-arrow {
-  fill: var(--theme-background-sidepanel);
+  .tooltip-arrow {
+    fill: var(--theme-background-sidepanel);
+  }
 }

--- a/src/web/components/Core/Tooltip.scss
+++ b/src/web/components/Core/Tooltip.scss
@@ -1,7 +1,8 @@
 .tooltip-trigger {
   border: none !important;
-  padding: 0 5px !important;
-
+  padding: 0 !important;
+  width: inherit;
+  
   .default-trigger {
     color: var(--theme-info-icon);
   }

--- a/src/web/components/Core/Tooltip.stories.tsx
+++ b/src/web/components/Core/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ export const WithSide: Story = {
 
 export const WithAlign: Story = {
   args: {
-    children: 'With end',
+    children: 'With align',
     align: 'start',
   },
 };

--- a/src/web/components/Core/Tooltip.stories.tsx
+++ b/src/web/components/Core/Tooltip.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Tooltip } from './Tooltip';
+
+export default {
+  title: 'Shared Components/Tooltip',
+  component: Tooltip,
+} as Meta<typeof Tooltip>;
+
+type Story = StoryObj<typeof Tooltip>;
+export const Default: Story = {
+  args: {
+    children: 'Default tooltip',
+  },
+};
+
+export const WithCustomTrigger: Story = {
+  args: {
+    children: 'With custom trigger',
+    trigger: 'My custom trigger',
+  },
+};
+
+export const WithSide: Story = {
+  args: {
+    children: 'With side',
+    side: 'left',
+  },
+};
+
+export const WithAlign: Story = {
+  args: {
+    children: 'With end',
+    align: 'start',
+  },
+};

--- a/src/web/components/Core/Tooltip.tsx
+++ b/src/web/components/Core/Tooltip.tsx
@@ -6,15 +6,22 @@ import './Tooltip.scss';
 
 type TooltipProps = {
   children: ReactNode;
+  trigger?: ReactNode;
   side?: 'top' | 'right' | 'bottom' | 'left';
   align?: 'center' | 'start' | 'end';
 };
-export function Tooltip({ children, side, align }: TooltipProps) {
+export function Tooltip({ children, trigger, side, align }: TooltipProps) {
   return (
     <TooltipPrimitive.Provider>
       <TooltipPrimitive.Root>
         <TooltipPrimitive.Trigger className='tooltip-trigger' type='button'>
-          <FontAwesomeIcon icon='circle-info' data-testid='tooltip-info-icon' />
+          {trigger ?? (
+            <FontAwesomeIcon
+              icon='circle-info'
+              data-testid='tooltip-info-icon'
+              className='default-trigger'
+            />
+          )}
         </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Content side={side} align={align} className='tooltip-content'>
           {children}

--- a/src/web/components/Core/Tooltip.tsx
+++ b/src/web/components/Core/Tooltip.tsx
@@ -12,7 +12,7 @@ type TooltipProps = {
 };
 export function Tooltip({ children, trigger, side, align }: TooltipProps) {
   return (
-    <TooltipPrimitive.Provider>
+    <TooltipPrimitive.Provider delayDuration={300}>
       <TooltipPrimitive.Root>
         <TooltipPrimitive.Trigger className='tooltip-trigger' type='button'>
           {trigger ?? (

--- a/src/web/components/Core/Tooltip.tsx
+++ b/src/web/components/Core/Tooltip.tsx
@@ -9,25 +9,30 @@ type TooltipProps = {
   trigger?: ReactNode;
   side?: 'top' | 'right' | 'bottom' | 'left';
   align?: 'center' | 'start' | 'end';
+  delayDuration?: number;
 };
-export function Tooltip({ children, trigger, side, align }: TooltipProps) {
+export function Tooltip({ children, trigger, side, align, delayDuration }: TooltipProps) {
+  const DEFAULT_DELAY_DURATION = 300;
+
   return (
-    <TooltipPrimitive.Provider delayDuration={300}>
-      <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger className='tooltip-trigger' type='button'>
-          {trigger ?? (
-            <FontAwesomeIcon
-              icon='circle-info'
-              data-testid='tooltip-info-icon'
-              className='default-trigger'
-            />
-          )}
-        </TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Content side={side} align={align} className='tooltip-content'>
-          {children}
-          <TooltipPrimitive.Arrow className='tooltip-arrow' />
-        </TooltipPrimitive.Content>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <div className='tooltip'>
+      <TooltipPrimitive.Provider delayDuration={delayDuration ?? DEFAULT_DELAY_DURATION}>
+        <TooltipPrimitive.Root>
+          <TooltipPrimitive.Trigger className='tooltip-trigger' type='button'>
+            {trigger ?? (
+              <FontAwesomeIcon
+                icon='circle-info'
+                data-testid='tooltip-info-icon'
+                className='default-trigger'
+              />
+            )}
+          </TooltipPrimitive.Trigger>
+          <TooltipPrimitive.Content side={side} align={align} className='tooltip-content'>
+            {children}
+            <TooltipPrimitive.Arrow className='tooltip-arrow' />
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Root>
+      </TooltipPrimitive.Provider>
+    </div>
   );
 }

--- a/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.stories.tsx
@@ -2,7 +2,6 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
 import { SharingSiteDTO } from '../../../api/helpers/siteConvertingHelpers';
-import { AvailableParticipantDTO } from '../../../api/routers/participantsRouter';
 import { TestAvailableSiteListProvider } from '../../services/site';
 import { BulkAddPermissions } from './BulkAddPermissions';
 

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -190,7 +190,7 @@ export function BulkAddPermissions({
       <form onSubmit={handleSubmit(handleSave)}>
         {!participant?.completedRecommendations && (
           <Collapsible
-            title='Bulk Add Permissions'
+            title='Add Permissions — Bulk'
             defaultOpen
             label='RECOMMENDATION'
             className='bulk-add-permissions-recommendations-collapsible'
@@ -199,7 +199,7 @@ export function BulkAddPermissions({
           </Collapsible>
         )}
         {participant?.completedRecommendations && (
-          <Collapsible title='Bulk Add Permissions' defaultOpen={false}>
+          <Collapsible title='Add Permissions — Bulk' defaultOpen={false}>
             {collapsibleContent}
           </Collapsible>
         )}

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -1,5 +1,6 @@
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
 import { ClientTypeDescriptions, SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 import {
   formatSourceColumn,
@@ -42,15 +43,26 @@ type ParticipantItemProps = ParticipantItemSimpleProps & {
 };
 
 export function ParticipantItem({ site, onClick, checked }: ParticipantItemProps) {
+  const checkboxDisabled = isSharingParticipant(site) && !isAddedByManual(site);
+  const checkbox = (
+    <TriStateCheckbox
+      onClick={onClick}
+      status={checked}
+      className='participant-checkbox'
+      disabled={checkboxDisabled}
+    />
+  );
   return (
     <tr className='participant-item-with-checkbox'>
       <td>
-        <TriStateCheckbox
-          onClick={onClick}
-          status={checked}
-          className='participant-checkbox'
-          disabled={isSharingParticipant(site) && !isAddedByManual(site)}
-        />
+        {checkboxDisabled ? (
+          <Tooltip trigger={checkbox}>
+            Gray indicates participants selected in bulk permissions. To update, adjust bulk
+            permission settings.
+          </Tooltip>
+        ) : (
+          checkbox
+        )}
       </td>
       <ParticipantItemSimple site={site} />
       {isSharingParticipant(site) && <td>{formatSourceColumn(site.addedBy)}</td>}

--- a/src/web/components/SharingPermission/ParticipantTableHelper.ts
+++ b/src/web/components/SharingPermission/ParticipantTableHelper.ts
@@ -64,7 +64,7 @@ export function formatSourceColumn(sources: SharingSiteWithSource['addedBy']) {
     if (sourceField) {
       sourceField += ' and ';
     }
-    sourceField += `Auto: ${sourcesWithoutManual
+    sourceField += `Bulk: ${sourcesWithoutManual
       .map((source) => ClientTypeDescriptions[source])
       .join(', ')}`;
   }

--- a/src/web/screens/accountInformation.scss
+++ b/src/web/screens/accountInformation.scss
@@ -1,12 +1,10 @@
 .account-info-content {
   margin-top: 32px;
-}
 
-.account-info-title {
-  margin-top: 24px !important;
-  margin-bottom: 8px;
-}
-
-.account-info-input {
-  max-width: 462px;
+  .account-info-title {
+    display: flex;
+    margin-top: 24px !important;
+    margin-bottom: 8px;
+    gap: 5px;
+  }
 }

--- a/src/web/screens/sharingPermissions.scss
+++ b/src/web/screens/sharingPermissions.scss
@@ -8,5 +8,9 @@
     flex-direction: column;
     margin-top: 30px;
     gap: 30px;
+
+    .search-description {
+      margin-top: 0;
+    }
   }
 }

--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -121,11 +121,17 @@ function SharingPermissions() {
           sharedTypes={sharedTypes ?? []}
           onBulkAddSharingPermission={handleSaveSharingType}
         />
-        <Collapsible title='Search and Add Permissions' defaultOpen>
-          <SearchAndAddParticipants
-            onSharingPermissionsAdded={handleAddSharingSite}
-            sharedSiteIds={sharedSiteIds}
-          />
+        <Collapsible title='Add Permissions — Individual' defaultOpen>
+          <>
+            <p className='search-description'>
+              Add individual participants, using search, and click to grant them permission to
+              decrypt your UID2 tokens.
+            </p>
+            <SearchAndAddParticipants
+              onSharingPermissionsAdded={handleAddSharingSite}
+              sharedSiteIds={sharedSiteIds}
+            />
+          </>
         </Collapsible>
         {(participant?.completedRecommendations || sharedSiteIds.length > 0) && (
           <SharingPermissionsTable


### PR DESCRIPTION
- Copy updates for various strings on the sharing permissions screen.
- Add description to individual sharing permissions control
- Change tooltip component with two props: `trigger` and `delayDuration`
- Add tooltip story
- Conditionally show the tooltip on a disabled checkbox in the "Your Sharing Permissions" table
- Styling to the tooltip
- Unrelated changes
  - Use children instead of mapping to content in Collapsible component
  - Remove unused import

**New tool tip for disabled row & new copy**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/fef1e2df-e541-44e3-9575-f55d6ae0dae3

**Participant Information tooltip working as expected**

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/2a8a31eb-0018-4bb5-b86e-16052413baa4



