### PR TITLE
Show participant is sharing with DSP when allow_sites is null

### DIFF
--- a/src/api/routers/participantsRouter.ts
+++ b/src/api/routers/participantsRouter.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import express, { Response } from 'express';
 import { z } from 'zod';
 
@@ -208,8 +209,15 @@ export function createParticipantsRouter() {
       if (!participant?.siteId) {
         return res.status(400).send('Site id is not set');
       }
-      const sharingList = await getSharingList(participant.siteId);
-      return res.status(200).json(sharingList);
+      try {
+        const sharingList = await getSharingList(participant.siteId);
+        return res.status(200).json(sharingList);
+      } catch (err) {
+        if (err instanceof AxiosError && err.response?.status === 404) {
+          return res.status(404).send('This site does not have a keyset.');
+        }
+        throw err;
+      }
     }
   );
 

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -15,21 +15,22 @@ const adminServiceClient = axios.create({
   },
 });
 
+const DEFAULT_SHARING_SETTINGS: Pick<SharingListResponse, 'allowed_sites' | 'allowed_types'> = {
+  allowed_types: ['DSP'],
+  allowed_sites: [],
+};
+
 export const getSharingList = async (siteId: number): Promise<SharingListResponse> => {
   try {
     const response = await adminServiceClient.get<SharingListResponse>(
       `/api/sharing/list/${siteId}`,
       {
-        validateStatus: (status) => (status >= 200 && status < 300) || status === 404,
+        validateStatus: (status) => status >= 200 && status < 300,
       }
     );
-    return response.status === 200
+    return response.data.allowed_sites
       ? response.data
-      : {
-          allowed_sites: [],
-          allowed_types: [],
-          hash: 0,
-        };
+      : { ...response.data, ...DEFAULT_SHARING_SETTINGS };
   } catch (error: unknown) {
     const [logger] = getLoggers();
     logger.error(`Get ACLs failed: ${error}`);
@@ -52,16 +53,12 @@ export const updateSharingList = async (
         hash,
       },
       {
-        validateStatus: (status) => (status >= 200 && status < 300) || status === 404,
+        validateStatus: (status) => status >= 200 && status < 300,
       }
     );
-    return response.status === 200
+    return response.data.allowed_sites
       ? response.data
-      : {
-          allowed_sites: [],
-          allowed_types: [],
-          hash: 0,
-        };
+      : { ...response.data, ...DEFAULT_SHARING_SETTINGS };
   } catch (error: unknown) {
     const [logger] = getLoggers();
     logger.error(`Update ACLs failed: ${error}`);

--- a/src/web/App.scss
+++ b/src/web/App.scss
@@ -23,6 +23,10 @@
     .heading-details {
       margin: 4px 0;
     }
+
+    p[role='alert'] {
+      color: var(--theme-error);
+    }
   }
 
   .app-centralize {

--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -1,9 +1,7 @@
-import { useContext, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { ReactNode, useContext, useEffect, useState } from 'react';
 
 import { ClientType } from '../../api/services/adminServiceHelpers';
 import { Collapsible } from '../components/Core/Collapsible';
-import { Dialog } from '../components/Core/Dialog';
 import { StatusNotificationType, StatusPopup } from '../components/Core/StatusPopup';
 import { BulkAddPermissions } from '../components/SharingPermission/BulkAddPermissions';
 import { SearchAndAddParticipants } from '../components/SharingPermission/SearchAndAddParticipants';
@@ -22,36 +20,17 @@ import { PortalRoute } from './routeUtils';
 
 import './sharingPermissions.scss';
 
-type NoKeySetErrorDialogProps = {
-  showDialog: boolean;
-  onOpenChange: (open: boolean) => void;
-};
-function NoKeySetErrorDialog({ showDialog, onOpenChange }: NoKeySetErrorDialogProps) {
-  const navigate = useNavigate();
-
-  const handleBackClick = () => {
-    onOpenChange(false);
-    navigate(-1);
-  };
+function SharingPermissionPageContainer({ children }: { children: ReactNode }) {
   return (
-    <Dialog open={showDialog} onOpenChange={onOpenChange} title='Access Denied - Technical Issue'>
-      <div className='dialog-body-section' />
-      We&apos;re experiencing an issue on our end. Access to sharing permissions is currently
-      unavailable for you.
-      <br />
-      <br />
-      Please reach out to our support team for assistance.
-      <div className='dialog-footer-section'>
-        <button type='button' className='primary-button' onClick={handleBackClick}>
-          Back
-        </button>
-      </div>
-    </Dialog>
+    <div className='sharingPermissions'>
+      <h1>Sharing Permissions</h1>
+      {children}
+    </div>
   );
 }
 
 function SharingPermissions() {
-  const [showErrorDialog, setShowErrorDialog] = useState(false);
+  const [showNoKeySetError, setNoKeySetError] = useState(false);
   const [showStatusPopup, setShowStatusPopup] = useState(false);
   const { participant, setParticipant } = useContext(ParticipantContext);
   const [sharedSiteIds, setSharedSiteIds] = useState<number[]>([]);
@@ -134,7 +113,7 @@ function SharingPermissions() {
       } catch (e: unknown) {
         if (e instanceof ApiError) {
           if (e.statusCode === 404) {
-            setShowErrorDialog(true);
+            setNoKeySetError(true);
             return;
           }
           throwError(e);
@@ -144,9 +123,22 @@ function SharingPermissions() {
     loadSharingList();
   }, [throwError]);
 
+  if (showNoKeySetError) {
+    return (
+      <SharingPermissionPageContainer>
+        <p className='heading-details' role='alert'>
+          We&apos;re experiencing an issue on our end. Access to sharing permissions is currently
+          unavailable for you.
+          <br />
+          <br />
+          Please reach out to our support team for assistance.
+        </p>
+      </SharingPermissionPageContainer>
+    );
+  }
+
   return (
-    <div className='sharingPermissions'>
-      <h1>Sharing Permissions</h1>
+    <SharingPermissionPageContainer>
       <p className='heading-details'>
         Adding a sharing permission allows the participant you’re sharing with to decrypt your UID2
         tokens.
@@ -189,8 +181,7 @@ function SharingPermissions() {
           message={statusPopup!.message}
         />
       )}
-      <NoKeySetErrorDialog showDialog={showErrorDialog} onOpenChange={setShowErrorDialog} />
-    </div>
+    </SharingPermissionPageContainer>
   );
 }
 

--- a/src/web/styles/themes.scss
+++ b/src/web/styles/themes.scss
@@ -35,7 +35,6 @@
   --theme-label-background: #c0d6ff;
   --theme-search-bar-background: rgb(112 133 212 / 15%);
   --theme-scrollbar: #c0d6ff;
-  --theme-error: red;
   --theme-disabled-button-text: #878787;
   --theme-disabled-button: #d9d9d9;
   --theme-label: rgb(120 204 0 / 40%);

--- a/src/web/utils/apiError.tsx
+++ b/src/web/utils/apiError.tsx
@@ -20,7 +20,7 @@ export function backendError(e: unknown, overrideMessage: string) {
 
     return new ApiError(overrideMessage, {
       errorHash: hash,
-      statusCode: e.status,
+      statusCode: e.status || e.response?.status,
     });
   }
   return Error(overrideMessage);


### PR DESCRIPTION
### Description:
- Show participant is sharing with DSP when allow_sites is null
- Throw error when sharing participant `/api/sharing/list/` return 404  (**I believe we should hide sharing permission from menu for this case, but I think there is a separate ticket for this already**.)

As discussed, when a participant is GENERATOR or SHARER or has a client_keypair, admin service creates a keyset for it. For now we don't allow user create keyset from portal

### Required PR:

- Admin service: [jyg-UID2-1736 return null instead of [] when allow_sites is empty](https://github.com/IABTechLab/uid2-admin/pull/164)

### Manual tests
1. Approve participant with a siteId that has SHAERE role, it should get empty allow_sites, and allow_types, it should show recommended bulk permission based on it's clientTypes
<img width="1791" alt="Screenshot 2023-10-06 at 3 56 56 pm" src="https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/a23bedfd-638f-4d24-a541-557f54cfdfd7">

2. Approve participant with a siteId with _GENERATOR_ role, it should get null allow_sites and empty allow_types. 
- In the portal, it should show recommended bulk permission based on it's clientTypes
<img width="1791" alt="Screenshot 2023-10-06 at 3 59 58 pm" src="https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/9bc58d7f-2dc4-4a0d-a534-5241819e7840">

- It should has `allow_sites` set to `[]` **after click save in bulk permission**
<img width="1792" alt="Screenshot 2023-10-06 at 4 00 38 pm" src="https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/4d83b7b0-ec00-46d4-a518-52201a19e8a5">

3. Approve participant with a siteId with **GENERATOR** role, and set`completedRecommendations` to true from DB, it should show shared with DSP
<img width="1785" alt="Screenshot 2023-10-06 at 4 05 25 pm" src="https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/b9c769ac-881d-486a-beb1-fa8ff430fc3a">

4. Approve participant with a siteId that has **MAPPER** role, it should error dialog when user goes to the sharing permission page

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/116539741/d0c6a074-ea8d-421e-8095-3e7154f05bec)
