### PR TITLE
Run API test server on different port to actual API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ Please add tests to your changes where possible! We don't have a minimum coverag
 
 Focus on testing functionality, not implementation. For example, if you have a button which waits 1 second and then displays a dialog, _do not_ simulate a click and then assert that `setTimeout(...)` was called. Instead, simulate a click, advance the timer, and make sure the dialog was displayed! Refer to the [Testing Library Guiding Principles](https://testing-library.com/docs/guiding-principles) and the section of the docs on [Query Priority](https://testing-library.com/docs/queries/about#priority).
 
-To run api tests `npm run test-api` please make sure the docker container is running and the api is not being run.
-
 ## Keycloak setup
 
 - Start database and Keycloak server by running `docker compose up -d`. Now Keycloak will be up and running, and the realm will be configured
@@ -192,10 +190,18 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 
+### `npm run api`
+
+Run the API on port 6540 by default. The API server will restart if you make edits, and you will see logs in the console. Useful if you need to debug the API.
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+### `npm run test-api`
+
+Runs the API tests. Please ensure the docker container is running.
 
 ### `npm run build`
 

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -65,7 +65,7 @@ function bypassHandlerForPaths(middleware: express.Handler, ...paths: BypassPath
   } as express.Handler;
 }
 
-export function configureAndStartApi(useMetrics: boolean = true) {
+export function configureAndStartApi(useMetrics: boolean = true, portNumber: number = 6540) {
   const container = new Container();
   container.bind<UserService>(TYPES.UserService).to(UserService);
   container.bind<LoggerService>(TYPES.LoggerService).to(LoggerService);
@@ -227,7 +227,7 @@ export function configureAndStartApi(useMetrics: boolean = true) {
     }
   };
   app.use(errorHandler);
-  const port = 6540;
+  const port = portNumber;
   const inversifyExpressServer = new InversifyExpressServer(container, router, null, app);
   const server = inversifyExpressServer.build().listen(port, () => {
     logger.info(`Listening on port ${port}.`);

--- a/src/api/tests/utils.ts
+++ b/src/api/tests/utils.ts
@@ -32,7 +32,7 @@ function useTestServer() {
     terminator = null;
   });
   beforeAll(async () => {
-    const serverDetails = configureAndStartApi(false);
+    const serverDetails = configureAndStartApi(false, 6541);
     api = serverDetails.server;
     routers = serverDetails.routers;
     terminator = createHttpTerminator({ server: api });


### PR DESCRIPTION
**Before**
You have to kill your local API, otherwise you when you run `npm run test-api` you will be hit with:
```
Error: Server is not running.
    at Server.close (node:net:2219:12)
    at Object.onceWrapper (node:events:632:28)
    at Server.emit (node:events:518:28)
    at Server.emit (node:domain:488:12)
    at emitCloseNT (node:net:2279:8)
    at processTicksAndRejections (node:internal/process/task_queues:81:21) {
  code: 'ERR_SERVER_NOT_RUNNING'
}
```

**After**
Since the API server runs on a different port, they can both be running at the same time with no issues.