### PR TITLE
Fix styling for API Permissions link

### DIFF
--- a/src/web/screens/apiKeyManagement.tsx
+++ b/src/web/screens/apiKeyManagement.tsx
@@ -70,6 +70,7 @@ function ApiKeyManagement() {
         View and manage your API keys. For more information, see{' '}
         <a
           target='_blank'
+          className='outside-link'
           href='https://unifiedid.com/docs/getting-started/gs-permissions'
           rel='noreferrer'
         >


### PR DESCRIPTION
Every other outside link (`target='_blank'`) uses this styling except for `DocumentationCard` which uses unique styling.

Before

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/ce614783-c3d4-450a-b796-1ec78b1a266f)


After

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/63fcf9c6-9517-48ff-933f-ed73070bb24b)
