### PR TITLE
Upgrade Keycloak to version 24.0.0

### DIFF
--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:23.0.0
+FROM quay.io/keycloak/keycloak:24.0.0
 
 ENV KC_TRANSACTION_XA_ENABLED 'false'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       MSSQL_SA_PASSWORD: 'D3velopmentP0'
   keycloak:
     container_name: uid2_selfserve_keycloak
-    image: quay.io/keycloak/keycloak:23.0.0
+    image: quay.io/keycloak/keycloak:24.0.0
     environment:
       KC_DB: mssql
       KC_DB_URL: jdbc:sqlserver://database:1433;DatabaseName=keycloak;encrypt=true;trustServerCertificate=true;
@@ -42,7 +42,6 @@ services:
       - --spi-theme-welcome-theme=uid2-theme
       - --health-enabled=true
       - --metrics-enabled=true
-      - --features=declarative-user-profile
       - --spi-connections-jpa-legacy-migration-strategy=update
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "inversify": "^6.0.2",
         "inversify-express-utils": "^6.4.6",
         "keycloak-connect": "20.0.3",
-        "keycloak-js": "^23.0.7",
+        "keycloak-js": "^24.0.1",
         "knex": "^2.5.1",
         "loglevel": "^1.9.1",
         "nodemailer": "^6.9.9",
@@ -22008,19 +22008,18 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "23.0.7",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-23.0.7.tgz",
-      "integrity": "sha512-OmszsKzBhhm5yP4W1q/tMd+nNnKpOAdeVYcoGhphlv8Fj1bNk4wRTYzp7pn5BkvueLz7fhvKHz7uOc33524YrA==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-24.0.1.tgz",
+      "integrity": "sha512-leV4mlpa0dqYUXTAuq1ufUfk8DOSBCembjQwMwzYrM6xfHSKpcZMxviTWXqro52LMSsYAnivSKVNEvBkLzi7Eg==",
       "dependencies": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.10.1",
+        "js-sha256": "^0.11.0",
         "jwt-decode": "^4.0.0"
       }
     },
     "node_modules/keycloak-js/node_modules/js-sha256": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
-      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
+      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
     },
     "node_modules/keycloak-request-token": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "inversify": "^6.0.2",
     "inversify-express-utils": "^6.4.6",
     "keycloak-connect": "20.0.3",
-    "keycloak-js": "^23.0.7",
+    "keycloak-js": "^24.0.1",
     "knex": "^2.5.1",
     "loglevel": "^1.9.1",
     "nodemailer": "^6.9.9",


### PR DESCRIPTION
- Similar to https://github.com/IABTechLab/uid2-self-serve-portal/pull/340 but for `24.0.0`
- `declarative-user-profile` has been deprecated, per https://www.keycloak.org/docs/latest/upgrading/index.html#user-profile-changes

## Manual testing

- Run `npm i`
- Re-run docker command to run Keycloak on the updated version
- Run your manual tests, such as logging in, logging out, signing into two different accounts in different sessions, etc.