### PR TITLE
Add LoggerService & inject into UserController

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ docker compose -f docker-compose.yml -f docker-compose.log-stack.yml up
 
 This will spawn 3 additional containers for Promtail, Loki and Grafana.
 
-Once running, log onto the Grafana UI from [here](http://localhost:3101). Use the username `admin` and password `admin`.
+Once running, log onto the Grafana UI from [http://localhost:3101](http://localhost:3101). Use the username `admin` and password `admin`.
 
 Add the Loki datasource in Grafana with the following Loki data-source url: `http://host.docker.internal:3100`. Notes: When adding Loki, if the test query fails, try a query in the **Explore** tab as it may have been added and working anyway. This url should match the value of `SSP_LOKI_HOST` in your `.env` file.
 

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -36,6 +36,7 @@ import makeMetricsApiMiddleware from './middleware/metrics';
 import { createParticipantsRouter } from './routers/participantsRouter';
 import { createSitesRouter } from './routers/sitesRouter';
 import { createUsersRouter } from './routers/usersRouter';
+import { LoggerService } from './services/loggerService';
 import { UserService } from './services/userService';
 
 const BASE_REQUEST_PATH = '/api';
@@ -67,6 +68,7 @@ function bypassHandlerForPaths(middleware: express.Handler, ...paths: BypassPath
 export function configureAndStartApi(useMetrics: boolean = true) {
   const container = new Container();
   container.bind<UserService>(TYPES.UserService).to(UserService);
+  container.bind<LoggerService>(TYPES.LoggerService).to(LoggerService);
   const app = express();
   const routers = {
     rootRouter: express.Router(),

--- a/src/api/constant/types.ts
+++ b/src/api/constant/types.ts
@@ -1,3 +1,4 @@
 export const TYPES = {
   UserService: Symbol.for('UserService'),
+  LoggerService: Symbol.for('LoggerService'),
 };

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -23,12 +23,16 @@ import {
   sendInviteEmail,
   updateUserProfile,
 } from '../services/kcUsersService';
+import { LoggerService } from '../services/loggerService';
 import { DeletedUser, UpdateUserParser, UserService } from '../services/userService';
 import { UserRequest } from '../services/usersService';
 
 @controller('/users')
 export class UserController {
-  constructor(@inject(TYPES.UserService) private userService: UserService) {}
+  constructor(
+    @inject(TYPES.UserService) private userService: UserService,
+    @inject(TYPES.LoggerService) private loggerService: LoggerService
+  ) {}
 
   @httpGet('/current')
   public async getCurrentUser(
@@ -83,7 +87,10 @@ export class UserController {
     @request() req: UserRequest,
     @response() res: Response
   ): Promise<void> {
-    const { infoLogger, errorLogger } = getLoggers();
+    // const { infoLogger, errorLogger } = getLoggers();
+    // const { infoLogger, errorLogger } = this.loggerService.getLoggers();
+    const errorLogger = this.loggerService.getErrorLogger();
+    const infoLogger = this.loggerService.getLogger();
     const traceId = getTraceId(req);
     const kcAdminClient = await getKcAdminClient();
     const user = await queryUsersByEmail(kcAdminClient, req.user?.email || '');

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -88,7 +88,7 @@ export class UserController {
     @response() res: Response
   ): Promise<void> {
     // const { infoLogger, errorLogger } = getLoggers();
-    const { infoLogger, errorLogger } = this.loggerService.getLoggers();
+    const { infoLogger, errorLogger } = this.loggerService.getLoggers(req);
     // const errorLogger = this.loggerService.getErrorLogger();
     // const infoLogger = this.loggerService.getLogger();
     const traceId = getTraceId(req);
@@ -98,8 +98,7 @@ export class UserController {
     const resultLength = user?.length ?? 0;
     if (resultLength < 1) {
       errorLogger.error(
-        `No results received when loading user entry for ${req.user?.email}`,
-        traceId
+        `No results received when loading user entry for ${req.user?.email}`
       );
       res.status(404).json({
         errorHash: traceId,
@@ -108,8 +107,7 @@ export class UserController {
     }
     if (resultLength > 1) {
       errorLogger.error(
-        `Multiple results received when loading user entry for ${req.user?.email}`,
-        traceId
+        `Multiple results received when loading user entry for ${req.user?.email}`
       );
       res.status(500).json({
         errorHash: traceId,
@@ -118,8 +116,7 @@ export class UserController {
     }
 
     infoLogger.info(
-      `Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`,
-      traceId
+      `Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`
     );
     await sendInviteEmail(kcAdminClient, user[0]);
     res.sendStatus(200);

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -106,18 +106,14 @@ export class UserController {
       return;
     }
     if (resultLength > 1) {
-      errorLogger.error(
-        `Multiple results received when loading user entry for ${req.user?.email}`
-      );
+      errorLogger.error(`Multiple results received when loading user entry for ${req.user?.email}`);
       res.status(500).json({
         errorHash: traceId,
       });
       return;
     }
 
-    infoLogger.info(
-      `Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`
-    );
+    infoLogger.info(`Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`);
     await sendInviteEmail(kcAdminClient, user[0]);
     res.sendStatus(200);
   }

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -88,9 +88,9 @@ export class UserController {
     @response() res: Response
   ): Promise<void> {
     // const { infoLogger, errorLogger } = getLoggers();
-    // const { infoLogger, errorLogger } = this.loggerService.getLoggers();
-    const errorLogger = this.loggerService.getErrorLogger();
-    const infoLogger = this.loggerService.getLogger();
+    const { infoLogger, errorLogger } = this.loggerService.getLoggers();
+    // const errorLogger = this.loggerService.getErrorLogger();
+    // const infoLogger = this.loggerService.getLogger();
     const traceId = getTraceId(req);
     const kcAdminClient = await getKcAdminClient();
     const user = await queryUsersByEmail(kcAdminClient, req.user?.email || '');

--- a/src/api/helpers/loggingHelpers.ts
+++ b/src/api/helpers/loggingHelpers.ts
@@ -5,7 +5,7 @@ import LokiTransport from 'winston-loki';
 
 import { SSP_APP_NAME, SSP_IS_DEVELOPMENT, SSP_LOKI_HOST } from '../envars';
 
-const traceFormat = winston.format.printf(({ timestamp, label, level, message, meta }) => {
+export const traceFormat = winston.format.printf(({ timestamp, label, level, message, meta }) => {
   const basicString = `${timestamp} [${label}] ${level}: ${message}`;
   const requestDetails = meta
     ? ` [traceId=${meta.req.headers.traceId ?? ''}] metadata=${JSON.stringify(meta)}`

--- a/src/api/routers/usersRouter.ts
+++ b/src/api/routers/usersRouter.ts
@@ -1,12 +1,13 @@
 import express from 'express';
 
 import { UserController } from '../controllers/userController';
-import {  UserService } from '../services/userService';
+import { LoggerService } from '../services/loggerService';
+import { UserService } from '../services/userService';
 import { enrichCurrentUser, enrichWithUserFromParams } from '../services/usersService';
 
 const createUsersRouter = () => {
   const usersRouter = express.Router();
-  const userController = new UserController(new UserService());
+  const userController = new UserController(new UserService(), new LoggerService());
 
   usersRouter.use('/current', enrichCurrentUser);
   usersRouter.get('/current', userController.getCurrentUser.bind(userController));

--- a/src/api/services/loggerService.ts
+++ b/src/api/services/loggerService.ts
@@ -68,10 +68,23 @@ export class LoggerService {
     ];
   }
 
-  public getLoggers(): { logger: winston.Logger; errorLogger: winston.Logger } {
+  private info(message: string, traceId: string) {
+    this.logger.info(`${message}, [traceId=${traceId}]`);
+  }
+
+  private error(message: string, traceId: string) {
+    this.logger.error(`${message}, [traceId=${traceId}]`);
+  }
+
+  public getLoggers() {
     return {
       logger: this.logger,
-      errorLogger: this.errorLogger,
+      infoLogger: {
+        info: this.info.bind(this),
+      },
+      errorLogger: {
+        error: this.error.bind(this),
+      },
     };
   }
 

--- a/src/api/services/loggerService.ts
+++ b/src/api/services/loggerService.ts
@@ -1,0 +1,85 @@
+import { injectable } from 'inversify';
+import winston from 'winston';
+import LokiTransport from 'winston-loki';
+
+import { SSP_APP_NAME, SSP_IS_DEVELOPMENT, SSP_LOKI_HOST } from '../envars';
+
+const traceFormat = winston.format.printf(({ timestamp, label, level, message, meta }) => {
+  const basicString = `${timestamp} [${label}] ${level}: ${message}`;
+  const requestDetails = meta
+    ? ` [traceId=${meta.req.headers.traceId ?? ''}] metadata=${JSON.stringify(meta)}`
+    : '';
+  return basicString + requestDetails;
+});
+
+@injectable()
+export class LoggerService {
+  private logger: winston.Logger;
+  private errorLogger: winston.Logger;
+
+  constructor() {
+    this.logger = this.createLogger();
+    this.errorLogger = this.createErrorLogger();
+  }
+
+  private createLogger(): winston.Logger {
+    return winston.createLogger({
+      transports: this.getTransports(),
+      format: this.loggerFormat(),
+    });
+  }
+
+  private createErrorLogger(): winston.Logger {
+    return winston.createLogger({
+      transports: this.getTransports(),
+      format: this.errorLoggerFormat(),
+    });
+  }
+
+  private loggerFormat(): winston.Logform.Format {
+    return winston.format.combine(
+      winston.format.label({ label: SSP_APP_NAME }),
+      winston.format.timestamp(),
+      winston.format.json(),
+      traceFormat
+    );
+  }
+
+  private errorLoggerFormat(): winston.Logform.Format {
+    return winston.format.combine(
+      winston.format.errors({ stack: SSP_IS_DEVELOPMENT }), // only show stack in development
+      winston.format.label({ label: SSP_APP_NAME }),
+      winston.format.timestamp(),
+      winston.format.json(),
+      traceFormat
+    );
+  }
+
+  private getTransports(): winston.transport[] {
+    return [
+      new winston.transports.Console(),
+      new LokiTransport({
+        host: SSP_LOKI_HOST,
+        labels: {
+          app: SSP_APP_NAME,
+        },
+        format: this.loggerFormat(),
+      }),
+    ];
+  }
+
+  public getLoggers(): { logger: winston.Logger; errorLogger: winston.Logger } {
+    return {
+      logger: this.logger,
+      errorLogger: this.errorLogger,
+    };
+  }
+
+  public getLogger(): winston.Logger {
+    return this.logger;
+  }
+
+  public getErrorLogger(): winston.Logger {
+    return this.errorLogger;
+  }
+}


### PR DESCRIPTION
- Introduce `LoggerService`, which contains a `getLogger` method which accepts a `Request` that extracts the `traceId` which is subsequently used for logging, hence reducing the need to pass around traceIds
- See `resendInvitation()` for an example of the new service in action.
- Decided to create one logger rather than having an `infoLogger` and an `errorLogger` - I think it is simpler without losing anything (unless I am missing something)