### PR TITLE
Hide disabled API roles when selecting roles for participant

### DIFF
--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -159,7 +159,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
   });
 
   router.get('/apiRoles', async (_req, res) => {
-    const apiRoles = await ApiRole.query();
+    const apiRoles = await ApiRole.query().where({ disabled: false });
     return res.status(200).json(apiRoles);
   });
 

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -159,7 +159,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
   });
 
   router.get('/apiRoles', async (_req, res) => {
-    const apiRoles = await ApiRole.query().where({ disabled: false });
+    const apiRoles = await ApiRole.query().where('disabled', false);
     return res.status(200).json(apiRoles);
   });
 

--- a/src/api/entities/ApiRole.ts
+++ b/src/api/entities/ApiRole.ts
@@ -34,5 +34,4 @@ export const ApiRoleSchema = z.object({
   id: z.number(),
   roleName: z.string(),
   externalName: z.string(),
-  disabled: z.boolean(),
 });

--- a/src/api/entities/ApiRole.ts
+++ b/src/api/entities/ApiRole.ts
@@ -25,12 +25,14 @@ export class ApiRole extends BaseModel {
   declare id: number;
   declare roleName: string;
   declare externalName: string;
+  declare disabled: boolean;
 }
 
-export type ApiRoleDTO = ModelObjectOpt<ApiRole>;
+export type ApiRoleDTO = Omit<ModelObjectOpt<ApiRole>, 'disabled'>;
 
 export const ApiRoleSchema = z.object({
   id: z.number(),
   roleName: z.string(),
   externalName: z.string(),
+  disabled: z.boolean(),
 });

--- a/src/database/migrations/20240104050829_DisableOptOutRole.ts
+++ b/src/database/migrations/20240104050829_DisableOptOutRole.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('apiRoles', (table) => {
+    table.boolean('disabled').defaultTo(true).notNullable();
+  });
+
+  const allowedRoles = ['MAPPER', 'GENERATOR', 'ID_READER', 'SHARER'];
+
+  await knex('apiRoles').whereIn('roleName', allowedRoles).update({ disabled: false });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('apiRoles', (table) => {
+    table.dropColumn('disabled');
+  });
+}

--- a/src/database/migrations/20240104050829_DisableOptOutRole.ts
+++ b/src/database/migrations/20240104050829_DisableOptOutRole.ts
@@ -5,9 +5,9 @@ export async function up(knex: Knex): Promise<void> {
     table.boolean('disabled').defaultTo(true).notNullable();
   });
 
-  const allowedRoles = ['MAPPER', 'GENERATOR', 'ID_READER', 'SHARER'];
+  const enabledRoles = ['MAPPER', 'GENERATOR', 'ID_READER', 'SHARER'];
 
-  await knex('apiRoles').whereIn('roleName', allowedRoles).update({ disabled: false });
+  await knex('apiRoles').whereIn('roleName', enabledRoles).update({ disabled: false });
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -9,7 +9,7 @@ import { SiteDTO } from '../../api/services/adminServiceHelpers';
 import { Loading } from '../components/Core/Loading';
 import { ApprovedParticipantsTable } from '../components/ParticipantManagement/ApprovedParticipantsTable';
 import { ParticipantRequestsTable } from '../components/ParticipantManagement/ParticipantRequestsTable';
-import { GetAllApiRoles } from '../services/apiRoles';
+import { GetEnabledApiRoles } from '../services/apiRoles';
 import {
   ApproveParticipantRequest,
   GetApprovedParticipants,
@@ -84,7 +84,7 @@ export const ManageParticipantsRoute: PortalRoute = {
     const participantsAwaitingApproval = GetParticipantsAwaitingApproval();
     const participantsApproved = GetApprovedParticipants();
     const participantTypes = GetAllParticipantTypes();
-    const apiRoles = GetAllApiRoles();
+    const apiRoles = GetEnabledApiRoles();
     const sitesList = preloadSiteList();
     const promises = Promise.all([
       participantsAwaitingApproval,

--- a/src/web/services/apiRoles.tsx
+++ b/src/web/services/apiRoles.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { backendError } from '../utils/apiError';
 
-export async function GetAllApiRoles() {
+export async function GetEnabledApiRoles() {
   try {
     const result = await axios.get<ApiRoleDTO[]>(`/apiRoles`, {
       validateStatus: (status) => status === 200,


### PR DESCRIPTION
Added migration which adds disabled field to apiRoles in DB. Disabled all keys except for known good keys by default.

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/152250444/89c19c9b-d463-4574-bb35-d48000fa7c90)
DB table
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/152250444/11ea24a8-dfb3-4905-a904-ee69dcb8b801)
Resulting approval screen