### PR TITLE
Bump required node version to 18.18

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the self-serve portal for UID2 participants. It enables a range of opera
 
 ## Requirements
 
-- A recent version of Node. Recommended: 18.12 or later. See [package.json](./package.json) for the required version.
+- A recent version of Node. Recommended: 18.18 or later. See [package.json](./package.json) for the required version.
 - Docker Desktop.
 - VS Code (or equivalent). Note that if you don't use VS Code, you will need to find equivalent extensions for things like linting.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the self-serve portal for UID2 participants. It enables a range of opera
 
 ## Requirements
 
-- A recent version of Node. Recommended: 16.14 or later. See [package.json](./package.json) for the required version.
+- A recent version of Node. Recommended: 18.12 or later. See [package.json](./package.json) for the required version.
 - Docker Desktop.
 - VS Code (or equivalent). Note that if you don't use VS Code, you will need to find equivalent extensions for things like linting.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,7 @@
         "ts-node": "^10.9.1"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=18.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,7 @@
         "ts-node": "^10.9.1"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=18.18"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">=16.14"
+    "node": ">=18.0"
   },
   "dependencies": {
     "@fontsource/roboto-mono": "^4.5.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">=18.0"
+    "node": ">=18.12"
   },
   "dependencies": {
     "@fontsource/roboto-mono": "^4.5.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">=18.12"
+    "node": ">=18.18"
   },
   "dependencies": {
     "@fontsource/roboto-mono": "^4.5.10",


### PR DESCRIPTION
**Node version < 18.18 fails**
```
> nvm use 16.14
Now using node v16.14.2 (64-bit)

> npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: uid2-ssportal@0.10.1
npm ERR! notsup Not compatible with your version of node/npm: uid2-ssportal@0.10.1
npm ERR! notsup Required: {"node":">=18.18"}
npm ERR! notsup Actual:   {"npm":"8.5.0","node":"v16.14.2"}
```

**Node version >=18.18 succeeds**
```
> nvm use 18.18
Now using node v18.18.0 (64-bit)

> npm install

removed 67 packages, and audited 2669 packages in 12s
...
```