### PR TITLE
Omit participants from sharing table if they're only included by type and don't have SHARER.

### DIFF
--- a/src/web/components/SharingPermission/SharingPermissionsTable.spec.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.spec.tsx
@@ -29,4 +29,15 @@ describe('SharingPermissionsTable', () => {
 
     expect(screen.getByText(/Delete Permissions/i)).toBeInTheDocument();
   });
+
+  it('shows participants included by site ID even if they are not a valid sharing target', async () => {
+    render(<SharedWithParticipants />);
+    expect(await screen.findByText('No SHARER and explicitly included')).toBeInTheDocument();
+  });
+
+  it('does not show participants that are included by group if they are not a valid sharing target', async () => {
+    render(<SharedWithParticipants />);
+    await screen.findByText('Site 1');
+    expect(screen.queryByText('No SHARER and not explicitly included')).not.toBeInTheDocument();
+  });
 });

--- a/src/web/components/SharingPermission/SharingPermissionsTable.stories.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.stories.tsx
@@ -46,6 +46,18 @@ const response: SharingSiteDTO[] = [
     id: 15,
     canBeSharedWith: true,
   },
+  {
+    name: 'No SHARER and not explicitly included',
+    clientTypes: ['DATA_PROVIDER'],
+    id: 16,
+    canBeSharedWith: false,
+  },
+  {
+    name: 'No SHARER and explicitly included',
+    clientTypes: ['DATA_PROVIDER'],
+    id: 17,
+    canBeSharedWith: false,
+  },
 ];
 const Template: ComponentStory<typeof SharingPermissionsTable> = (args) => (
   <TestAllSitesListProvider response={response}>
@@ -55,7 +67,7 @@ const Template: ComponentStory<typeof SharingPermissionsTable> = (args) => (
 
 export const SharedWithParticipants = Template.bind({});
 SharedWithParticipants.args = {
-  sharedSiteIds: [10, 11, 12, 14, 15],
+  sharedSiteIds: [10, 11, 12, 14, 15, 17],
   sharedTypes: ['DSP', 'DATA_PROVIDER'],
   onDeleteSharingPermission: () => Promise.resolve(),
 };

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -230,6 +230,7 @@ export function SharingPermissionsTable({
   const { sites, isLoading } = useAllSitesList();
   const getSharingParticipants: () => SharingSiteWithSource[] = () => {
     return sites!
+      .filter((p) => p.canBeSharedWith || sharedSiteIds.includes(p.id))
       .map((p) => {
         const maybeManualArray: (typeof MANUALLY_ADDED)[] = sharedSiteIds.includes(p.id)
           ? [MANUALLY_ADDED]


### PR DESCRIPTION
Filter out participants from the sharing table if they are only included by type and don't have SHARER.
Add tests for the edge cases around SHARER.