### PR TITLE
Rename SiteDTO to SiteAdmin

### DIFF
--- a/src/api/helpers/siteConvertingHelpers.ts
+++ b/src/api/helpers/siteConvertingHelpers.ts
@@ -1,8 +1,8 @@
 import { Participant } from '../entities/Participant';
 import { ParticipantTypeDTO } from '../entities/ParticipantType';
-import { ClientType, SiteAdmin } from '../services/adminServiceHelpers';
+import { AdminSiteDTO, ClientType } from '../services/adminServiceHelpers';
 
-export type SharingSiteDTO = Pick<SiteAdmin, 'clientTypes' | 'id' | 'name'> & {
+export type SharingSiteDTO = Pick<AdminSiteDTO, 'clientTypes' | 'id' | 'name'> & {
   canBeSharedWith: boolean;
 };
 export type SharingSiteWithSource = SharingSiteDTO & {
@@ -23,7 +23,7 @@ export const mapClientTypeToParticipantType = (
   return types;
 };
 
-export const canBeSharedWith = (site: SiteAdmin): boolean => {
+export const canBeSharedWith = (site: AdminSiteDTO): boolean => {
   if (
     (site.roles.includes('SHARER') ||
       (site.roles.includes('ID_READER') && site.clientTypes?.includes('DSP'))) &&
@@ -34,7 +34,7 @@ export const canBeSharedWith = (site: SiteAdmin): boolean => {
 };
 
 export const convertSiteToSharingSiteDTO = (
-  site: SiteAdmin,
+  site: AdminSiteDTO,
   participants: Participant[]
 ): SharingSiteDTO => {
   const matchedParticipant = participants.find((p) => p.siteId === site.id);

--- a/src/api/helpers/siteConvertingHelpers.ts
+++ b/src/api/helpers/siteConvertingHelpers.ts
@@ -1,8 +1,8 @@
 import { Participant } from '../entities/Participant';
 import { ParticipantTypeDTO } from '../entities/ParticipantType';
-import { ClientType, SiteDTO } from '../services/adminServiceHelpers';
+import { ClientType, SiteAdmin } from '../services/adminServiceHelpers';
 
-export type SharingSiteDTO = Pick<SiteDTO, 'clientTypes' | 'id' | 'name'> & {
+export type SharingSiteDTO = Pick<SiteAdmin, 'clientTypes' | 'id' | 'name'> & {
   canBeSharedWith: boolean;
 };
 export type SharingSiteWithSource = SharingSiteDTO & {
@@ -23,7 +23,7 @@ export const mapClientTypeToParticipantType = (
   return types;
 };
 
-export const canBeSharedWith = (site: SiteDTO): boolean => {
+export const canBeSharedWith = (site: SiteAdmin): boolean => {
   if (
     (site.roles.includes('SHARER') ||
       (site.roles.includes('ID_READER') && site.clientTypes?.includes('DSP'))) &&
@@ -34,7 +34,7 @@ export const canBeSharedWith = (site: SiteDTO): boolean => {
 };
 
 export const convertSiteToSharingSiteDTO = (
-  site: SiteDTO,
+  site: SiteAdmin,
   participants: Participant[]
 ): SharingSiteDTO => {
   const matchedParticipant = participants.find((p) => p.siteId === site.id);

--- a/src/api/routers/participantsRouter.ts
+++ b/src/api/routers/participantsRouter.ts
@@ -28,7 +28,7 @@ import {
   setSiteClientTypes,
   updateApiKeyRoles,
 } from '../services/adminServiceClient';
-import { mapAdminApiKeysToApiKeyDTOs, SiteDTO } from '../services/adminServiceHelpers';
+import { mapAdminApiKeysToApiKeyDTOs, SiteAdmin } from '../services/adminServiceHelpers';
 import {
   createdApiKeyToApiKeySecrets,
   getApiKey,
@@ -116,7 +116,7 @@ export function createParticipantsRouter() {
     const participants = await getParticipantsApproved();
 
     const sitesList = await getSiteList();
-    const siteMap = new Map<number, SiteDTO>(sitesList.map((s) => [s.id, s]));
+    const siteMap = new Map<number, SiteAdmin>(sitesList.map((s) => [s.id, s]));
 
     const allParticipantTypes = await ParticipantType.query();
     const result = participants

--- a/src/api/routers/participantsRouter.ts
+++ b/src/api/routers/participantsRouter.ts
@@ -28,7 +28,7 @@ import {
   setSiteClientTypes,
   updateApiKeyRoles,
 } from '../services/adminServiceClient';
-import { mapAdminApiKeysToApiKeyDTOs, SiteAdmin } from '../services/adminServiceHelpers';
+import { AdminSiteDTO, mapAdminApiKeysToApiKeyDTOs } from '../services/adminServiceHelpers';
 import {
   createdApiKeyToApiKeySecrets,
   getApiKey,
@@ -116,7 +116,7 @@ export function createParticipantsRouter() {
     const participants = await getParticipantsApproved();
 
     const sitesList = await getSiteList();
-    const siteMap = new Map<number, SiteAdmin>(sitesList.map((s) => [s.id, s]));
+    const siteMap = new Map<number, AdminSiteDTO>(sitesList.map((s) => [s.id, s]));
 
     const allParticipantTypes = await ParticipantType.query();
     const result = participants

--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -7,7 +7,7 @@ import {
 } from '../helpers/siteConvertingHelpers';
 import { isApproverCheck } from '../middleware/approversMiddleware';
 import { getSiteList, getVisibleSiteList } from '../services/adminServiceClient';
-import { SiteAdmin } from '../services/adminServiceHelpers';
+import { AdminSiteDTO } from '../services/adminServiceHelpers';
 import { getAttachedSiteIDs, getParticipantsBySiteIds } from '../services/participantsService';
 
 export function createSitesRouter() {
@@ -24,7 +24,7 @@ export function createSitesRouter() {
     const visibleSites = await getVisibleSiteList();
     const availableSites = visibleSites.filter(canBeSharedWith);
     const matchedParticipants = await getParticipantsBySiteIds(availableSites.map((s) => s.id));
-    const availableSharingSites: SharingSiteDTO[] = availableSites.map((site: SiteAdmin) =>
+    const availableSharingSites: SharingSiteDTO[] = availableSites.map((site: AdminSiteDTO) =>
       convertSiteToSharingSiteDTO(site, matchedParticipants)
     );
     return res.status(200).json(availableSharingSites);
@@ -33,7 +33,7 @@ export function createSitesRouter() {
   sitesRouter.get('/', async (_req, res) => {
     const visibleSites = await getVisibleSiteList();
     const matchedParticipants = await getParticipantsBySiteIds(visibleSites.map((s) => s.id));
-    const sharingSites: SharingSiteDTO[] = visibleSites.map((site: SiteAdmin) =>
+    const sharingSites: SharingSiteDTO[] = visibleSites.map((site: AdminSiteDTO) =>
       convertSiteToSharingSiteDTO(site, matchedParticipants)
     );
     return res.status(200).json(sharingSites);

--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -7,7 +7,7 @@ import {
 } from '../helpers/siteConvertingHelpers';
 import { isApproverCheck } from '../middleware/approversMiddleware';
 import { getSiteList, getVisibleSiteList } from '../services/adminServiceClient';
-import { SiteDTO } from '../services/adminServiceHelpers';
+import { SiteAdmin } from '../services/adminServiceHelpers';
 import { getAttachedSiteIDs, getParticipantsBySiteIds } from '../services/participantsService';
 
 export function createSitesRouter() {
@@ -24,7 +24,7 @@ export function createSitesRouter() {
     const visibleSites = await getVisibleSiteList();
     const availableSites = visibleSites.filter(canBeSharedWith);
     const matchedParticipants = await getParticipantsBySiteIds(availableSites.map((s) => s.id));
-    const availableSharingSites: SharingSiteDTO[] = availableSites.map((site: SiteDTO) =>
+    const availableSharingSites: SharingSiteDTO[] = availableSites.map((site: SiteAdmin) =>
       convertSiteToSharingSiteDTO(site, matchedParticipants)
     );
     return res.status(200).json(availableSharingSites);
@@ -33,7 +33,7 @@ export function createSitesRouter() {
   sitesRouter.get('/', async (_req, res) => {
     const visibleSites = await getVisibleSiteList();
     const matchedParticipants = await getParticipantsBySiteIds(visibleSites.map((s) => s.id));
-    const sharingSites: SharingSiteDTO[] = visibleSites.map((site: SiteDTO) =>
+    const sharingSites: SharingSiteDTO[] = visibleSites.map((site: SiteAdmin) =>
       convertSiteToSharingSiteDTO(site, matchedParticipants)
     );
     return res.status(200).json(sharingSites);

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -12,7 +12,7 @@ import {
   KeyPairDTO,
   mapClientTypesToAdminEnums,
   SharingListResponse,
-  SiteDTO,
+  SiteAdmin,
 } from './adminServiceHelpers';
 
 const adminServiceClient = axios.create({
@@ -71,13 +71,13 @@ export const updateSharingList = async (
   }
 };
 
-export const getSiteList = async (): Promise<SiteDTO[]> => {
-  const response = await adminServiceClient.get<SiteDTO[]>('/api/site/list');
+export const getSiteList = async (): Promise<SiteAdmin[]> => {
+  const response = await adminServiceClient.get<SiteAdmin[]>('/api/site/list');
   return response.data;
 };
 
-export const getSite = async (siteId: number): Promise<SiteDTO> => {
-  const response = await adminServiceClient.get<SiteDTO>(`/api/site/${siteId}`);
+export const getSite = async (siteId: number): Promise<SiteAdmin> => {
+  const response = await adminServiceClient.get<SiteAdmin>(`/api/site/${siteId}`);
   return response.data;
 };
 
@@ -113,7 +113,7 @@ export const updateApiKeyRoles = async (contact: string, apiRoles: string[]): Pr
   });
 };
 
-export const getVisibleSiteList = async (): Promise<SiteDTO[]> => {
+export const getVisibleSiteList = async (): Promise<SiteAdmin[]> => {
   const siteList = await getSiteList();
   return siteList.filter((x) => x.visible !== false);
 };

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -6,13 +6,13 @@ import { ParticipantApprovalPartial } from '../entities/Participant';
 import { SSP_ADMIN_SERVICE_BASE_URL, SSP_ADMIN_SERVICE_CLIENT_KEY } from '../envars';
 import { getLoggers } from '../helpers/loggingHelpers';
 import {
+  AdminSiteDTO,
   ApiKeyAdmin,
   ClientType,
   CreatedApiKeyDTO,
   KeyPairDTO,
   mapClientTypesToAdminEnums,
   SharingListResponse,
-  SiteAdmin,
 } from './adminServiceHelpers';
 
 const adminServiceClient = axios.create({
@@ -71,13 +71,13 @@ export const updateSharingList = async (
   }
 };
 
-export const getSiteList = async (): Promise<SiteAdmin[]> => {
-  const response = await adminServiceClient.get<SiteAdmin[]>('/api/site/list');
+export const getSiteList = async (): Promise<AdminSiteDTO[]> => {
+  const response = await adminServiceClient.get<AdminSiteDTO[]>('/api/site/list');
   return response.data;
 };
 
-export const getSite = async (siteId: number): Promise<SiteAdmin> => {
-  const response = await adminServiceClient.get<SiteAdmin>(`/api/site/${siteId}`);
+export const getSite = async (siteId: number): Promise<AdminSiteDTO> => {
+  const response = await adminServiceClient.get<AdminSiteDTO>(`/api/site/${siteId}`);
   return response.data;
 };
 
@@ -113,7 +113,7 @@ export const updateApiKeyRoles = async (contact: string, apiRoles: string[]): Pr
   });
 };
 
-export const getVisibleSiteList = async (): Promise<SiteAdmin[]> => {
+export const getVisibleSiteList = async (): Promise<AdminSiteDTO[]> => {
   const siteList = await getSiteList();
   return siteList.filter((x) => x.visible !== false);
 };

--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -22,7 +22,7 @@ export const ClientRolesWithDescriptions: Record<AvailableClientRole, string> = 
   MAPPER: 'Mapper',
   ID_READER: 'ID Reader',
 };
-export type SiteAdmin = {
+export type AdminSiteDTO = {
   id: number;
   name: string;
   enabled: boolean;

--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -22,7 +22,7 @@ export const ClientRolesWithDescriptions: Record<AvailableClientRole, string> = 
   MAPPER: 'Mapper',
   ID_READER: 'ID Reader',
 };
-export type SiteDTO = {
+export type SiteAdmin = {
   id: number;
   name: string;
   enabled: boolean;

--- a/src/api/tests/siteConvertingHelpers.spec.ts
+++ b/src/api/tests/siteConvertingHelpers.spec.ts
@@ -4,7 +4,7 @@ import {
   convertSiteToSharingSiteDTO,
   mapClientTypeToParticipantType,
 } from '../helpers/siteConvertingHelpers';
-import { ClientType, SiteDTO } from '../services/adminServiceHelpers';
+import { ClientType, SiteAdmin } from '../services/adminServiceHelpers';
 
 describe('Sharing Permission Helper Tests', () => {
   const participantTypes = [
@@ -59,7 +59,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteDTO;
+      } as SiteAdmin;
       const convertedType = convertSiteToSharingSiteDTO(site, []);
       expect(convertedType).toEqual({
         name: 'Test Site',
@@ -78,7 +78,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteDTO;
+      } as SiteAdmin;
       const participant = {
         id: 100,
         name: 'Participant Name',
@@ -111,7 +111,7 @@ describe('Sharing Permission Helper Tests', () => {
         // eslint-disable-next-line camelcase
         client_count: 1,
         visible: true,
-      } as SiteDTO;
+      } as SiteAdmin;
       expect(canBeSharedWith(site)).toBe(true);
     });
 
@@ -124,7 +124,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteDTO;
+      } as SiteAdmin;
       expect(canBeSharedWith(site)).toBe(true);
     });
 
@@ -137,7 +137,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteDTO;
+      } as SiteAdmin;
       expect(canBeSharedWith(site)).toBe(false);
     });
 
@@ -150,7 +150,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['DSP'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteDTO;
+      } as SiteAdmin;
       expect(canBeSharedWith(site)).toBe(false);
     });
   });

--- a/src/api/tests/siteConvertingHelpers.spec.ts
+++ b/src/api/tests/siteConvertingHelpers.spec.ts
@@ -4,7 +4,7 @@ import {
   convertSiteToSharingSiteDTO,
   mapClientTypeToParticipantType,
 } from '../helpers/siteConvertingHelpers';
-import { ClientType, SiteAdmin } from '../services/adminServiceHelpers';
+import { AdminSiteDTO, ClientType } from '../services/adminServiceHelpers';
 
 describe('Sharing Permission Helper Tests', () => {
   const participantTypes = [
@@ -59,7 +59,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteAdmin;
+      } as AdminSiteDTO;
       const convertedType = convertSiteToSharingSiteDTO(site, []);
       expect(convertedType).toEqual({
         name: 'Test Site',
@@ -78,7 +78,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteAdmin;
+      } as AdminSiteDTO;
       const participant = {
         id: 100,
         name: 'Participant Name',
@@ -111,7 +111,7 @@ describe('Sharing Permission Helper Tests', () => {
         // eslint-disable-next-line camelcase
         client_count: 1,
         visible: true,
-      } as SiteAdmin;
+      } as AdminSiteDTO;
       expect(canBeSharedWith(site)).toBe(true);
     });
 
@@ -124,7 +124,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteAdmin;
+      } as AdminSiteDTO;
       expect(canBeSharedWith(site)).toBe(true);
     });
 
@@ -137,7 +137,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['PUBLISHER'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteAdmin;
+      } as AdminSiteDTO;
       expect(canBeSharedWith(site)).toBe(false);
     });
 
@@ -150,7 +150,7 @@ describe('Sharing Permission Helper Tests', () => {
         clientTypes: ['DSP'],
         // eslint-disable-next-line camelcase
         client_count: 1,
-      } as SiteAdmin;
+      } as AdminSiteDTO;
       expect(canBeSharedWith(site)).toBe(false);
     });
   });

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import Fuse from 'fuse.js';
 
-import { SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
 import { HighlightedResult } from './ParticipantApprovalForm';
 
 const createResult = (text: string, indices: [number, number][]) => {
-  const result: Fuse.FuseResult<SiteDTO> = {
+  const result: Fuse.FuseResult<SiteAdmin> = {
     item: {
       name: text,
       id: 1,

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import Fuse from 'fuse.js';
 
-import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { AdminSiteDTO } from '../../../api/services/adminServiceHelpers';
 import { HighlightedResult } from './ParticipantApprovalForm';
 
 const createResult = (text: string, indices: [number, number][]) => {
-  const result: Fuse.FuseResult<SiteAdmin> = {
+  const result: Fuse.FuseResult<AdminSiteDTO> = {
     item: {
       name: text,
       id: 1,

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -6,7 +6,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { ParticipantRequestDTO } from '../../../api/routers/participantsRouter';
-import { SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { useSiteList } from '../../services/site';
 import { CheckboxInput } from '../Input/CheckboxInput';
@@ -45,7 +45,7 @@ const getSpans = (matches: [number, number][], totalLength: number) => {
 };
 
 type HighlightedResultProps = {
-  result: Fuse.FuseResult<SiteDTO>;
+  result: Fuse.FuseResult<SiteAdmin>;
 };
 export function HighlightedResult({ result }: HighlightedResultProps) {
   const text = `${result.item.name} (Site ID ${result.item.id})`;
@@ -82,9 +82,9 @@ function ParticipantApprovalForm({
         : null,
     [sites]
   );
-  const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<SiteDTO>[]>();
+  const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<SiteAdmin>[]>();
   const [searchText, setSearchText] = useState(participant.name);
-  const [selectedSite, setSelectedSite] = useState<SiteDTO>();
+  const [selectedSite, setSelectedSite] = useState<SiteAdmin>();
 
   useEffect(() => {
     setSiteSearchResults(fuse?.search(searchText ?? participant.name));
@@ -99,7 +99,7 @@ function ParticipantApprovalForm({
     await onApprove(data);
   };
 
-  const onSiteClick = (site: SiteDTO) => {
+  const onSiteClick = (site: SiteAdmin) => {
     setValue('siteId', site.id);
     setSelectedSite(site);
   };

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -6,7 +6,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { ParticipantRequestDTO } from '../../../api/routers/participantsRouter';
-import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { AdminSiteDTO } from '../../../api/services/adminServiceHelpers';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { useSiteList } from '../../services/site';
 import { CheckboxInput } from '../Input/CheckboxInput';
@@ -45,7 +45,7 @@ const getSpans = (matches: [number, number][], totalLength: number) => {
 };
 
 type HighlightedResultProps = {
-  result: Fuse.FuseResult<SiteAdmin>;
+  result: Fuse.FuseResult<AdminSiteDTO>;
 };
 export function HighlightedResult({ result }: HighlightedResultProps) {
   const text = `${result.item.name} (Site ID ${result.item.id})`;
@@ -82,9 +82,9 @@ function ParticipantApprovalForm({
         : null,
     [sites]
   );
-  const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<SiteAdmin>[]>();
+  const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<AdminSiteDTO>[]>();
   const [searchText, setSearchText] = useState(participant.name);
-  const [selectedSite, setSelectedSite] = useState<SiteAdmin>();
+  const [selectedSite, setSelectedSite] = useState<AdminSiteDTO>();
 
   useEffect(() => {
     setSiteSearchResults(fuse?.search(searchText ?? participant.name));
@@ -99,7 +99,7 @@ function ParticipantApprovalForm({
     await onApprove(data);
   };
 
-  const onSiteClick = (site: SiteAdmin) => {
+  const onSiteClick = (site: AdminSiteDTO) => {
     setValue('siteId', site.id);
     setSelectedSite(site);
   };

--- a/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
 import { UserRole } from '../../../api/entities/User';
-import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { AdminSiteDTO } from '../../../api/services/adminServiceHelpers';
 import { TestSiteListProvider } from '../../services/site';
 import ParticipantApprovalForm from './ParticipantApprovalForm';
 
@@ -11,7 +11,7 @@ export default {
   component: ParticipantApprovalForm,
 } as ComponentMeta<typeof ParticipantApprovalForm>;
 
-const response: SiteAdmin[] = [
+const response: AdminSiteDTO[] = [
   {
     id: 2,
     name: 'Test Site',

--- a/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
 import { UserRole } from '../../../api/entities/User';
-import { SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
 import { TestSiteListProvider } from '../../services/site';
 import ParticipantApprovalForm from './ParticipantApprovalForm';
 
@@ -11,7 +11,7 @@ export default {
   component: ParticipantApprovalForm,
 } as ComponentMeta<typeof ParticipantApprovalForm>;
 
-const response: SiteDTO[] = [
+const response: SiteAdmin[] = [
   {
     id: 2,
     name: 'Test Site',

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -1,5 +1,5 @@
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
-import { ClientTypeDescriptions, SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { AdminSiteDTO, ClientTypeDescriptions } from '../../../api/services/adminServiceHelpers';
 import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 import {
@@ -10,7 +10,7 @@ import {
 
 import './ParticipantItem.scss';
 
-function getParticipantTypes(siteTypes?: SiteAdmin['clientTypes']) {
+function getParticipantTypes(siteTypes?: AdminSiteDTO['clientTypes']) {
   if (!siteTypes) return null;
   return siteTypes.map((pt) => (
     <div className='participant-type-label' key={pt}>

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -1,5 +1,5 @@
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
-import { ClientTypeDescriptions, SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { ClientTypeDescriptions, SiteAdmin } from '../../../api/services/adminServiceHelpers';
 import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 import {
@@ -10,7 +10,7 @@ import {
 
 import './ParticipantItem.scss';
 
-function getParticipantTypes(siteTypes?: SiteDTO['clientTypes']) {
+function getParticipantTypes(siteTypes?: SiteAdmin['clientTypes']) {
   if (!siteTypes) return null;
   return siteTypes.map((pt) => (
     <div className='participant-type-label' key={pt}>

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -5,7 +5,7 @@ import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { ParticipantDTO } from '../../api/entities/Participant';
 import { ParticipantTypeDTO } from '../../api/entities/ParticipantType';
 import { ParticipantRequestDTO } from '../../api/routers/participantsRouter';
-import { SiteAdmin } from '../../api/services/adminServiceHelpers';
+import { AdminSiteDTO } from '../../api/services/adminServiceHelpers';
 import { Loading } from '../components/Core/Loading';
 import { ApprovedParticipantsTable } from '../components/ParticipantManagement/ApprovedParticipantsTable';
 import { ParticipantRequestsTable } from '../components/ParticipantManagement/ParticipantRequestsTable';
@@ -30,7 +30,7 @@ function ManageParticipants() {
       ParticipantDTO[],
       ParticipantTypeDTO[],
       ApiRoleDTO[],
-      SiteAdmin[]
+      AdminSiteDTO[]
     ];
   };
 

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -5,7 +5,7 @@ import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { ParticipantDTO } from '../../api/entities/Participant';
 import { ParticipantTypeDTO } from '../../api/entities/ParticipantType';
 import { ParticipantRequestDTO } from '../../api/routers/participantsRouter';
-import { SiteDTO } from '../../api/services/adminServiceHelpers';
+import { SiteAdmin } from '../../api/services/adminServiceHelpers';
 import { Loading } from '../components/Core/Loading';
 import { ApprovedParticipantsTable } from '../components/ParticipantManagement/ApprovedParticipantsTable';
 import { ParticipantRequestsTable } from '../components/ParticipantManagement/ParticipantRequestsTable';
@@ -30,7 +30,7 @@ function ManageParticipants() {
       ParticipantDTO[],
       ParticipantTypeDTO[],
       ApiRoleDTO[],
-      SiteDTO[]
+      SiteAdmin[]
     ];
   };
 

--- a/src/web/services/site.ts
+++ b/src/web/services/site.ts
@@ -1,19 +1,19 @@
 import axios from 'axios';
 
 import { SharingSiteDTO } from '../../api/helpers/siteConvertingHelpers';
-import { SiteDTO } from '../../api/services/adminServiceHelpers';
+import { SiteAdmin } from '../../api/services/adminServiceHelpers';
 import { createSwrHook } from './SwrHelpers';
 
 const unattachedEndpoint = `/sites/unattached/`;
 const fetcher = async () => {
   try {
-    const result = await axios.get<SiteDTO[]>(unattachedEndpoint);
+    const result = await axios.get<SiteAdmin[]>(unattachedEndpoint);
     return result.data;
   } catch {
     return [];
   }
 };
-const swrHook = createSwrHook<SiteDTO[]>(unattachedEndpoint, fetcher);
+const swrHook = createSwrHook<SiteAdmin[]>(unattachedEndpoint, fetcher);
 export const useSiteList = swrHook.hookFunction;
 export const preloadSiteList = swrHook.preloadFunction;
 export const TestSiteListProvider = swrHook.TestDataProvider;

--- a/src/web/services/site.ts
+++ b/src/web/services/site.ts
@@ -1,19 +1,19 @@
 import axios from 'axios';
 
 import { SharingSiteDTO } from '../../api/helpers/siteConvertingHelpers';
-import { SiteAdmin } from '../../api/services/adminServiceHelpers';
+import { AdminSiteDTO } from '../../api/services/adminServiceHelpers';
 import { createSwrHook } from './SwrHelpers';
 
 const unattachedEndpoint = `/sites/unattached/`;
 const fetcher = async () => {
   try {
-    const result = await axios.get<SiteAdmin[]>(unattachedEndpoint);
+    const result = await axios.get<AdminSiteDTO[]>(unattachedEndpoint);
     return result.data;
   } catch {
     return [];
   }
 };
-const swrHook = createSwrHook<SiteAdmin[]>(unattachedEndpoint, fetcher);
+const swrHook = createSwrHook<AdminSiteDTO[]>(unattachedEndpoint, fetcher);
 export const useSiteList = swrHook.hookFunction;
 export const preloadSiteList = swrHook.preloadFunction;
 export const TestSiteListProvider = swrHook.TestDataProvider;


### PR DESCRIPTION
SiteDTO is only sent to the portal in one place. I am changing the option and as such aim to rename this to a more relevant name