### PR TITLE
Filter out sites from sharing permissions features by using `visible` flag

### DIFF
--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -6,7 +6,7 @@ import {
   SharingSiteDTO,
 } from '../helpers/siteConvertingHelpers';
 import { isApproverCheck } from '../middleware/approversMiddleware';
-import { getSiteList } from '../services/adminServiceClient';
+import { getSiteList, getVisibleSiteList } from '../services/adminServiceClient';
 import { SiteDTO } from '../services/adminServiceHelpers';
 import { getAttachedSiteIDs, getParticipantsBySiteIds } from '../services/participantsService';
 
@@ -21,8 +21,8 @@ export function createSitesRouter() {
   });
 
   sitesRouter.get('/available', async (_req, res) => {
-    const sites = await getSiteList();
-    const availableSites = sites.filter(canBeSharedWith);
+    const visibleSites = await getVisibleSiteList();
+    const availableSites = visibleSites.filter(canBeSharedWith);
     const matchedParticipants = await getParticipantsBySiteIds(availableSites.map((s) => s.id));
     const availableSharingSites: SharingSiteDTO[] = availableSites.map((site: SiteDTO) =>
       convertSiteToSharingSiteDTO(site, matchedParticipants)
@@ -31,9 +31,9 @@ export function createSitesRouter() {
   });
 
   sitesRouter.get('/', async (_req, res) => {
-    const sites = await getSiteList();
-    const matchedParticipants = await getParticipantsBySiteIds(sites.map((s) => s.id));
-    const sharingSites: SharingSiteDTO[] = sites.map((site: SiteDTO) =>
+    const visibleSites = await getVisibleSiteList();
+    const matchedParticipants = await getParticipantsBySiteIds(visibleSites.map((s) => s.id));
+    const sharingSites: SharingSiteDTO[] = visibleSites.map((site: SiteDTO) =>
       convertSiteToSharingSiteDTO(site, matchedParticipants)
     );
     return res.status(200).json(sharingSites);

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -71,6 +71,11 @@ export const getSiteList = async (): Promise<SiteDTO[]> => {
   return response.data;
 };
 
+export const getVisibleSiteList = async (): Promise<SiteDTO[]> => {
+  const siteList = await getSiteList();
+  return siteList.filter((x) => x.visible !== false);
+};
+
 export const getKeyPairsList = async (siteId: number): Promise<KeyPairDTO[]> => {
   const response = await adminServiceClient.get<KeyPairDTO[]>(
     `/api/v2/sites/${siteId}/client-side-keypairs`

--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -24,6 +24,7 @@ export type SiteDTO = {
   roles: ClientRole[];
   clientTypes?: ClientType[];
   client_count: number;
+  visible: boolean;
 };
 
 export type SharingListResponse = {

--- a/src/api/tests/siteConvertingHelpers.spec.ts
+++ b/src/api/tests/siteConvertingHelpers.spec.ts
@@ -110,6 +110,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['DSP'],
         // eslint-disable-next-line camelcase
         client_count: 1,
+        visible: true,
       } as SiteDTO;
       expect(canBeSharedWith(site)).toBeTruthy();
     });

--- a/src/web/components/ParticipantRequests/ParticipantApprovalForm.spec.tsx
+++ b/src/web/components/ParticipantRequests/ParticipantApprovalForm.spec.tsx
@@ -6,8 +6,16 @@ import { HighlightedResult } from './ParticipantApprovalForm';
 
 const createResult = (text: string, indices: [number, number][]) => {
   const result: Fuse.FuseResult<SiteDTO> = {
-    // eslint-disable-next-line camelcase
-    item: { name: text, id: 1, enabled: true, roles: [], clientTypes: [], client_count: 1 },
+    item: {
+      name: text,
+      id: 1,
+      enabled: true,
+      roles: [],
+      clientTypes: [],
+      // eslint-disable-next-line camelcase
+      client_count: 1,
+      visible: false,
+    },
     matches: [
       {
         indices,

--- a/src/web/components/ParticipantRequests/ParticipantRequestForm.stories.tsx
+++ b/src/web/components/ParticipantRequests/ParticipantRequestForm.stories.tsx
@@ -20,6 +20,7 @@ const response: SiteDTO[] = [
     clientTypes: ['PUBLISHER'],
     // eslint-disable-next-line camelcase
     client_count: 1,
+    visible: true,
   },
   {
     id: 4,
@@ -29,6 +30,7 @@ const response: SiteDTO[] = [
     clientTypes: ['PUBLISHER'],
     // eslint-disable-next-line camelcase
     client_count: 1,
+    visible: false,
   },
 ];
 


### PR DESCRIPTION
- Create a new method `getVisibleSiteList` in `adminServiceClient.ts` to call `getSiteList()` then filter out the appropriate sites before returning to the front end. 
- The method of filtering allows for existing sites that have `visible==null` to still be included, as that is the default for sites that were created before the `visible` flag was introduced. The default for new sites is `visible==true`
- Use `getVisibleSiteList` in the base (`/`) router and `/available` in the sites router. These routes are only used for non-admin functionality and does not break core functionality of the website when the current participant has a site that has visible set to false
- Ultimately this hides invisible sites from being included on the sharing permissions count on the home screen, as well as being hidden from the sharing permissions screen (i.e. in the bulk add control, the search and add control, and the sharing permissions table)

# Manual testing
Given the following sites exist:
```
  {
    "name": "a visible site",
    "clientTypes": [
      "DSP"
    ],
    "visible": true, //or null
    ...
  },
  {
    "name": "an invisible site",
    "clientTypes": [
      "DSP"
    ],
    "visible": false,
    ...
  }
```
We see that `a visible site` shows up in areas of the UI relating to sharing, but `an invisible site` does not. 
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/02620ec2-f788-40bc-bb72-1f48d6df902a)

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/a3a46900-ecc9-470e-991f-68f838780e00)

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/045eec49-d535-4ce3-bbd5-b3175aecc01f)

The `an invisible site` should still show up in admin areas such as approving participant requests.

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ba1bb820-e5f3-41fd-8dd4-9c5b966009fe)

Other manual testing verified that the functionality of the portal did not break when the user was associated with a site that had `visible==false`
