### PR TITLE
Bypass handler for envar endpoint

### DIFF
--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -122,6 +122,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
         const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
         return roles.includes('api-participant-member');
       }),
+      { url: `${BASE_REQUEST_PATH}/envars`, method: 'GET' },
       { url: `${BASE_REQUEST_PATH}/participantTypes`, method: 'GET' },
       { url: `${BASE_REQUEST_PATH}/participants`, method: 'POST' },
       { url: `${BASE_REQUEST_PATH}/users/current`, method: 'GET' },


### PR DESCRIPTION
The `envars` endpoint was being called before a user had been approved (and therefore received the keycloak role to call our API), so it was failing with `unauthorised`, which would crash the page. 

This PR adds the `envars` endpoint to the list of paths that bypass the claim check, so now it returns with `200` and will not crash the page after a user has verified their email and they are on the `account/create` screen.