### PR TITLE
Include GUID in existing logging

### DIFF
--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -23,6 +23,7 @@ import {
   getErrorLoggingMiddleware,
   getLoggers,
   getLoggingMiddleware,
+  getTraceId,
 } from './helpers/loggingHelpers';
 import makeMetricsApiMiddleware from './middleware/metrics';
 import { createParticipantsRouter } from './routers/participantsRouter';
@@ -167,7 +168,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
 
   app.use(getErrorLoggingMiddleware());
   const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
-    const traceId = req?.headers?.traceId?.toString() ?? '';
+    const traceId = getTraceId(req);
     errorLogger.error(`Fallback error handler invoked: ${err.message}`, traceId);
     if (err.statusCode === 401) {
       res.status(401).json({

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -73,7 +73,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
 
   app.use(getLoggingMiddleware());
 
-  const [logger, errorLogger] = getLoggers();
+  const { logger, errorLogger } = getLoggers();
   if (useMetrics) {
     app.use(
       makeMetricsApiMiddleware(
@@ -167,7 +167,8 @@ export function configureAndStartApi(useMetrics: boolean = true) {
 
   app.use(getErrorLoggingMiddleware());
   const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
-    logger.error(`Fallback error handler invoked: ${err.message}`);
+    const traceId = req?.headers?.traceId?.toString() ?? '';
+    errorLogger.error(`Fallback error handler invoked: ${err.message}`, traceId);
     if (err.statusCode === 401) {
       res.status(401).json({
         message: 'Unauthorized. You do not have the necessary permissions.',

--- a/src/api/helpers/loggingHelpers.ts
+++ b/src/api/helpers/loggingHelpers.ts
@@ -1,3 +1,4 @@
+import { Request } from 'express';
 import expressWinston from 'express-winston';
 import winston from 'winston';
 import LokiTransport from 'winston-loki';
@@ -80,3 +81,7 @@ export const getErrorLoggingMiddleware = () =>
     winstonInstance: errorLogger,
     headerBlacklist: headersToRedact,
   });
+
+export const getTraceId = (request: Request): string => {
+  return request?.headers?.traceId?.toString() ?? '';
+};

--- a/src/api/helpers/loggingHelpers.ts
+++ b/src/api/helpers/loggingHelpers.ts
@@ -50,8 +50,21 @@ const errorLogger = winston.createLogger({
   ),
 });
 
+const infoLoggerWrapper = {
+  info: (message: string, traceId: string) => logger.info(`${message}, [traceId=${traceId}]`),
+};
+
+const errorLoggerWrapper = {
+  error: (message: string, traceId: string) =>
+    errorLogger.error(`${message}, [traceId=${traceId}]`),
+};
+
 export const getLoggers = () => {
-  return [logger, errorLogger];
+  return {
+    logger,
+    infoLogger: infoLoggerWrapper,
+    errorLogger: errorLoggerWrapper,
+  };
 };
 
 const headersToRedact = ['authorization'];

--- a/src/api/routers/participantsRouter.ts
+++ b/src/api/routers/participantsRouter.ts
@@ -12,6 +12,7 @@ import {
   ParticipantStatus,
 } from '../entities/Participant';
 import { UserDTO, UserRole } from '../entities/User';
+import { getTraceId } from '../helpers/loggingHelpers';
 import { getKcAdminClient } from '../keycloakAdminClient';
 import { isApproverCheck } from '../middleware/approversMiddleware';
 import { addKeyPair, getKeyPairsList, getSharingList } from '../services/adminServiceClient';
@@ -90,7 +91,7 @@ export function createParticipantsRouter() {
 
   participantsRouter.post('/', async (req, res) => {
     try {
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       const data = {
         ...ParticipantCreationPartial.parse(req.body),
         status: ParticipantStatus.AwaitingApproval,
@@ -119,7 +120,7 @@ export function createParticipantsRouter() {
     isApproverCheck,
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       const data = {
         ...ParticipantApprovalPartial.parse(req.body),
         status: ParticipantStatus.Approved,
@@ -202,7 +203,7 @@ export function createParticipantsRouter() {
     '/:participantId/sharingPermission',
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       if (!participant?.siteId) {
         return res.status(400).send('Site id is not set');
       }
@@ -226,7 +227,7 @@ export function createParticipantsRouter() {
     '/:participantId/sharingPermission/add',
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       if (!participant?.siteId) {
         return res.status(400).send('Site id is not set');
       }
@@ -261,7 +262,7 @@ export function createParticipantsRouter() {
     '/:participantId/keyPair/add',
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       if (!participant?.siteId) {
         return res.status(400).send('Site id is not set');
       }
@@ -305,7 +306,7 @@ export function createParticipantsRouter() {
     '/:participantId/sharingPermission/delete',
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       if (!participant?.siteId) {
         return res.status(400).send('Site id is not set');
       }
@@ -339,7 +340,7 @@ export function createParticipantsRouter() {
     '/:participantId/sharingPermission/shareWithTypes',
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
-      const traceId = req?.headers?.traceId?.toString() ?? '';
+      const traceId = getTraceId(req);
       if (!participant?.siteId) {
         return res.status(400).send('Site id is not set');
       }

--- a/src/api/routers/usersRouter.ts
+++ b/src/api/routers/usersRouter.ts
@@ -75,8 +75,8 @@ export function createUsersRouter() {
   });
 
   usersRouter.post('/:userId/resendInvitation', async (req: UserRequest, res) => {
-    const [logger, errorLogger] = getLoggers();
-
+    const { infoLogger, errorLogger } = getLoggers();
+    const traceId = req?.headers?.traceId?.toString() ?? '';
     const kcAdminClient = await getKcAdminClient();
     const user = await queryUsersByEmail(kcAdminClient, req.user?.email || '');
 
@@ -85,11 +85,17 @@ export function createUsersRouter() {
       return res.sendStatus(404);
     }
     if (resultLength > 1) {
-      errorLogger.error(`Multiple results received when loading user entry for ${req.user?.email}`);
+      errorLogger.error(
+        `Multiple results received when loading user entry for ${req.user?.email}`,
+        traceId
+      );
       return res.sendStatus(500);
     }
 
-    logger.info(`Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`);
+    infoLogger.info(
+      `Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`,
+      traceId
+    );
     await sendInviteEmail(kcAdminClient, user[0]);
     return res.sendStatus(200);
   });

--- a/src/api/routers/usersRouter.ts
+++ b/src/api/routers/usersRouter.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { Participant, ParticipantStatus } from '../entities/Participant';
 import { ParticipantType } from '../entities/ParticipantType';
 import { UserRole } from '../entities/User';
-import { getLoggers } from '../helpers/loggingHelpers';
+import { getLoggers, getTraceId } from '../helpers/loggingHelpers';
 import { mapClientTypeToParticipantType } from '../helpers/siteConvertingHelpers';
 import { getKcAdminClient } from '../keycloakAdminClient';
 import { getSiteList } from '../services/adminServiceClient';
@@ -76,7 +76,7 @@ export function createUsersRouter() {
 
   usersRouter.post('/:userId/resendInvitation', async (req: UserRequest, res) => {
     const { infoLogger, errorLogger } = getLoggers();
-    const traceId = req?.headers?.traceId?.toString() ?? '';
+    const traceId = getTraceId(req);
     const kcAdminClient = await getKcAdminClient();
     const user = await queryUsersByEmail(kcAdminClient, req.user?.email || '');
 

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -20,7 +20,10 @@ const DEFAULT_SHARING_SETTINGS: Pick<SharingListResponse, 'allowed_sites' | 'all
   allowed_sites: [],
 };
 
-export const getSharingList = async (siteId: number): Promise<SharingListResponse> => {
+export const getSharingList = async (
+  siteId: number,
+  traceId: string
+): Promise<SharingListResponse> => {
   try {
     const response = await adminServiceClient.get<SharingListResponse>(
       `/api/sharing/list/${siteId}`,
@@ -32,8 +35,8 @@ export const getSharingList = async (siteId: number): Promise<SharingListRespons
       ? response.data
       : { ...response.data, ...DEFAULT_SHARING_SETTINGS };
   } catch (error: unknown) {
-    const [logger] = getLoggers();
-    logger.error(`Get ACLs failed: ${error}`);
+    const { errorLogger } = getLoggers();
+    errorLogger.error(`Get ACLs failed: ${error}`, traceId);
     throw error;
   }
 };
@@ -42,7 +45,8 @@ export const updateSharingList = async (
   siteId: number,
   hash: number,
   siteList: number[],
-  typeList: ClientType[]
+  typeList: ClientType[],
+  traceId: string
 ): Promise<SharingListResponse> => {
   try {
     const response = await adminServiceClient.post<SharingListResponse>(
@@ -60,8 +64,8 @@ export const updateSharingList = async (
       ? response.data
       : { ...response.data, ...DEFAULT_SHARING_SETTINGS };
   } catch (error: unknown) {
-    const [logger] = getLoggers();
-    logger.error(`Update ACLs failed: ${error}`);
+    const { errorLogger } = getLoggers();
+    errorLogger.error(`Update ACLs failed: ${error}`, traceId);
     throw error;
   }
 };

--- a/src/api/services/auditTrailService.ts
+++ b/src/api/services/auditTrailService.ts
@@ -29,7 +29,8 @@ export const insertSharingAuditTrails = async (
   userId: number,
   userEmail: string,
   action: AuditAction,
-  siteIds: number[]
+  siteIds: number[],
+  traceId: string
 ) => {
   try {
     const sharingAuditTrail: Omit<AuditTrailDTO, 'id'> = {
@@ -47,8 +48,8 @@ export const insertSharingAuditTrails = async (
 
     return await AuditTrail.query().insert(sharingAuditTrail);
   } catch (error) {
-    const [logger] = getLoggers();
-    logger.error(`Audit trails inserted failed: ${error}`);
+    const { errorLogger } = getLoggers();
+    errorLogger.error(`Audit trails inserted failed: ${error}`, traceId);
     throw error;
   }
 };
@@ -57,7 +58,8 @@ export const insertSharingTypesAuditTrail = async (
   participant: Participant,
   userId: number,
   userEmail: string,
-  types: ClientType[]
+  types: ClientType[],
+  traceId: string
 ) => {
   try {
     const sharingAuditTrail: Omit<AuditTrailDTO, 'id'> = {
@@ -74,8 +76,8 @@ export const insertSharingTypesAuditTrail = async (
 
     return await AuditTrail.query().insert(sharingAuditTrail);
   } catch (error) {
-    const [logger] = getLoggers();
-    logger.error(`Audit trails inserted failed: ${error}`);
+    const { errorLogger } = getLoggers();
+    errorLogger.error(`Audit trails inserted failed: ${error}`, traceId);
     throw error;
   }
 };
@@ -86,7 +88,8 @@ export const insertKeyPairAuditTrails = async (
   userEmail: string,
   action: AuditAction,
   name: string,
-  disabled: boolean
+  disabled: boolean,
+  traceId: string
 ) => {
   try {
     const keyPairAuditTrail: Omit<AuditTrailDTO, 'id'> = {
@@ -105,8 +108,8 @@ export const insertKeyPairAuditTrails = async (
 
     return await AuditTrail.query().insert(keyPairAuditTrail);
   } catch (error) {
-    const [logger] = getLoggers();
-    logger.error(`Audit trails inserted failed: ${error}`);
+    const { errorLogger } = getLoggers();
+    errorLogger.error(`Audit trails inserted failed: ${error}`, traceId);
     throw error;
   }
 };

--- a/src/api/services/emailService.ts
+++ b/src/api/services/emailService.ts
@@ -6,7 +6,7 @@ import * as SendGridService from './sendGridService';
 export function createEmailService() {
   const isProduction = process.env.NODE_ENV === 'production';
 
-  async function sendEmail(args: EmailArgs): Promise<void> {
+  async function sendEmail(args: EmailArgs, traceId: string): Promise<void> {
     const emailArgs = {
       ...args,
       templateData: {
@@ -15,7 +15,7 @@ export function createEmailService() {
       },
     };
     if (isProduction) {
-      await SendGridService.sendEmail(emailArgs);
+      await SendGridService.sendEmail(emailArgs, traceId);
     } else {
       await NodemailerService.sendEmail(emailArgs);
     }

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -12,6 +12,7 @@ import {
 import { ParticipantType } from '../entities/ParticipantType';
 import { User } from '../entities/User';
 import { SSP_WEB_BASE_URL } from '../envars';
+import { getTraceId } from '../helpers/loggingHelpers';
 import { getSharingList, updateSharingList } from './adminServiceClient';
 import { ClientType, SharingListResponse } from './adminServiceHelpers';
 import { findApproversByType, getApprovableParticipantTypeIds } from './approversService';
@@ -168,7 +169,7 @@ const idParser = z.object({
 
 const hasParticipantAccess = async (req: ParticipantRequest, res: Response, next: NextFunction) => {
   const { participantId } = idParser.parse(req.params);
-  const traceId = req?.headers?.traceId?.toString() ?? '';
+  const traceId = getTraceId(req);
   const participant = await Participant.query().findById(participantId).withGraphFetched('types');
   if (!participant) {
     return res.status(404).send([{ message: 'The participant cannot be found.' }]);

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -25,7 +25,8 @@ export interface ParticipantRequest extends Request {
 
 export const sendNewParticipantEmail = async (
   newParticipant: z.infer<typeof ParticipantCreationPartial>,
-  typeIds: number[]
+  typeIds: number[],
+  traceId: string
 ) => {
   const participantTypes = await ParticipantType.query().findByIds(typeIds);
   const emailService = createEmailService();
@@ -45,7 +46,7 @@ export const sendNewParticipantEmail = async (
     template: 'newParticipantReadyForReview',
     to: approvers.map((a) => ({ name: a.displayName, email: a.email })),
   };
-  emailService.sendEmail(emailArgs);
+  emailService.sendEmail(emailArgs, traceId);
 };
 
 export const getParticipantsAwaitingApproval = async (email: string): Promise<Participant[]> => {
@@ -77,24 +78,27 @@ export const getParticipantsBySiteIds = async (siteIds: number[]) => {
 
 export const addSharingParticipants = async (
   participantSiteId: number,
-  siteIds: number[]
+  siteIds: number[],
+  traceId: string
 ): Promise<SharingListResponse> => {
-  const sharingListResponse = await getSharingList(participantSiteId);
+  const sharingListResponse = await getSharingList(participantSiteId, traceId);
   const newSharingSet = new Set([...sharingListResponse.allowed_sites, ...siteIds]);
   const response = await updateSharingList(
     participantSiteId,
     sharingListResponse.hash,
     [...newSharingSet],
-    sharingListResponse.allowed_types
+    sharingListResponse.allowed_types,
+    traceId
   );
   return response;
 };
 
 export const deleteSharingParticipants = async (
   participantSiteId: number,
-  siteIds: number[]
+  siteIds: number[],
+  traceId: string
 ): Promise<SharingListResponse> => {
-  const sharingListResponse = await getSharingList(participantSiteId);
+  const sharingListResponse = await getSharingList(participantSiteId, traceId);
   const newSharingList = sharingListResponse.allowed_sites.filter(
     (siteId) => !siteIds.includes(siteId)
   );
@@ -102,7 +106,8 @@ export const deleteSharingParticipants = async (
     participantSiteId,
     sharingListResponse.hash,
     newSharingList,
-    sharingListResponse.allowed_types
+    sharingListResponse.allowed_types,
+    traceId
   );
 };
 
@@ -133,18 +138,20 @@ export const updateParticipantAndTypes = async (
 
 export const UpdateSharingTypes = async (
   participantSiteId: number,
-  types: ClientType[]
+  types: ClientType[],
+  traceId: string
 ): Promise<SharingListResponse> => {
-  const sharingListResponse = await getSharingList(participantSiteId);
+  const sharingListResponse = await getSharingList(participantSiteId, traceId);
   return updateSharingList(
     participantSiteId,
     sharingListResponse.hash,
     sharingListResponse.allowed_sites,
-    types
+    types,
+    traceId
   );
 };
 
-export const sendParticipantApprovedEmail = async (users: User[]) => {
+export const sendParticipantApprovedEmail = async (users: User[], traceId: string) => {
   const emailService = createEmailService();
   const emailArgs: EmailArgs = {
     subject: 'Your account has been confirmed',
@@ -152,7 +159,7 @@ export const sendParticipantApprovedEmail = async (users: User[]) => {
     template: 'accountHasBeenConfirmed',
     to: users.map((user) => ({ name: user.fullName(), email: user.email })),
   };
-  emailService.sendEmail(emailArgs);
+  emailService.sendEmail(emailArgs, traceId);
 };
 
 const idParser = z.object({
@@ -161,13 +168,14 @@ const idParser = z.object({
 
 const hasParticipantAccess = async (req: ParticipantRequest, res: Response, next: NextFunction) => {
   const { participantId } = idParser.parse(req.params);
+  const traceId = req?.headers?.traceId?.toString() ?? '';
   const participant = await Participant.query().findById(participantId).withGraphFetched('types');
   if (!participant) {
     return res.status(404).send([{ message: 'The participant cannot be found.' }]);
   }
 
   const currentUserEmail = req.auth?.payload?.email as string;
-  if (!(await isUserBelongsToParticipant(currentUserEmail, participantId))) {
+  if (!(await isUserBelongsToParticipant(currentUserEmail, participantId, traceId))) {
     return res.status(403).send([{ message: 'You do not have permission to that participant.' }]);
   }
 

--- a/src/api/services/sendGridService.ts
+++ b/src/api/services/sendGridService.ts
@@ -25,7 +25,10 @@ const findTemplate = (template: string): string => {
   throw Error('template not exist');
 };
 
-export const sendEmail = async ({ to, subject, templateData, template }: EmailArgs) => {
+export const sendEmail = async (
+  { to, subject, templateData, template }: EmailArgs,
+  traceId: string
+) => {
   const message = {
     from: UID2Sender,
     templateId: findTemplate(template),
@@ -43,8 +46,8 @@ export const sendEmail = async ({ to, subject, templateData, template }: EmailAr
   try {
     sgMail.send(message);
   } catch (err: unknown) {
-    const [logger] = getLoggers();
+    const { errorLogger } = getLoggers();
 
-    logger.error(`Send email failed: ${err}`);
+    errorLogger.error(`Send email failed: ${err}`, traceId);
   }
 };

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { Participant } from '../entities/Participant';
 import { User, UserDTO } from '../entities/User';
-import { getLoggers } from '../helpers/loggingHelpers';
+import { getLoggers, getTraceId } from '../helpers/loggingHelpers';
 import { isUserAnApprover } from './approversService';
 
 export type UserWithIsApprover = User & { isApprover: boolean };
@@ -72,7 +72,7 @@ export const enrichWithUserFromParams = async (
   next: NextFunction
 ) => {
   const { userId } = userIdParser.parse(req.params);
-  const traceId = req?.headers?.traceId?.toString() ?? '';
+  const traceId = getTraceId(req);
   const user = await User.query().findById(userId);
   if (!user) {
     return res.status(404).send([{ message: 'The user cannot be found.' }]);


### PR DESCRIPTION
- Pass traceId from the request through to the service, so that it can be logged
- Refactor the loggers to reduce chance of using the wrong logger (to prevent have cases of `logger.error` instead of `errorLogger.logger`)
- We might have to revisit this design in the future to avoid having to prevent `traceId`s around everywhere, but that will involve a bit more work. Alternative options include using dependency injection or the factory pattern.

## Manual testing 
**Fail to add a sharing permission**
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ff96bc19-9be5-4d97-9202-558348e40a90)

**Info when sending an email invite**
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/517c4a1f-c810-492f-a45e-ca3ec6f9f601)

