### PR TITLE
Clean up DB migration files

### DIFF
--- a/src/database/migrations/20230201060429_CreateUserTable.ts
+++ b/src/database/migrations/20230201060429_CreateUserTable.ts
@@ -1,14 +1,12 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  console.log('Creating users table...');
   await knex.schema.createTable('users', (table) => {
     table.increments('id').primary();
     table.string('email', 256).unique();
     table.string('location', 100);
     table.string('phone', 20);
   });
-  console.log('Created users table.');
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/src/database/migrations/20230308044836_UpdateUserSchemeAndAddStatusToParticipant.ts
+++ b/src/database/migrations/20230308044836_UpdateUserSchemeAndAddStatusToParticipant.ts
@@ -4,7 +4,7 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable('users', (table) => {
     table.string('firstName').notNullable();
     table.string('lastName').notNullable();
-    table.enu('role', ['admin', 'user']).notNullable().defaultTo('user');
+    table.string('role', 100).notNullable().defaultTo('user');
   });
 
   await knex.schema.alterTable('participants', (table) => {

--- a/src/database/migrations/20231220235718_RemoveParticipantIdColumnFromAuditTrail.ts
+++ b/src/database/migrations/20231220235718_RemoveParticipantIdColumnFromAuditTrail.ts
@@ -1,13 +1,17 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  await knex('auditTrails')
-    .whereNotNull('participantId')
-    .update({
-      eventData: knex.raw("JSON_MODIFY(eventData, '$.participantId', ?)", [
-        knex.ref('participantId'),
-      ]),
-    });
+  const auditTrailsCount = (await knex('auditTrails').count({ count: '*' }))[0].count;
+
+  if (Number(auditTrailsCount) > 0) {
+    await knex('auditTrails')
+      .whereNotNull('participantId')
+      .update({
+        eventData: knex.raw("JSON_MODIFY(eventData, '$.participantId', ?)", [
+          knex.ref('participantId'),
+        ]),
+      });
+  }
 
   await knex.schema.alterTable('auditTrails', (table) => {
     table.dropForeign('participantId');
@@ -25,17 +29,21 @@ export async function down(knex: Knex): Promise<void> {
     table.integer('participantId').references('participants.id');
   });
 
-  await knex('auditTrails')
-    .whereExists(
-      knex
-        .select('*')
-        .from('participants')
-        .whereRaw("participants.id = JSON_VALUE(auditTrails.eventData, '$.participantId')")
-    )
-    .update({
-      participantId: knex.raw("JSON_VALUE(eventData, '$.participantId')"),
-      eventData: knex.raw("JSON_MODIFY(eventData, '$.participantId', null)"),
-    });
+  const auditTrailsCount = (await knex('auditTrails').count({ count: '*' }))[0].count;
+
+  if (Number(auditTrailsCount) > 0) {
+    await knex('auditTrails')
+      .whereExists(
+        knex
+          .select('*')
+          .from('participants')
+          .whereRaw("participants.id = JSON_VALUE(auditTrails.eventData, '$.participantId')")
+      )
+      .update({
+        participantId: knex.raw("JSON_VALUE(eventData, '$.participantId')"),
+        eventData: knex.raw("JSON_MODIFY(eventData, '$.participantId', null)"),
+      });
+  }
 
   await knex.schema.alterTable('businessContacts', (table) => {
     table.dropForeign('participantId');


### PR DESCRIPTION
- Remove unnecessary console logs
- Replace unused enum with string. Turns out this syntax doesn't work with SQL Server, but it does with SQLite. Our SQL Server db just had `nvarchar(100)` so we've updated the migration to match that.
- Add conditions so that SQL syntax that doesn't work on SQLite shouldn't be run. Specifically, it is not happy with `JSON_MODIFY`