### PR TITLE
ajy-UID2-Minor-sharing-permissions-fixes

### DIFF
--- a/src/web/components/SharingPermission/ParticipantItem.scss
+++ b/src/web/components/SharingPermission/ParticipantItem.scss
@@ -3,8 +3,8 @@
     width: 21px;
     height: 21px;
   }
-  .participant-checkbox {
-    margin-right: 16px;
+  .tooltip {
+    padding-right: 16px;
   }
 }
 

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -45,12 +45,7 @@ type ParticipantItemProps = ParticipantItemSimpleProps & {
 export function ParticipantItem({ site, onClick, checked }: ParticipantItemProps) {
   const checkboxDisabled = isSharingParticipant(site) && !isAddedByManual(site);
   const checkbox = (
-    <TriStateCheckbox
-      onClick={onClick}
-      status={checked}
-      className='participant-checkbox'
-      disabled={checkboxDisabled}
-    />
+    <TriStateCheckbox onClick={onClick} status={checked} disabled={checkboxDisabled} />
   );
   return (
     <tr className='participant-item-with-checkbox'>

--- a/src/web/components/SharingPermission/ParticipantSearchBar.tsx
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.tsx
@@ -63,11 +63,7 @@ export function ParticipantSearchBar({
     <thead>
       <tr className='participant-item-with-checkbox'>
         <th>
-          <TriStateCheckbox
-            onClick={handleCheckboxChange}
-            status={checkboxStatus}
-            className='participant-checkbox'
-          />
+          <TriStateCheckbox onClick={handleCheckboxChange} status={checkboxStatus} />
         </th>
         <th colSpan={3}>
           <span className='select-all'>Select All {filteredSites.length} Participants</span>

--- a/src/web/components/SharingPermission/ParticipantTableHelper.ts
+++ b/src/web/components/SharingPermission/ParticipantTableHelper.ts
@@ -16,6 +16,15 @@ export const isAddedByManual = (site: SharingSiteWithSource) => {
   return site.addedBy.includes(MANUALLY_ADDED);
 };
 
+export const disableSelectAllCheckbox = (sites: SharingSiteWithSource[]) => {
+  for (const site of sites) {
+    if (isAddedByManual(site)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 export function filterSites<TSharingSite extends SharingSiteDTO>(
   sites: TSharingSite[],
   filterText: string,

--- a/src/web/components/SharingPermission/ParticipantTableHelper.ts
+++ b/src/web/components/SharingPermission/ParticipantTableHelper.ts
@@ -17,12 +17,7 @@ export const isAddedByManual = (site: SharingSiteWithSource) => {
 };
 
 export const disableSelectAllCheckbox = (sites: SharingSiteWithSource[]) => {
-  for (const site of sites) {
-    if (isAddedByManual(site)) {
-      return false;
-    }
-  }
-  return true;
+  return !sites.some(isAddedByManual);
 };
 
 export function filterSites<TSharingSite extends SharingSiteDTO>(

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -13,6 +13,7 @@ import { Dialog } from '../Core/Dialog';
 import { Loading } from '../Core/Loading';
 import { MultiSelectDropdown } from '../Core/MultiSelectDropdown';
 import { SortableTableHeader } from '../Core/SortableTableHeader';
+import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox, TriStateCheckboxState } from '../Core/TriStateCheckbox';
 import { ParticipantsTable } from './ParticipantsTable';
 import {
@@ -169,15 +170,26 @@ export function SharingPermissionsTableContent({
     </thead>
   );
 
+  const selectAllCheckbox = (
+    <TriStateCheckbox
+      onClick={handleCheckboxChange}
+      status={checkboxStatus}
+      disabled={disableCheckbox()}
+    />
+  );
+
   return (
     <>
       <div className='sharing-permissions-table-header-container'>
         <div className='sharing-permission-actions'>
-          <TriStateCheckbox
-            onClick={handleCheckboxChange}
-            status={checkboxStatus}
-            disabled={disableCheckbox()}
-          />
+          {disableCheckbox() ? (
+            <Tooltip trigger={selectAllCheckbox}>
+              Gray indicates participants selected in bulk permissions. To update, adjust bulk
+              permission settings.
+            </Tooltip>
+          ) : (
+            selectAllCheckbox
+          )}
           {checkedSites.size > 0 && (
             <DeletePermissionDialog
               onDeleteSharingPermission={handleDeletePermissions}
@@ -227,7 +239,7 @@ export function SharingPermissionsTable({
   const getSharingParticipants: () => SharingSiteWithSource[] = () => {
     return sites!
       .map((p) => {
-        const maybeManualArray: typeof MANUALLY_ADDED[] = sharedSiteIds.includes(p.id)
+        const maybeManualArray: (typeof MANUALLY_ADDED)[] = sharedSiteIds.includes(p.id)
           ? [MANUALLY_ADDED]
           : [];
         const includedTypes =

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -17,6 +17,7 @@ import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox, TriStateCheckboxState } from '../Core/TriStateCheckbox';
 import { ParticipantsTable } from './ParticipantsTable';
 import {
+  disableSelectAllCheckbox,
   filterSites,
   getSelectAllState,
   isAddedByManual,
@@ -150,15 +151,6 @@ export function SharingPermissionsTableContent({
     }
   };
 
-  const disableCheckbox = () => {
-    for (const site of filteredSites) {
-      if (isAddedByManual(site)) {
-        return false;
-      }
-    }
-    return true;
-  };
-
   const tableHeader = (
     <thead>
       <tr className='participant-item-with-checkbox'>
@@ -174,7 +166,7 @@ export function SharingPermissionsTableContent({
     <TriStateCheckbox
       onClick={handleCheckboxChange}
       status={checkboxStatus}
-      disabled={disableCheckbox()}
+      disabled={disableSelectAllCheckbox(filteredSites)}
     />
   );
 
@@ -182,7 +174,7 @@ export function SharingPermissionsTableContent({
     <>
       <div className='sharing-permissions-table-header-container'>
         <div className='sharing-permission-actions'>
-          {disableCheckbox() ? (
+          {disableSelectAllCheckbox(filteredSites) ? (
             <Tooltip trigger={selectAllCheckbox}>
               Gray indicates participants selected in bulk permissions. To update, adjust bulk
               permission settings.

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -149,6 +149,15 @@ export function SharingPermissionsTableContent({
     }
   };
 
+  const disableCheckbox = () => {
+    for (const site of filteredSites) {
+      if (isAddedByManual(site)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   const tableHeader = (
     <thead>
       <tr className='participant-item-with-checkbox'>
@@ -167,7 +176,7 @@ export function SharingPermissionsTableContent({
           <TriStateCheckbox
             onClick={handleCheckboxChange}
             status={checkboxStatus}
-            className='participant-checkbox'
+            disabled={disableCheckbox()}
           />
           {checkedSites.size > 0 && (
             <DeletePermissionDialog

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -151,6 +151,14 @@ export function SharingPermissionsTableContent({
     }
   };
 
+  const selectAllCheckbox = (
+    <TriStateCheckbox
+      onClick={handleCheckboxChange}
+      status={checkboxStatus}
+      disabled={disableSelectAllCheckbox(filteredSites)}
+    />
+  );
+
   const tableHeader = (
     <thead>
       <tr className='participant-item-with-checkbox'>
@@ -160,14 +168,6 @@ export function SharingPermissionsTableContent({
         <SortableTableHeader<SharingSiteWithSource> sortKey='addedBy' header='Source' />
       </tr>
     </thead>
-  );
-
-  const selectAllCheckbox = (
-    <TriStateCheckbox
-      onClick={handleCheckboxChange}
-      status={checkboxStatus}
-      disabled={disableSelectAllCheckbox(filteredSites)}
-    />
   );
 
   return (


### PR DESCRIPTION
- Conditionally disable checkbox, including tooltip for disabled state. 
- Ensure consistent styling regardless of the state of checkboxes in the table

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/5e4518f1-de2c-4e53-9108-34c07d61c4fe

