### PR TITLE
Restrict API Role approval endpoint

### DIFF
--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -142,7 +142,7 @@ export const updateParticipantApiRolesWithTransaction = async (
       'id',
       apiRoleIds.map((role) => role.id)
     )
-    .where('disabled', true);
+    .where('disabled', false);
 
   if (apiRoles.length > 0) {
     await participant.$relatedQuery('apiRoles', trx).relate(apiRoles);

--- a/src/web/components/ApiKeyManagement/KeyItem.tsx
+++ b/src/web/components/ApiKeyManagement/KeyItem.tsx
@@ -29,28 +29,30 @@ function KeyItem({ apiKey: apiKeyInitial, onEdit, onDisable, availableRoles }: K
         <ApiRolesCell apiRoles={apiKey.roles} />
       </td>
       <td>{formatUnixDate(apiKey.created)}</td>
-      <td>
-        <KeyEditDialog
-          apiKey={apiKey}
-          onEdit={onEdit}
-          triggerButton={
-            <button type='button' className='transparent-button'>
-              <FontAwesomeIcon icon='pencil' />
-            </button>
-          }
-          availableRoles={availableRoles}
-          setApiKey={setApiKey}
-        />
-        <KeyDisableDialog
-          apiKey={apiKey}
-          onDisable={onDisable}
-          triggerButton={
-            <button type='button' className='transparent-button'>
-              <FontAwesomeIcon icon='trash-can' />
-            </button>
-          }
-        />
-      </td>
+      {availableRoles.length > 0 && (
+        <td>
+          <KeyEditDialog
+            apiKey={apiKey}
+            onEdit={onEdit}
+            triggerButton={
+              <button type='button' className='transparent-button'>
+                <FontAwesomeIcon icon='pencil' />
+              </button>
+            }
+            availableRoles={availableRoles}
+            setApiKey={setApiKey}
+          />
+          <KeyDisableDialog
+            apiKey={apiKey}
+            onDisable={onDisable}
+            triggerButton={
+              <button type='button' className='transparent-button'>
+                <FontAwesomeIcon icon='trash-can' />
+              </button>
+            }
+          />
+        </td>
+      )}
     </tr>
   );
 }

--- a/src/web/components/ApiKeyManagement/KeyTable.tsx
+++ b/src/web/components/ApiKeyManagement/KeyTable.tsx
@@ -41,7 +41,7 @@ function KeyTable({ apiKeys, onKeyEdit, onKeyDisable, availableRoles }: KeyTable
             </th>
             <th>Roles</th>
             <th>Created</th>
-            <th>Action</th>
+            {availableRoles.length > 0 && <th>Action</th>}
           </tr>
         </thead>
         <tbody>

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -168,7 +168,6 @@ function ParticipantApprovalForm({
             <CheckboxInput
               inputName='apiRoles'
               label='API Roles'
-              rules={{ required: 'Please specify the API Roles' }}
               options={apiRoles.map((p) => ({
                 optionLabel: p.externalName,
                 optionToolTip: p.roleName,

--- a/src/web/components/ParticipantManagement/UpdateParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/UpdateParticipantDialog.tsx
@@ -48,7 +48,6 @@ function UpdateParticipantDialog({
         <CheckboxInput
           inputName='apiRoles'
           label='API Roles'
-          rules={{ required: 'Please specify the API Roles' }}
           options={apiRoles.map((p) => ({
             optionLabel: p.externalName,
             optionToolTip: p.roleName,


### PR DESCRIPTION
Added check to endpoint so only adds  enabled api roles when a participant is approved/edited.

Also removed restriction on no API Roles as this provides a way to stop API key management by a participant