### PR TITLE
ajy-UID2-1929-Call-v2-keypairs-endpoint

### DIFF
--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -75,8 +75,9 @@ export const getSiteList = async (): Promise<SiteDTO[]> => {
 };
 
 export const getKeyPairsList = async (siteId: number): Promise<KeyPairDTO[]> => {
-  // convert this to use site-specific endpoint after UID2-1847
-  const response = await adminServiceClient.get<KeyPairDTO[]>('/api/client_side_keypairs/list');
+  const response = await adminServiceClient.get<KeyPairDTO[]>(
+    `api/v2/sites/${siteId}/client-side-keypairs`
+  );
   return response.data;
 };
 

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -76,7 +76,7 @@ export const getSiteList = async (): Promise<SiteDTO[]> => {
 
 export const getKeyPairsList = async (siteId: number): Promise<KeyPairDTO[]> => {
   const response = await adminServiceClient.get<KeyPairDTO[]>(
-    `api/v2/sites/${siteId}/client-side-keypairs`
+    `/api/v2/sites/${siteId}/client-side-keypairs`
   );
   return response.data;
 };

--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -36,9 +36,9 @@ export type KeyPairDTO = {
   contact?: string;
   created: number;
   disabled: boolean;
-  public_key: string;
-  site_id: number;
-  subscription_id: string;
+  publicKey: string;
+  siteId: number;
+  subscriptionId: string;
   name?: string;
 };
 

--- a/src/web/components/KeyPairs/KeyPairModel.tsx
+++ b/src/web/components/KeyPairs/KeyPairModel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { KeyPairDTO } from '../../../api/services/adminServiceHelpers';
 
 export type KeyPairModel = {
@@ -15,12 +14,12 @@ export type KeyPairModel = {
 export const mapKeyPairDTOToModel = (dto: KeyPairDTO): KeyPairModel => {
   const model: KeyPairModel = {
     contact: dto.contact as string | undefined,
-    createdString: new Date(dto.created * 1000).toUTCString(),
-    created: new Date(dto.created * 1000),
+    createdString: new Date(dto.created).toISOString().split('T')[0],
+    created: new Date(dto.created),
     disabled: dto.disabled as boolean,
-    publicKey: dto.public_key as string,
-    siteId: dto.site_id as number,
-    subscriptionId: dto.subscription_id as string,
+    publicKey: dto.publicKey as string,
+    siteId: dto.siteId as number,
+    subscriptionId: dto.subscriptionId as string,
     name: dto.name as string,
   };
   return model;
@@ -31,9 +30,9 @@ export const mapKeyPairModelToDTO = (model: KeyPairModel): KeyPairDTO => {
     contact: model.contact,
     created: new Date(model.created).getTime(),
     disabled: model.disabled,
-    public_key: model.publicKey,
-    site_id: model.siteId,
-    subscription_id: model.subscriptionId,
+    publicKey: model.publicKey,
+    siteId: model.siteId,
+    subscriptionId: model.subscriptionId,
     name: model.name,
   };
   return dto;

--- a/src/web/components/KeyPairs/KeyPairModel.tsx
+++ b/src/web/components/KeyPairs/KeyPairModel.tsx
@@ -14,7 +14,7 @@ export type KeyPairModel = {
 export const mapKeyPairDTOToModel = (dto: KeyPairDTO): KeyPairModel => {
   const model: KeyPairModel = {
     contact: dto.contact as string | undefined,
-    createdString: new Date(dto.created).toISOString().split('T')[0],
+    createdString: new Date(dto.created).toLocaleDateString(),
     created: new Date(dto.created),
     disabled: dto.disabled as boolean,
     publicKey: dto.publicKey as string,

--- a/src/web/screens/keyPairsScreen.tsx
+++ b/src/web/screens/keyPairsScreen.tsx
@@ -16,10 +16,9 @@ function KeyPairsScreen() {
   const [statusPopup, setStatusPopup] = useState<StatusNotificationType>();
 
   const loadKeyPairs = useCallback(async () => {
-    const data = await GetKeyPairs(participant!.id!);
+    const data = await GetKeyPairs();
     const sortedKeyPairs = data?.sort((a, b) => a.created.getTime() - b.created.getTime());
     setKeyPairData(sortedKeyPairs);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/web/screens/keyPairsScreen.tsx
+++ b/src/web/screens/keyPairsScreen.tsx
@@ -1,16 +1,14 @@
-import { Suspense, useCallback, useContext, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 
 import { Loading } from '../components/Core/Loading';
 import { StatusNotificationType, StatusPopup } from '../components/Core/StatusPopup';
 import { KeyPairModel } from '../components/KeyPairs/KeyPairModel';
 import KeyPairsTable from '../components/KeyPairs/KeyPairsTable';
-import { ParticipantContext } from '../contexts/ParticipantProvider';
 import { AddKeyPair, AddKeyPairFormProps, GetKeyPairs } from '../services/keyPairService';
 import { ApiError } from '../utils/apiError';
 import { PortalRoute } from './routeUtils';
 
 function KeyPairsScreen() {
-  const { participant } = useContext(ParticipantContext);
   const [keyPairData, setKeyPairData] = useState<KeyPairModel[]>();
   const [showStatusPopup, setShowStatusPopup] = useState<boolean>(false);
   const [statusPopup, setStatusPopup] = useState<StatusNotificationType>();
@@ -47,7 +45,7 @@ function KeyPairsScreen() {
   const handleAddKeyPair = async (formData: AddKeyPairFormProps) => {
     const { name, disabled = false } = formData;
     try {
-      const response = await AddKeyPair({ name, disabled, participantId: participant?.id! });
+      const response = await AddKeyPair({ name, disabled });
       if (response.status === 201) {
         handleSuccessPopup('Key Pair added.');
         loadKeyPairs();

--- a/src/web/screens/keyPairsScreen.tsx
+++ b/src/web/screens/keyPairsScreen.tsx
@@ -19,7 +19,8 @@ function KeyPairsScreen() {
     const data = await GetKeyPairs(participant!.id!);
     const sortedKeyPairs = data?.sort((a, b) => a.created.getTime() - b.created.getTime());
     setKeyPairData(sortedKeyPairs);
-  }, [participant]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     loadKeyPairs();

--- a/src/web/services/keyPairService.tsx
+++ b/src/web/services/keyPairService.tsx
@@ -10,9 +10,11 @@ export type AddKeyPairFormProps = {
   disabled: boolean;
 };
 
-export async function GetKeyPairs(participantId: number) {
+export async function GetKeyPairs(participantId?: number) {
   try {
-    const result = await axios.get<KeyPairDTO[]>(`/participants/${participantId}/keyPairs`);
+    const result = await axios.get<KeyPairDTO[]>(
+      `/participants/${participantId ?? 'current'}/keyPairs`
+    );
     if (result.status === 200) {
       return (result.data as KeyPairDTO[]).map(mapKeyPairDTOToModel);
     }

--- a/src/web/services/keyPairService.tsx
+++ b/src/web/services/keyPairService.tsx
@@ -5,7 +5,7 @@ import { mapKeyPairDTOToModel } from '../components/KeyPairs/KeyPairModel';
 import { backendError } from '../utils/apiError';
 
 export type AddKeyPairFormProps = {
-  participantId: number;
+  participantId?: number;
   name?: string;
   disabled: boolean;
 };
@@ -26,7 +26,10 @@ export async function GetKeyPairs(participantId?: number) {
 export async function AddKeyPair(props: AddKeyPairFormProps) {
   try {
     const { participantId } = props;
-    const result = await axios.post(`/participants/${participantId}/keyPair/add`, props);
+    const result = await axios.post(
+      `/participants/${participantId ?? 'current'}/keyPair/add`,
+      props
+    );
     return result;
   } catch (e: unknown) {
     throw backendError(e, 'Could not add Key Pair');


### PR DESCRIPTION
For manual testing with the keypair `name` populated, please check out `ajy-UID2-1929-Add-name-to-client-side-keypair-response` on `uid2-admin`. Otherwise, everything else should work but `name` will be blank.

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/99138dde-e4ac-410b-83e5-d139576e2159

