### PR TITLE
Display errorHash when resending team member invite

### DIFF
--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -90,14 +90,24 @@ export class UserController {
 
     const resultLength = user?.length ?? 0;
     if (resultLength < 1) {
-      res.sendStatus(404);
+      errorLogger.error(
+        `No results received when loading user entry for ${req.user?.email}`,
+        traceId
+      );
+      res.status(404).json({
+        errorHash: traceId,
+      });
+      return;
     }
     if (resultLength > 1) {
       errorLogger.error(
         `Multiple results received when loading user entry for ${req.user?.email}`,
         traceId
       );
-      res.sendStatus(500);
+      res.status(500).json({
+        errorHash: traceId,
+      });
+      return;
     }
 
     infoLogger.info(

--- a/src/web/services/userAccount.ts
+++ b/src/web/services/userAccount.ts
@@ -50,7 +50,7 @@ export async function ResendInvite(id: number): Promise<void> {
   try {
     return await axios.post(`/users/${id}/resendInvitation`);
   } catch (e: unknown) {
-    const error = backendError(e, 'Unable to resend invite.');
+    const error = backendError(e, 'Unable to resend invite');
     log.error(error);
     throw error;
   }


### PR DESCRIPTION
**Before**
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/8044cbb8-d125-4634-a57f-7557667a0023)

**After**
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/bca581fd-a5b6-4978-b9e9-d791d081f9f1)


Also added `return` statements so that we don't get the following api error by setting the status multiple times:
```
Error: Cannot set headers after they are sent to the client
```
