### PR TITLE
Extract handleErrorPopup method

### DIFF
--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import { useCallback, useState } from 'react';
 
 import { UpdateTeamMemberForm, UserResponse } from '../../services/userAccount';
-import { ApiError } from '../../utils/apiError';
+import { handleErrorPopup } from '../../utils/apiError';
 import { Dialog } from '../Core/Dialog';
 import { InlineMessage } from '../Core/InlineMessage';
 import { StatusNotificationType, StatusPopup } from '../Core/StatusPopup';
@@ -101,14 +101,7 @@ function TeamMember({
     } catch (e) {
       setErrorInfo(e as Error);
       setInviteState(InviteState.error);
-      const err = e as Error;
-      const hasHash = Object.hasOwn(err, 'errorHash') && (e as ApiError).errorHash;
-      const hash = hasHash ? `: (${(e as ApiError).errorHash})` : '';
-      setStatusPopup({
-        type: 'Error',
-        message: `${err.message}${hash}`,
-      });
-      setShowStatusPopup(true);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   }, [person.id, reinviteState, resendInvite]);
 

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -101,7 +101,7 @@ function TeamMember({
     } catch (e) {
       setErrorInfo(e as Error);
       setInviteState(InviteState.error);
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   }, [person.id, reinviteState, resendInvite]);
 

--- a/src/web/screens/emailContacts.tsx
+++ b/src/web/screens/emailContacts.tsx
@@ -11,7 +11,7 @@ import {
   RemoveEmailContact,
   UpdateEmailContact,
 } from '../services/participant';
-import { ApiError } from '../utils/apiError';
+import { handleErrorPopup } from '../utils/apiError';
 import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
 import { PortalRoute } from './routeUtils';
 
@@ -30,17 +30,6 @@ export function BusinessContacts() {
   const [showStatusPopup, setShowStatusPopup] = useState<boolean>(false);
   const [statusPopup, setStatusPopup] = useState<StatusNotificationType>();
 
-  const handleErrorPopup = (e: Error) => {
-    const hasHash = Object.hasOwn(e, 'errorHash') && (e as ApiError).errorHash;
-    const hash = hasHash ? `: (${(e as ApiError).errorHash})` : '';
-    setStatusPopup({
-      type: 'Error',
-      message: `${e.message}${hash}`,
-    });
-    setShowStatusPopup(true);
-    throw new Error(e.message);
-  };
-
   const handleSuccessPopup = (message: string) => {
     setStatusPopup({
       type: 'Success',
@@ -57,7 +46,7 @@ export function BusinessContacts() {
       }
       handleBusinessContactUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -69,7 +58,7 @@ export function BusinessContacts() {
       }
       handleBusinessContactUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -81,7 +70,7 @@ export function BusinessContacts() {
       }
       handleBusinessContactUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/emailContacts.tsx
+++ b/src/web/screens/emailContacts.tsx
@@ -46,7 +46,7 @@ export function BusinessContacts() {
       }
       handleBusinessContactUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -58,7 +58,7 @@ export function BusinessContacts() {
       }
       handleBusinessContactUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -70,7 +70,7 @@ export function BusinessContacts() {
       }
       handleBusinessContactUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/keyPairsScreen.tsx
+++ b/src/web/screens/keyPairsScreen.tsx
@@ -41,7 +41,7 @@ function KeyPairsScreen() {
         loadKeyPairs();
       }
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/keyPairsScreen.tsx
+++ b/src/web/screens/keyPairsScreen.tsx
@@ -5,7 +5,7 @@ import { StatusNotificationType, StatusPopup } from '../components/Core/StatusPo
 import { KeyPairModel } from '../components/KeyPairs/KeyPairModel';
 import KeyPairsTable from '../components/KeyPairs/KeyPairsTable';
 import { AddKeyPair, AddKeyPairFormProps, GetKeyPairs } from '../services/keyPairService';
-import { ApiError } from '../utils/apiError';
+import { handleErrorPopup } from '../utils/apiError';
 import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
 import { PortalRoute } from './routeUtils';
 
@@ -24,17 +24,6 @@ function KeyPairsScreen() {
     loadKeyPairs();
   }, [loadKeyPairs]);
 
-  const handleErrorPopup = (e: Error) => {
-    const hasHash = Object.hasOwn(e, 'errorHash') && (e as ApiError).errorHash;
-    const hash = hasHash ? `: (${(e as ApiError).errorHash})` : '';
-    setStatusPopup({
-      type: 'Error',
-      message: `${e.message}${hash}`,
-    });
-    setShowStatusPopup(true);
-    throw new Error(e.message);
-  };
-
   const handleSuccessPopup = (message: string) => {
     setStatusPopup({
       type: 'Success',
@@ -52,7 +41,7 @@ function KeyPairsScreen() {
         loadKeyPairs();
       }
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -14,7 +14,7 @@ import {
   GetSharingList,
   UpdateSharingTypes,
 } from '../services/participant';
-import { ApiError } from '../utils/apiError';
+import { ApiError, handleErrorPopup } from '../utils/apiError';
 import { useAsyncError } from '../utils/errorHandler';
 import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
 import { PortalRoute } from './routeUtils';
@@ -50,18 +50,14 @@ function SharingPermissions() {
             : `${selectedTypes.length} Participant types`
         } saved to Your Sharing Permissions`,
       });
+      setShowStatusPopup(true);
       setSharedTypes(response.allowed_types ?? []);
       if (!participant?.completedRecommendations) {
         const updatedParticipant = await CompleteRecommendations(participant!.id);
         setParticipant(updatedParticipant);
       }
     } catch (e) {
-      setStatusPopup({
-        type: 'Error',
-        message: `Save Sharing Permissions Failed`,
-      });
-    } finally {
-      setShowStatusPopup(true);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -74,14 +70,10 @@ function SharingPermissions() {
           selectedSiteIds.length === 1 ? '1 Participant' : `${selectedSiteIds.length} Participants`
         } added to Your Sharing Permissions`,
       });
+      setShowStatusPopup(true);
       setSharedSiteIds(response.allowed_sites);
     } catch (e) {
-      setStatusPopup({
-        type: 'Error',
-        message: `Add Sharing Permissions Failed`,
-      });
-    } finally {
-      setShowStatusPopup(true);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -94,14 +86,10 @@ function SharingPermissions() {
           siteIdsToDelete.length > 1 ? 'permissions' : 'permission'
         } deleted`,
       });
+      setShowStatusPopup(true);
       setSharedSiteIds(response.allowed_sites);
     } catch (e) {
-      setStatusPopup({
-        type: 'Error',
-        message: `Delete Sharing Permissions Failed`,
-      });
-    } finally {
-      setShowStatusPopup(true);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -57,7 +57,7 @@ function SharingPermissions() {
         setParticipant(updatedParticipant);
       }
     } catch (e) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -73,7 +73,7 @@ function SharingPermissions() {
       setShowStatusPopup(true);
       setSharedSiteIds(response.allowed_sites);
     } catch (e) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -89,7 +89,7 @@ function SharingPermissions() {
       setShowStatusPopup(true);
       setSharedSiteIds(response.allowed_sites);
     } catch (e) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/teamMembers.tsx
+++ b/src/web/screens/teamMembers.tsx
@@ -50,7 +50,7 @@ function TeamMembers() {
       }
       onTeamMembersUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -62,7 +62,7 @@ function TeamMembers() {
       }
       onTeamMembersUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -75,7 +75,7 @@ function TeamMembers() {
       onTeamMembersUpdated();
       if (LoggedInUser?.user?.id === userId) await loadUser();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
+      handleErrorPopup(e, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/screens/teamMembers.tsx
+++ b/src/web/screens/teamMembers.tsx
@@ -15,7 +15,7 @@ import {
   UpdateUser,
   UserResponse,
 } from '../services/userAccount';
-import { ApiError } from '../utils/apiError';
+import { handleErrorPopup } from '../utils/apiError';
 import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
 import { PortalRoute } from './routeUtils';
 
@@ -34,17 +34,6 @@ function TeamMembers() {
   const [showStatusPopup, setShowStatusPopup] = useState<boolean>(false);
   const [statusPopup, setStatusPopup] = useState<StatusNotificationType>();
 
-  const handleErrorPopup = (e: Error) => {
-    const hasHash = Object.hasOwn(e, 'errorHash') && (e as ApiError).errorHash;
-    const hash = hasHash ? `: (${(e as ApiError).errorHash})` : '';
-    setStatusPopup({
-      type: 'Error',
-      message: `${e.message}${hash}`,
-    });
-    setShowStatusPopup(true);
-    throw new Error(e.message);
-  };
-
   const handleSuccessPopup = (message: string) => {
     setStatusPopup({
       type: 'Success',
@@ -61,7 +50,7 @@ function TeamMembers() {
       }
       onTeamMembersUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -73,7 +62,7 @@ function TeamMembers() {
       }
       onTeamMembersUpdated();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 
@@ -86,7 +75,7 @@ function TeamMembers() {
       onTeamMembersUpdated();
       if (LoggedInUser?.user?.id === userId) await loadUser();
     } catch (e: unknown) {
-      handleErrorPopup(e as Error);
+      handleErrorPopup(e as Error, setStatusPopup, setShowStatusPopup);
     }
   };
 

--- a/src/web/utils/apiError.tsx
+++ b/src/web/utils/apiError.tsx
@@ -1,4 +1,6 @@
 import { AxiosError } from 'axios';
+
+import { StatusNotificationType } from '../components/Core/StatusPopup';
 /*
  * Backend errors may return an `errorHash` that can help correlate the logs
  * with the user reported issues.
@@ -24,4 +26,19 @@ export function backendError(e: unknown, overrideMessage: string) {
     });
   }
   return Error(overrideMessage);
+}
+
+export function handleErrorPopup(
+  e: Error,
+  setStatusPopup: React.Dispatch<React.SetStateAction<StatusNotificationType | undefined>>,
+  setShowStatusPopup: React.Dispatch<React.SetStateAction<boolean>>
+) {
+  const hasHash = Object.hasOwn(e, 'errorHash') && (e as ApiError).errorHash;
+  const hash = hasHash ? `: (${(e as ApiError).errorHash})` : '';
+  setStatusPopup({
+    type: 'Error',
+    message: `${e.message}${hash}`,
+  });
+  setShowStatusPopup(true);
+  throw new Error(e.message);
 }


### PR DESCRIPTION
- Extract `handleErrorPopup` method so that it is no longer defined locally multiple times
- Use `handleErrorPopup` instead of manually setting a message in the frontend - if the messages aren't friendly enough we can just change them on our backend.
- Ensure the `errorHash` is extracted from different error types
- Stronger type safety