### PR TITLE
Revert Keycloak.ts refactoring

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { App } from './web/App';
 import { setAuthToken } from './web/axios';
 import { CurrentUserProvider } from './web/contexts/CurrentUserProvider';
-import { createKeycloakInstance } from './web/Keycloak';
+import keycloak from './web/Keycloak';
 import { configureLogging } from './web/logging';
 import { reportWebVitals } from './web/reportWebVitals';
 import { Routes } from './web/screens/routes';
@@ -41,7 +41,7 @@ function Root() {
 
   return (
     <ReactKeycloakProvider
-      authClient={createKeycloakInstance()}
+      authClient={keycloak}
       initOptions={{
         checkLoginIframe: false,
       }}

--- a/src/web/Keycloak.ts
+++ b/src/web/Keycloak.ts
@@ -1,20 +1,5 @@
 import Keycloak from 'keycloak-js';
 
-let keycloakInstance: Keycloak | null = null;
+const keycloak = new Keycloak('/api/keycloak-config');
 
-export const getKeycloakInstance = () => {
-  if (!keycloakInstance) {
-    throw new Error(
-      'No Keycloak instance found. Please call createKeycloakInstance() to initialize one.'
-    );
-  }
-  return keycloakInstance;
-};
-
-export const createKeycloakInstance = () => {
-  if (keycloakInstance) {
-    throw new Error('Keycloak instance already exists. Unable to create another instance.');
-  }
-  keycloakInstance = new Keycloak('/api/keycloak-config');
-  return keycloakInstance;
-};
+export default keycloak;

--- a/src/web/screens/routeUtils.tsx
+++ b/src/web/screens/routeUtils.tsx
@@ -1,7 +1,7 @@
 import { LoaderFunctionArgs, RouteObject } from 'react-router-dom';
 
 import { setAuthToken } from '../axios';
-import { getKeycloakInstance } from '../Keycloak';
+import keycloak from '../Keycloak';
 import { PrivateRoute } from './PrivateRoute';
 
 function IsPortalRoute(route: PortalRoute | RouteObject): route is PortalRoute {
@@ -23,7 +23,6 @@ export const makePrivateRoute = (route: PortalRoute | RouteObject): PortalRoute 
     element: <PrivateRoute>{route.element}</PrivateRoute>,
     loader: route.loader
       ? async (args: LoaderFunctionArgs) => {
-          const keycloak = getKeycloakInstance();
           if (!keycloak.authenticated) {
             const token = localStorage.getItem('authToken');
             setAuthToken(token ?? undefined);


### PR DESCRIPTION
Revert some refactoring done as part of https://github.com/IABTechLab/uid2-self-serve-portal/pull/340. It turns out the changes made in the aforementioned PR to [src/testHelpers/testContextProvider.tsx](https://github.com/IABTechLab/uid2-self-serve-portal/pull/340/files#diff-c729b5d173e81313f5856e205131b456893c90b8890546db0c76941d992cfe2a) were sufficient. One the other hand, the changes made to `Keycloak.ts` actually broke functionality. It was over-engineered and went against the intended usage of the package, see https://www.npmjs.com/package/@react-keycloak/web#setup-keycloak-instance

**Before**
Refreshing certain screens (Team Members, Email Contacts, Manage Participants & API Key Management) would lead to errors

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/9dcc6731-e896-4b8d-8306-6e7909de7b9a

**After**
Refreshing those screens behave as expected

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/fbfa7005-f265-425e-afb9-4896daf1ccce

