### PR TITLE
Stricter check for sharing sites

### DIFF
--- a/src/api/helpers/siteConvertingHelpers.ts
+++ b/src/api/helpers/siteConvertingHelpers.ts
@@ -26,8 +26,7 @@ export const mapClientTypeToParticipantType = (
 export const canBeSharedWith = (site: SiteDTO): boolean => {
   if (
     (site.roles.includes('SHARER') ||
-      site.roles.includes('ID_READER') ||
-      site.clientTypes?.includes('DSP')) &&
+      (site.roles.includes('ID_READER') && site.clientTypes?.includes('DSP'))) &&
     !site.roles.includes('OPTOUT')
   )
     return true;

--- a/src/api/tests/siteConvertingHelpers.spec.ts
+++ b/src/api/tests/siteConvertingHelpers.spec.ts
@@ -100,19 +100,19 @@ describe('Sharing Permission Helper Tests', () => {
     });
   });
 
-  describe('#hasSharerRole', () => {
-    it('should return true if site is DSP', () => {
+  describe('#canBeSharedWith', () => {
+    it('should return true if site is DSP and has ID_READER', () => {
       const site = {
         id: 2,
         name: 'Test Site',
         enabled: true,
-        roles: [],
+        roles: ['ID_READER'],
         clientTypes: ['DSP'],
         // eslint-disable-next-line camelcase
         client_count: 1,
         visible: true,
       } as SiteDTO;
-      expect(canBeSharedWith(site)).toBeTruthy();
+      expect(canBeSharedWith(site)).toBe(true);
     });
 
     it('should return true if site has SHARER role', () => {
@@ -125,7 +125,33 @@ describe('Sharing Permission Helper Tests', () => {
         // eslint-disable-next-line camelcase
         client_count: 1,
       } as SiteDTO;
-      expect(canBeSharedWith(site)).toBeTruthy();
+      expect(canBeSharedWith(site)).toBe(true);
+    });
+
+    it('should return false if site has ID_READER but is not a DSP', () => {
+      const site = {
+        id: 2,
+        name: 'Test Site',
+        enabled: true,
+        roles: ['ID_READER'],
+        clientTypes: ['PUBLISHER'],
+        // eslint-disable-next-line camelcase
+        client_count: 1,
+      } as SiteDTO;
+      expect(canBeSharedWith(site)).toBe(false);
+    });
+
+    it('should return false if site has OPTOUT role', () => {
+      const site = {
+        id: 2,
+        name: 'Test Site',
+        enabled: true,
+        roles: ['OPTOUT'],
+        clientTypes: ['DSP'],
+        // eslint-disable-next-line camelcase
+        client_count: 1,
+      } as SiteDTO;
+      expect(canBeSharedWith(site)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Enforce ID_READER AND DSP, rather than ID_READER OR DSP.
Manual Testing
The following site will not show up in sharing permissions:
```
  {
    "id": 1001,
    "name": "Non-DSP with ID_READER",
    "clientTypes": [
      "PUBLISHER" // Importantly, not DSP.
    ], 
    "roles": [
      "ID_READER"
    ],
  },
```

While the following site will show up in sharing permissions:
```
  {
    "id": 123,
    "name": "DSP", // This is mapped to "DSP Example" in the portal db, hence the name in the screenshot below.
    "clientTypes": [
      "DSP"
    ],
    "roles": [
      "ID_READER"
    ],
  },
```
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/2db9b6cd-251e-4e49-8185-3fe37de18e0b)
