### PR TITLE
Prefill API Roles when approving a participant

### DIFF
--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -17,7 +17,9 @@ export function createSitesRouter() {
     const allSitesPromise = getSiteList();
     const attachedSitesPromise = getAttachedSiteIDs();
     const [allSites, attachedSites] = await Promise.all([allSitesPromise, attachedSitesPromise]);
-    const siteDTOs = mapAdminSitesToSiteDTOs(allSites.filter((s) => !attachedSites.includes(s.id)));
+    const siteDTOs = await mapAdminSitesToSiteDTOs(
+      allSites.filter((s) => !attachedSites.includes(s.id))
+    );
     return res.status(200).json(siteDTOs);
   });
 

--- a/src/api/routers/sitesRouter.ts
+++ b/src/api/routers/sitesRouter.ts
@@ -7,7 +7,7 @@ import {
 } from '../helpers/siteConvertingHelpers';
 import { isApproverCheck } from '../middleware/approversMiddleware';
 import { getSiteList, getVisibleSiteList } from '../services/adminServiceClient';
-import { SiteAdmin } from '../services/adminServiceHelpers';
+import { mapAdminSitesToSiteDTOs, SiteAdmin } from '../services/adminServiceHelpers';
 import { getAttachedSiteIDs, getParticipantsBySiteIds } from '../services/participantsService';
 
 export function createSitesRouter() {
@@ -17,7 +17,8 @@ export function createSitesRouter() {
     const allSitesPromise = getSiteList();
     const attachedSitesPromise = getAttachedSiteIDs();
     const [allSites, attachedSites] = await Promise.all([allSitesPromise, attachedSitesPromise]);
-    return res.status(200).json(allSites.filter((s) => !attachedSites.includes(s.id)));
+    const siteDTOs = mapAdminSitesToSiteDTOs(allSites.filter((s) => !attachedSites.includes(s.id)));
+    return res.status(200).json(siteDTOs);
   });
 
   sitesRouter.get('/available', async (_req, res) => {

--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -22,6 +22,7 @@ export const ClientRolesWithDescriptions: Record<AvailableClientRole, string> = 
   MAPPER: 'Mapper',
   ID_READER: 'ID Reader',
 };
+
 export type SiteAdmin = {
   id: number;
   name: string;
@@ -31,6 +32,8 @@ export type SiteAdmin = {
   client_count: number;
   visible: boolean;
 };
+
+export type SiteDTO = Omit<SiteAdmin, 'roles'> & { apiRoles: ApiRoleDTO[] };
 
 export type SharingListResponse = {
   allowed_sites: number[];

--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -122,13 +122,19 @@ function mapAdminRolesToApiRoleDTOs(adminRoles: string[], apiRoleMap: Map<String
   });
 }
 
-export async function mapAdminApiKeysToApiKeyDTOs(
-  adminApiKeys: ApiKeyAdmin[]
-): Promise<ApiKeyDTO[]> {
+async function loadLoadRoleMaps(): Promise<Map<String, ApiRoleDTO>> {
   const apiRoleList = await ApiRole.query();
   const apiRoleMap = new Map<String, ApiRoleDTO>(
     apiRoleList.map((apiRole) => [apiRole.roleName, apiRole as ApiRoleDTO])
   );
+
+  return apiRoleMap;
+}
+
+export async function mapAdminApiKeysToApiKeyDTOs(
+  adminApiKeys: ApiKeyAdmin[]
+): Promise<ApiKeyDTO[]> {
+  const apiRoleMap = await loadLoadRoleMaps();
 
   return adminApiKeys.map((adminKey) => {
     const roles = mapAdminRolesToApiRoleDTOs(adminKey.roles.split(','), apiRoleMap);
@@ -142,6 +148,24 @@ export async function mapAdminApiKeysToApiKeyDTOs(
       site_id: adminKey.site_id,
       roles,
       service_id: adminKey.service_id,
+    };
+  });
+}
+
+export async function mapAdminSitesToSiteDTOs(adminSites: SiteAdmin[]): Promise<SiteDTO[]> {
+  const apiRoleMap = await loadLoadRoleMaps();
+
+  return adminSites.map((adminSite) => {
+    const apiRoles = mapAdminRolesToApiRoleDTOs(adminSite.roles, apiRoleMap);
+
+    return {
+      id: adminSite.id,
+      client_count: adminSite.client_count,
+      enabled: adminSite.enabled,
+      name: adminSite.name,
+      visible: adminSite.visible,
+      clientTypes: adminSite.clientTypes,
+      apiRoles,
     };
   });
 }

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
@@ -1,16 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import Fuse from 'fuse.js';
 
-import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { SiteAdmin, SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { HighlightedResult } from './ParticipantApprovalForm';
 
 const createResult = (text: string, indices: [number, number][]) => {
-  const result: Fuse.FuseResult<SiteAdmin> = {
+  const result: Fuse.FuseResult<SiteDTO> = {
     item: {
       name: text,
       id: 1,
       enabled: true,
-      roles: [],
+      apiRoles: [],
       clientTypes: [],
       // eslint-disable-next-line camelcase
       client_count: 1,

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import Fuse from 'fuse.js';
 
-import { SiteAdmin, SiteDTO } from '../../../api/services/adminServiceHelpers';
+import {  SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { HighlightedResult } from './ParticipantApprovalForm';
 
 const createResult = (text: string, indices: [number, number][]) => {

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -6,7 +6,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { ParticipantRequestDTO } from '../../../api/routers/participantsRouter';
-import { SiteAdmin, SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { useSiteList } from '../../services/site';
 import { CheckboxInput } from '../Input/CheckboxInput';
@@ -102,6 +102,12 @@ function ParticipantApprovalForm({
   const onSiteClick = (site: SiteDTO) => {
     setValue('siteId', site.id);
     setSelectedSite(site);
+
+    const siteApiRoleIds = site.apiRoles.map((apiRole) => apiRole.id);
+    setValue(
+      'apiRoles',
+      apiRoles.filter((apiRole) => siteApiRoleIds.includes(apiRole.id)).map((apiRole) => apiRole.id)
+    );
   };
 
   const onSearchInputChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -6,7 +6,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { ParticipantRequestDTO } from '../../../api/routers/participantsRouter';
-import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { SiteAdmin, SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { useSiteList } from '../../services/site';
 import { CheckboxInput } from '../Input/CheckboxInput';
@@ -45,7 +45,7 @@ const getSpans = (matches: [number, number][], totalLength: number) => {
 };
 
 type HighlightedResultProps = {
-  result: Fuse.FuseResult<SiteAdmin>;
+  result: Fuse.FuseResult<SiteDTO>;
 };
 export function HighlightedResult({ result }: HighlightedResultProps) {
   const text = `${result.item.name} (Site ID ${result.item.id})`;
@@ -82,9 +82,9 @@ function ParticipantApprovalForm({
         : null,
     [sites]
   );
-  const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<SiteAdmin>[]>();
+  const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<SiteDTO>[]>();
   const [searchText, setSearchText] = useState(participant.name);
-  const [selectedSite, setSelectedSite] = useState<SiteAdmin>();
+  const [selectedSite, setSelectedSite] = useState<SiteDTO>();
 
   useEffect(() => {
     setSiteSearchResults(fuse?.search(searchText ?? participant.name));
@@ -99,7 +99,7 @@ function ParticipantApprovalForm({
     await onApprove(data);
   };
 
-  const onSiteClick = (site: SiteAdmin) => {
+  const onSiteClick = (site: SiteDTO) => {
     setValue('siteId', site.id);
     setSelectedSite(site);
   };

--- a/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
 import { UserRole } from '../../../api/entities/User';
-import { SiteAdmin } from '../../../api/services/adminServiceHelpers';
+import { SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { TestSiteListProvider } from '../../services/site';
 import ParticipantApprovalForm from './ParticipantApprovalForm';
 
@@ -11,12 +11,15 @@ export default {
   component: ParticipantApprovalForm,
 } as ComponentMeta<typeof ParticipantApprovalForm>;
 
-const response: SiteAdmin[] = [
+const response: SiteDTO[] = [
   {
     id: 2,
     name: 'Test Site',
     enabled: true,
-    roles: ['SHARER'],
+    apiRoles: [
+      { id: 1, roleName: 'Role1', externalName: 'Role 1' },
+      { id: 2, roleName: 'Role2', externalName: 'Role 2' },
+    ],
     clientTypes: ['PUBLISHER'],
     // eslint-disable-next-line camelcase
     client_count: 1,
@@ -26,7 +29,7 @@ const response: SiteAdmin[] = [
     id: 4,
     name: 'Test Four',
     enabled: true,
-    roles: ['SHARER'],
+    apiRoles: [{ id: 1, roleName: 'Role1', externalName: 'Role 1' }],
     clientTypes: ['PUBLISHER'],
     // eslint-disable-next-line camelcase
     client_count: 1,

--- a/src/web/services/site.ts
+++ b/src/web/services/site.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { SharingSiteDTO } from '../../api/helpers/siteConvertingHelpers';
-import { SiteAdmin, SiteDTO } from '../../api/services/adminServiceHelpers';
+import { SiteDTO } from '../../api/services/adminServiceHelpers';
 import { createSwrHook } from './SwrHelpers';
 
 const unattachedEndpoint = `/sites/unattached/`;

--- a/src/web/services/site.ts
+++ b/src/web/services/site.ts
@@ -1,19 +1,19 @@
 import axios from 'axios';
 
 import { SharingSiteDTO } from '../../api/helpers/siteConvertingHelpers';
-import { SiteAdmin } from '../../api/services/adminServiceHelpers';
+import { SiteAdmin, SiteDTO } from '../../api/services/adminServiceHelpers';
 import { createSwrHook } from './SwrHelpers';
 
 const unattachedEndpoint = `/sites/unattached/`;
 const fetcher = async () => {
   try {
-    const result = await axios.get<SiteAdmin[]>(unattachedEndpoint);
+    const result = await axios.get<SiteDTO[]>(unattachedEndpoint);
     return result.data;
   } catch {
     return [];
   }
 };
-const swrHook = createSwrHook<SiteAdmin[]>(unattachedEndpoint, fetcher);
+const swrHook = createSwrHook<SiteDTO[]>(unattachedEndpoint, fetcher);
 export const useSiteList = swrHook.hookFunction;
 export const preloadSiteList = swrHook.preloadFunction;
 export const TestSiteListProvider = swrHook.TestDataProvider;


### PR DESCRIPTION
When approving a new participant, it will pull apiRoles from the linked site and prefill the form with these roles
![chrome_pAfY8z4TWa](https://github.com/IABTechLab/uid2-self-serve-portal/assets/152250444/4d131353-d1b0-428b-8197-0b939c009bee)
