### PR TITLE
Fix styling for Your Sharing Permissions checkbox + copy for keys

### DIFF
--- a/src/web/components/SharingPermission/ParticipantItem.scss
+++ b/src/web/components/SharingPermission/ParticipantItem.scss
@@ -6,6 +6,10 @@
   .tooltip {
     padding-right: 16px;
   }
+
+  .tristate-checkbox {
+    margin-right: 16px;
+  }
 }
 
 .participant-type-label {

--- a/src/web/screens/apiKeyManagement.tsx
+++ b/src/web/screens/apiKeyManagement.tsx
@@ -57,7 +57,7 @@ function ApiKeyManagement() {
     try {
       await DisableApiKey(apiKey);
       reloader.revalidate();
-      SuccessToast('Your key has been disabled');
+      SuccessToast('Your key has been deleted');
     } catch (e) {
       handleErrorToast(e);
     }


### PR DESCRIPTION
**Styling for Your Sharing Permissions table**
Before

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/b5b338ea-fe83-4081-9ef8-ea2538191be5)

After

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/d9e24e14-b40b-4a75-9a77-66f8f9813d91)

**Toast when deleting a key on API Key Management screen**

Before

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/49c60b8a-0daa-47a4-ab94-ca49a9f9fafb)

After

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/6ccfe666-5442-4939-8a8c-8acb9448eb4e)



