### PR TITLE
Disable new workflow that isn't working.

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -1,57 +1,57 @@
-name: Release Self Serve Portal Image
-run-name: ${{ inputs.release_type == 'Snapshot' && 'Publish Pre-release' || format('Release {0}', inputs.release_type)}} Self Serve Portal Image by @${{ github.actor }}  
-on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        type: choice
-        description: The type of release
-        options:
-        - Major
-        - Minor
-        - Patch
-        - Snapshot
-        required: true
+# name: Release Self Serve Portal Image
+# run-name: ${{ inputs.release_type == 'Snapshot' && 'Publish Pre-release' || format('Release {0}', inputs.release_type)}} Self Serve Portal Image by @${{ github.actor }}
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       release_type:
+#         type: choice
+#         description: The type of release
+#         options:
+#         - Major
+#         - Minor
+#         - Patch
+#         - Snapshot
+#         required: true
 
-jobs:
-  incrementVersionNumber:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v2
-    with:
-      release_type: ${{ inputs.release_type }}
-    secrets: inherit
+# jobs:
+#   incrementVersionNumber:
+#     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v2
+#     with:
+#       release_type: ${{ inputs.release_type }}
+#     secrets: inherit
 
-  publishForApiUi:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v2
-    needs: incrementVersionNumber
-    with: 
-      new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
-      image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
-      release_type: ${{ inputs.release_type }}
-      docker_file: Dockerfile_ssportal
-      docker_image_name: iabtechlab/uid2-ssportal
-      docker_registry: ghcr.io
-    secrets: inherit
+#   publishForApiUi:
+#     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v2
+#     needs: incrementVersionNumber
+#     with:
+#       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
+#       image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
+#       release_type: ${{ inputs.release_type }}
+#       docker_file: Dockerfile_ssportal
+#       docker_image_name: iabtechlab/uid2-ssportal
+#       docker_registry: ghcr.io
+#     secrets: inherit
 
-  publishForDBMigration:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v2
-    needs: incrementVersionNumber
-    with: 
-      new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
-      image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
-      release_type: ${{ inputs.release_type }}
-      docker_file: Dockerfile_ssportal_migration
-      docker_image_name: iabtechlab/uid2-ssportal-migration
-      docker_registry: ghcr.io
-    secrets: inherit
+#   publishForDBMigration:
+#     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v2
+#     needs: incrementVersionNumber
+#     with:
+#       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
+#       image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
+#       release_type: ${{ inputs.release_type }}
+#       docker_file: Dockerfile_ssportal_migration
+#       docker_image_name: iabtechlab/uid2-ssportal-migration
+#       docker_registry: ghcr.io
+#     secrets: inherit
 
-  publishForKeycloak:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v2
-    needs: incrementVersionNumber
-    with: 
-      new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
-      image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
-      release_type: ${{ inputs.release_type }}
-      docker_file: Dockerfile_keycloak
-      docker_image_name: iabtechlab/uid2-ssportal-keycloak
-      docker_registry: ghcr.io
-    secrets: inherit
+#   publishForKeycloak:
+#     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v2
+#     needs: incrementVersionNumber
+#     with:
+#       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
+#       image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
+#       release_type: ${{ inputs.release_type }}
+#       docker_file: Dockerfile_keycloak
+#       docker_image_name: iabtechlab/uid2-ssportal-keycloak
+#       docker_registry: ghcr.io
+#     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uid2-ssportal",
-  "version": "0.10.2-0673698d5c",
+  "version": "0.10.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/version.json
+++ b/version.json
@@ -1,1 +1,0 @@
-{ "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json", "version": "0.10.2", "publicReleaseRefSpec": [ "^refs/heads/master$", "^refs/heads/v\\d+(?:\\.\\d+)?$" ], "cloudBuild": { "setVersionVariables": true, "buildNumber": { "enabled": true, "includeCommitId": { "when": "always" } } } }


### PR DESCRIPTION
Remove version.json as it's not relevant for the existing workflow and might introduce inconsistencies in the version number. Bump the version.