### PR TITLE
Warn publishers against removing sharing with DSPs

### DIFF
--- a/src/web/components/Core/Banner.scss
+++ b/src/web/components/Core/Banner.scss
@@ -12,5 +12,6 @@
   .banner-text {
     font-weight: 600;
     color: var(--theme-button-text);
+    line-height: 1.25;
   }
 }

--- a/src/web/components/Core/Collapsible.scss
+++ b/src/web/components/Core/Collapsible.scss
@@ -47,6 +47,6 @@
   .collapsible-content {
     display: flex;
     flex-direction: column;
-    padding: 0 0 20px 20px;
+    padding: 0 40px 20px 20px;
   }
 }

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -23,7 +23,13 @@
   }
 
   .bulk-add-permissions-body {
-    padding-left: 10px;
+    padding: 0 10px;
+
+    .bulk-add-permissions-body-warnings {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
 
     .participant-type-checkbox-section {
       display: flex;

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -21,6 +21,7 @@ import {
   getRecommendedTypeFromParticipant,
   hasPendingTypeChanges,
   hasUncheckedASharedType,
+  publisherHasUncheckedDSP,
 } from './bulkAddPermissionsHelpers';
 import { ParticipantItemSimple } from './ParticipantItem';
 
@@ -177,20 +178,28 @@ export function BulkAddPermissions({
     <div className='bulk-add-permissions'>
       <div className='bulk-add-permissions-body'>
         {commonContent}
-        {hasUncheckedASharedType(
-          sharedTypes,
-          watchPublisherChecked,
-          watchAdvertiserChecked,
-          watchDSPChecked,
-          watchDataProviderChecked
-        ) && (
-          <div className='remove-recommended-type-warning'>
+        <div className='bulk-add-permissions-body-warnings'>
+          {hasUncheckedASharedType(
+            sharedTypes,
+            watchPublisherChecked,
+            watchAdvertiserChecked,
+            watchDSPChecked,
+            watchDataProviderChecked
+          ) && (
+            <div className='remove-recommended-type-warning'>
+              <Banner
+                type='Warning'
+                message='If you remove the sharing permissions for a participant type, all sharing permissions of that type are removed, including future participants of that type.'
+              />
+            </div>
+          )}
+          {publisherHasUncheckedDSP(participant!.types || [], watchDSPChecked) && (
             <Banner
               type='Warning'
-              message='If you remove the sharing permissions for a participant type, all sharing permissions of that type are removed, including future participants of that type.'
+              message='As a publisher, if you remove the sharing permission of DSPs, DSPs will no longer be able to decrypt your UID2 tokens. This means that DSPs cannot bid on any UID2 tokens you pass to them within the bid stream. Please proceed with caution.'
             />
-          </div>
-        )}
+          )}
+        </div>
       </div>
       {savePermissionsButton}
     </div>

--- a/src/web/components/SharingPermission/SearchAndAddParticipants.scss
+++ b/src/web/components/SharingPermission/SearchAndAddParticipants.scss
@@ -15,10 +15,6 @@
       font-weight: 600;
     }
   }
-
-  .add-participant-dialog-search-bar {
-    padding-right: 70px;
-  }
 }
 
 .sharing-permission-actions .add-sharing-permission-button {

--- a/src/web/components/SharingPermission/SearchAndAddParticipants.tsx
+++ b/src/web/components/SharingPermission/SearchAndAddParticipants.tsx
@@ -57,15 +57,13 @@ export function SearchAndAddParticipants({
 
   return (
     <div className='search-and-add-participants'>
-      <div className='add-participant-dialog-search-bar'>
-        <ParticipantSearchBar
-          selectedParticipantIds={selectedSites}
-          sites={getSearchableSites(sites!)}
-          onSelectedChange={handleSelectedSitesChanged}
-          open={openSearchResult}
-          onToggleOpen={setOpenSearchResult}
-        />
-      </div>
+      <ParticipantSearchBar
+        selectedParticipantIds={selectedSites}
+        sites={getSearchableSites(sites!)}
+        onSelectedChange={handleSelectedSitesChanged}
+        open={openSearchResult}
+        onToggleOpen={setOpenSearchResult}
+      />
       <div className='action-section'>
         {selectedSites.size > 0 && <p>{getSitesText(selectedSites.size)} selected</p>}
         <Dialog

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -1,5 +1,7 @@
+import { ParticipantTypeData, ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { SharingSiteDTO } from '../../../api/helpers/siteConvertingHelpers';
 import { ClientType } from '../../../api/services/adminServiceHelpers';
+import { GetAllParticipantTypes } from '../../services/participantType';
 import { formatStringsWithSeparator, getArticle } from '../../utils/textHelpers';
 
 export type BulkAddPermissionsForm = {
@@ -125,4 +127,14 @@ export const getFilteredParticipantsByType = (
     }
     return false;
   });
+};
+
+export const publisherHasUncheckedDSP = (
+  participantTypes: ParticipantTypeDTO[],
+  DSPChecked: boolean
+) => {
+  return (
+    participantTypes.some((type) => type.typeName === ParticipantTypeData.Publisher.typeName) &&
+    !DSPChecked
+  );
 };

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -1,7 +1,6 @@
 import { ParticipantTypeData, ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { SharingSiteDTO } from '../../../api/helpers/siteConvertingHelpers';
 import { ClientType } from '../../../api/services/adminServiceHelpers';
-import { GetAllParticipantTypes } from '../../services/participantType';
 import { formatStringsWithSeparator, getArticle } from '../../utils/textHelpers';
 
 export type BulkAddPermissionsForm = {


### PR DESCRIPTION
This includes a minimum-effort change to the usersRouter to populate the current participant with the source-of-truth types, which is used in the participant context in the bulk add control.

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ab61725a-bca3-4505-b336-a38a65645583



