### PR TITLE
Warn Publishers when removing sharing with DSP during recommendations flow

### DIFF
--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -29,7 +29,7 @@
       display: flex;
       flex-direction: column;
 
-      > div {
+      & > div {
         margin-top: 20px;
       }
     }

--- a/src/web/components/SharingPermission/BulkAddPermissions.scss
+++ b/src/web/components/SharingPermission/BulkAddPermissions.scss
@@ -28,7 +28,10 @@
     .bulk-add-permissions-body-warnings {
       display: flex;
       flex-direction: column;
-      gap: 20px;
+
+      > div {
+        margin-top: 20px;
+      }
     }
 
     .participant-type-checkbox-section {
@@ -38,10 +41,6 @@
       .checkbox-label {
         padding-right: 25px;
       }
-    }
-
-    .remove-recommended-type-warning {
-      padding-top: 20px;
     }
 
     .bulk-add-permissions-view-recommendations-button {

--- a/src/web/components/SharingPermission/BulkAddPermissions.tsx
+++ b/src/web/components/SharingPermission/BulkAddPermissions.tsx
@@ -167,9 +167,24 @@ export function BulkAddPermissions({
     </>
   );
 
+  const publisherUncheckDSPWarning = publisherHasUncheckedDSP(
+    participant!.types || [],
+    watchDSPChecked,
+    sharedTypes,
+    participant!.completedRecommendations
+  ) && (
+    <Banner
+      type='Warning'
+      message='As a publisher, if you remove the sharing permission of DSPs, DSPs will no longer be able to decrypt your UID2 tokens. This means that DSPs cannot bid on any UID2 tokens you pass to them within the bid stream. Please proceed with caution.'
+    />
+  );
+
   const recommendationContent = (
     <div className='bulk-add-permissions'>
-      <div className='bulk-add-permissions-body'>{commonContent}</div>
+      <div className='bulk-add-permissions-body'>
+        {commonContent}
+        <div className='bulk-add-permissions-body-warnings'>{publisherUncheckDSPWarning}</div>
+      </div>
       {savePermissionsButton}
     </div>
   );
@@ -186,19 +201,12 @@ export function BulkAddPermissions({
             watchDSPChecked,
             watchDataProviderChecked
           ) && (
-            <div className='remove-recommended-type-warning'>
-              <Banner
-                type='Warning'
-                message='If you remove the sharing permissions for a participant type, all sharing permissions of that type are removed, including future participants of that type.'
-              />
-            </div>
-          )}
-          {publisherHasUncheckedDSP(participant!.types || [], watchDSPChecked) && (
             <Banner
               type='Warning'
-              message='As a publisher, if you remove the sharing permission of DSPs, DSPs will no longer be able to decrypt your UID2 tokens. This means that DSPs cannot bid on any UID2 tokens you pass to them within the bid stream. Please proceed with caution.'
+              message='If you remove the sharing permissions for a participant type, all sharing permissions of that type are removed, including future participants of that type.'
             />
           )}
+          {publisherUncheckDSPWarning}
         </div>
       </div>
       {savePermissionsButton}

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
@@ -3,100 +3,25 @@ import { publisherHasUncheckedDSP } from './bulkAddPermissionsHelpers';
 
 describe('Bulk add permission helper tests', () => {
   describe('#publisherHasUncheckedDSP', () => {
-    it('Returns true when DSP is unchecked, sharedTypes includes DSP, and completedRecommendations is false', () => {
-      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
-      const DSPChecked = false;
-      const sharedTypes: ClientType[] = ['DSP'];
-      const completedRecommendations = false;
-
-      const result = publisherHasUncheckedDSP(
-        participantTypes,
-        DSPChecked,
-        sharedTypes,
-        completedRecommendations
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('Returns true when DSP is unchecked, sharedTypes includes DSP, and completedRecommendations is true', () => {
-      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
-      const DSPChecked = false;
-      const sharedTypes: ClientType[] = ['DSP'];
-      const completedRecommendations = true;
-
-      const result = publisherHasUncheckedDSP(
-        participantTypes,
-        DSPChecked,
-        sharedTypes,
-        completedRecommendations
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('Returns true when DSP is unchecked, sharedTypes does not include DSP, and completedRecommendations is false', () => {
-      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
-      const DSPChecked = false;
-      const sharedTypes: ClientType[] = ['ADVERTISER'];
-      const completedRecommendations = false;
-
-      const result = publisherHasUncheckedDSP(
-        participantTypes,
-        DSPChecked,
-        sharedTypes,
-        completedRecommendations
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('Returns false when DSP is unchecked, sharedTypes does not include DSP, and completedRecommendations is true', () => {
-      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
-      const DSPChecked = false;
-      const sharedTypes: ClientType[] = ['ADVERTISER'];
-      const completedRecommendations = true;
-
-      const result = publisherHasUncheckedDSP(
-        participantTypes,
-        DSPChecked,
-        sharedTypes,
-        completedRecommendations
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('Returns false when participantTypes do not include Publisher', () => {
-      const participantTypes = [{ id: 3, typeName: 'Advertiser' }];
-      const DSPChecked = false;
-      const sharedTypes: ClientType[] = ['DSP'];
-      const completedRecommendations = false;
-
-      const result = publisherHasUncheckedDSP(
-        participantTypes,
-        DSPChecked,
-        sharedTypes,
-        completedRecommendations
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('Returns false when DSP is checked', () => {
-      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
-      const DSPChecked = true;
-      const sharedTypes: ClientType[] = ['DSP'];
-      const completedRecommendations = false;
-
-      const result = publisherHasUncheckedDSP(
-        participantTypes,
-        DSPChecked,
-        sharedTypes,
-        completedRecommendations
-      );
-
-      expect(result).toBe(false);
-    });
+    const shareWithDsp: ClientType[] = ['DSP'];
+    const publisherType = { id: 2, typeName: 'Publisher' };
+    test.each([
+      [publisherType, false, shareWithDsp, false, true],
+      [publisherType, false, shareWithDsp, true, true],
+      [publisherType, false, [], true, false],
+      [{ id: 3, typeName: 'Advertiser' }, false, shareWithDsp, false, false],
+      [publisherType, true, shareWithDsp, false, false],
+    ])(
+      'Returns %p when participantTypes is %p, DSPChecked is %p, sharedTypes is %p, and completedRecommendations is %p',
+      (participantTypes, dspChecked, sharedTypes, completedRecommendations, expected) => {
+        const result = publisherHasUncheckedDSP(
+          [participantTypes],
+          dspChecked,
+          sharedTypes,
+          completedRecommendations
+        );
+        expect(result).toBe(expected);
+      }
+    );
   });
 });

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
@@ -5,15 +5,16 @@ describe('Bulk add permission helper tests', () => {
   describe('#publisherHasUncheckedDSP', () => {
     const shareWithDsp: ClientType[] = ['DSP'];
     const publisherType = { id: 2, typeName: 'Publisher' };
+
     test.each([
-      [publisherType, false, shareWithDsp, false, true],
-      [publisherType, false, shareWithDsp, true, true],
-      [publisherType, false, [], true, false],
-      [{ id: 3, typeName: 'Advertiser' }, false, shareWithDsp, false, false],
-      [publisherType, true, shareWithDsp, false, false],
+      [true, publisherType, false, shareWithDsp, false],
+      [true, publisherType, false, shareWithDsp, true],
+      [false, publisherType, false, [], true],
+      [false, { id: 3, typeName: 'Advertiser' }, false, shareWithDsp, false],
+      [false, publisherType, true, shareWithDsp, false],
     ])(
-      'Returns %p when participantTypes is %p, DSPChecked is %p, sharedTypes is %p, and completedRecommendations is %p',
-      (participantTypes, dspChecked, sharedTypes, completedRecommendations, expected) => {
+      'returns %p when participantTypes is %p, DSPChecked is %p, sharedTypes is %p, and completedRecommendations is %p',
+      (expected, participantTypes, dspChecked, sharedTypes, completedRecommendations) => {
         const result = publisherHasUncheckedDSP(
           [participantTypes],
           dspChecked,

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
@@ -1,0 +1,102 @@
+import { ClientType } from '../../../api/services/adminServiceHelpers';
+import { publisherHasUncheckedDSP } from './bulkAddPermissionsHelpers';
+
+describe('Bulk add permission helper tests', () => {
+  describe('#publisherHasUncheckedDSP', () => {
+    it('Returns true when DSP is unchecked, sharedTypes includes DSP, and completedRecommendations is false', () => {
+      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
+      const DSPChecked = false;
+      const sharedTypes: ClientType[] = ['DSP'];
+      const completedRecommendations = false;
+
+      const result = publisherHasUncheckedDSP(
+        participantTypes,
+        DSPChecked,
+        sharedTypes,
+        completedRecommendations
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('Returns true when DSP is unchecked, sharedTypes includes DSP, and completedRecommendations is true', () => {
+      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
+      const DSPChecked = false;
+      const sharedTypes: ClientType[] = ['DSP'];
+      const completedRecommendations = true;
+
+      const result = publisherHasUncheckedDSP(
+        participantTypes,
+        DSPChecked,
+        sharedTypes,
+        completedRecommendations
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('Returns true when DSP is unchecked, sharedTypes does not include DSP, and completedRecommendations is false', () => {
+      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
+      const DSPChecked = false;
+      const sharedTypes: ClientType[] = ['ADVERTISER'];
+      const completedRecommendations = false;
+
+      const result = publisherHasUncheckedDSP(
+        participantTypes,
+        DSPChecked,
+        sharedTypes,
+        completedRecommendations
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('Returns false when DSP is unchecked, sharedTypes does not include DSP, and completedRecommendations is true', () => {
+      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
+      const DSPChecked = false;
+      const sharedTypes: ClientType[] = ['ADVERTISER'];
+      const completedRecommendations = true;
+
+      const result = publisherHasUncheckedDSP(
+        participantTypes,
+        DSPChecked,
+        sharedTypes,
+        completedRecommendations
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('Returns false when participantTypes do not include Publisher', () => {
+      const participantTypes = [{ id: 3, typeName: 'Advertiser' }];
+      const DSPChecked = false;
+      const sharedTypes: ClientType[] = ['DSP'];
+      const completedRecommendations = false;
+
+      const result = publisherHasUncheckedDSP(
+        participantTypes,
+        DSPChecked,
+        sharedTypes,
+        completedRecommendations
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('Returns false when DSP is checked', () => {
+      const participantTypes = [{ id: 2, typeName: 'Publisher' }];
+      const DSPChecked = true;
+      const sharedTypes: ClientType[] = ['DSP'];
+      const completedRecommendations = false;
+
+      const result = publisherHasUncheckedDSP(
+        participantTypes,
+        DSPChecked,
+        sharedTypes,
+        completedRecommendations
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.spec.ts
@@ -3,15 +3,15 @@ import { publisherHasUncheckedDSP } from './bulkAddPermissionsHelpers';
 
 describe('Bulk add permission helper tests', () => {
   describe('#publisherHasUncheckedDSP', () => {
-    const shareWithDsp: ClientType[] = ['DSP'];
-    const publisherType = { id: 2, typeName: 'Publisher' };
+    const dspSharedType: ClientType[] = ['DSP'];
+    const publisherParticipantType = { id: 2, typeName: 'Publisher' };
 
     test.each([
-      [true, publisherType, false, shareWithDsp, false],
-      [true, publisherType, false, shareWithDsp, true],
-      [false, publisherType, false, [], true],
-      [false, { id: 3, typeName: 'Advertiser' }, false, shareWithDsp, false],
-      [false, publisherType, true, shareWithDsp, false],
+      [true, publisherParticipantType, false, dspSharedType, false],
+      [true, publisherParticipantType, false, dspSharedType, true],
+      [false, publisherParticipantType, false, [], true],
+      [false, { id: 3, typeName: 'Advertiser' }, false, dspSharedType, false],
+      [false, publisherParticipantType, true, dspSharedType, false],
     ])(
       'returns %p when participantTypes is %p, DSPChecked is %p, sharedTypes is %p, and completedRecommendations is %p',
       (expected, participantTypes, dspChecked, sharedTypes, completedRecommendations) => {

--- a/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
+++ b/src/web/components/SharingPermission/bulkAddPermissionsHelpers.ts
@@ -130,10 +130,13 @@ export const getFilteredParticipantsByType = (
 
 export const publisherHasUncheckedDSP = (
   participantTypes: ParticipantTypeDTO[],
-  DSPChecked: boolean
+  DSPChecked: boolean,
+  sharedTypes: ClientType[],
+  completedRecommendations: boolean
 ) => {
   return (
     participantTypes.some((type) => type.typeName === ParticipantTypeData.Publisher.typeName) &&
-    !DSPChecked
+    !DSPChecked &&
+    (sharedTypes.includes('DSP') || completedRecommendations === false)
   );
 };

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -112,10 +112,9 @@ export async function UpdateParticipant(formData: UpdateParticipantForm, partici
 
 export async function CompleteRecommendations(participantId: number): Promise<ParticipantDTO> {
   try {
-    const result = await axios.put<ParticipantDTO>(
-      `/participants/${participantId}/completeRecommendations`
-    );
-    return result.data;
+    await axios.put<ParticipantDTO>(`/participants/${participantId}/completeRecommendations`);
+    const result = await GetCurrentUsersParticipant();
+    return result;
   } catch (e: unknown) {
     throw backendError(e, 'Could not update participant');
   }


### PR DESCRIPTION
We had previously implemented this banner once the participant had already completed the recommendations flow, but this PR implements it during the recommendations flow.

I also fixed two bugs which I noticed during development:

**Banner shows at the wrong time**

Before
Note the participant type changes to "DSP" after completing the recommendations. Hence why the warning does not show when unchecking DSP after completing recommendations, because the participant does not appear to be a Publisher.

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ed263f8d-b3b0-4493-bd64-43c14fe67ead)


After
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/2ba755e1-5d47-43ac-ad06-74733ddeb57f)

I've also added unit tests for `publisherHasUncheckedDSP`

**Completing the recommendations changes the participant types**

Before

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/2d5e7462-faa2-4632-b12c-35f9277afef1


After

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/e6353097-569d-40ac-946a-0ab5221a9942



