### PR TITLE
Remove deprecated feature from `Dockerfile_keycloak`

### DIFF
--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -11,4 +11,4 @@ RUN chmod -R 775 /opt/keycloak/data/import
 USER keycloak
 
 ENTRYPOINT sed -i -E "s#http://localhost:[0-9]*#$SSP_WEB_HOST#g" opt/keycloak/data/import/realm-export.json && \
-/opt/keycloak/bin/kc.sh start --hostname=$SSP_AUTH_HOST --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --spi-theme-welcome-theme=uid-theme --health-enabled=true --metrics-enabled=true --features=declarative-user-profile --spi-connections-jpa-legacy-migration-strategy=update
+/opt/keycloak/bin/kc.sh start --hostname=$SSP_AUTH_HOST --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --spi-theme-welcome-theme=uid-theme --health-enabled=true --metrics-enabled=true --spi-connections-jpa-legacy-migration-strategy=update


### PR DESCRIPTION
As part of https://github.com/IABTechLab/uid2-self-serve-portal/pull/343/files I removed `--features=declarative-user-profile` from `docker-compose.yml` but didn't realise I needed to remove it in `Dockerfile_keycloak` as well.


## Manual testing
First change `start` to `start-dev` in `Dockerfile_keycloak`


**Before**

```
> docker build -f Dockerfile_keycloak -t ajy-test .
[+] Building 2.5s (9/9) FINISHED
 => [internal] load build definition from Dockerfile_keycloak                                                             1.0s
 => => transferring dockerfile: 774B                                                                                      0.0s
 => [internal] load .dockerignore                                                                                         0.7s
 => => transferring context: 2B                                                                                           0.0s
 => [internal] load metadata for quay.io/keycloak/keycloak:24.0.0                                                         0.0s
 => [1/4] FROM quay.io/keycloak/keycloak:24.0.0                                                                           0.0s
 => [internal] load build context                                                                                         0.4s
 => => transferring context: 1.92kB                                                                                       0.0s
 => CACHED [2/4] COPY keycloak/realm/realm-export.json /opt/keycloak/data/import/realm-export.json                        0.0s
 => CACHED [3/4] COPY keycloak/themes /opt/keycloak/themes                                                                0.0s
 => CACHED [4/4] RUN chmod -R 775 /opt/keycloak/data/import                                                               0.0s
 => exporting to image                                                                                                    0.6s
 => => exporting layers                                                                                                   0.0s
 => => writing image sha256:a252d15f9762b82485c9d0b206a334ac19d7b1460a243453eaba643f63520750                              0.1s
 => => naming to docker.io/library/ajy-test                                                                               0.1s

> docker run -ti ajy-test sh
declarative-user-profile is an unrecognized feature, it should be one of [account-api, account2, account3, admin-api, admin-fine-grained-authz, admin2, authorization, ciba, client-policies, client-secret-rotation, client-types, declarative-ui, device-flow, docker, dpop, dynamic-scopes, fips, impersonation, js-adapter, kerberos, linkedin-oauth, login2, multi-site, offline-session-preloading, oid4vc-vci, par, preview, recovery-codes, scripts, step-up-authentication, token-exchange, transient-users, update-email, web-authn]
```

**After**
```
> docker build -f Dockerfile_keycloak -t ajy-test .
[+] Building 2.8s (9/9) FINISHED
 => [internal] load build definition from Dockerfile_keycloak                                                             1.1s
 => => transferring dockerfile: 738B                                                                                      0.0s
 => [internal] load .dockerignore                                                                                         0.8s
 => => transferring context: 2B                                                                                           0.0s
 => [internal] load metadata for quay.io/keycloak/keycloak:24.0.0                                                         0.0s
 => [1/4] FROM quay.io/keycloak/keycloak:24.0.0                                                                           0.0s
 => [internal] load build context                                                                                         0.6s
 => => transferring context: 1.92kB                                                                                       0.0s
 => CACHED [2/4] COPY keycloak/realm/realm-export.json /opt/keycloak/data/import/realm-export.json                        0.0s
 => CACHED [3/4] COPY keycloak/themes /opt/keycloak/themes                                                                0.0s
 => CACHED [4/4] RUN chmod -R 775 /opt/keycloak/data/import                                                               0.0s
 => exporting to image                                                                                                    0.6s
 => => exporting layers                                                                                                   0.0s
 => => writing image sha256:ddc486ebf76e009324cfcb5b526ff22c10357ffa5563bc77c505185ee51f32ec                              0.1s
 => => naming to docker.io/library/ajy-test                                                                               0.1s

> docker run -ti ajy-test sh
Updating the configuration and installing your custom providers, if any. Please wait.
2024-03-06 23:44:51,105 INFO  [io.qua.dep.QuarkusAugmentor] (main) Quarkus augmentation completed in 40897ms
2024-03-06 23:44:52,833 INFO  [org.keycloak.quarkus.runtime.hostname.DefaultHostnameProvider] (main) Hostname settings: Base URL: <unset>, Hostname: <request>, Strict HTTPS: false, Path: <request>, Strict BackChannel: false, Admin URL: <unset>, Admin: <request>, Port: -1, Proxied: false
2024-03-06 23:44:52,980 WARN  [org.infinispan.CONFIG] (keycloak-cache-init) ISPN000569: Unable to persist Infinispan internal caches as no global state enabled
2024-03-06 23:44:53,032 INFO  [org.infinispan.CONTAINER] (keycloak-cache-init) ISPN000556: Starting user marshaller 'org.infinispan.jboss.marshalling.core.JBossUserMarshaller'
2024-03-06 23:44:56,584 INFO  [org.keycloak.quarkus.runtime.storage.legacy.liquibase.QuarkusJpaUpdaterProvider] (main) Initializing database schema. Using changelog META-INF/jpa-changelog-master.xml

UPDATE SUMMARY
Run:                        121
Previously run:               0
Filtered out:                 0
-------------------------------
Total change sets:          121

2024-03-06 23:44:58,464 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Node name: node_170445, Site name: null
2024-03-06 23:44:58,555 INFO  [org.keycloak.broker.provider.AbstractIdentityProviderMapper] (main) Registering class org.keycloak.broker.provider.mappersync.ConfigSyncEventListener
2024-03-06 23:44:58,616 INFO  [org.keycloak.services] (main) KC-SERVICES0050: Initializing master realm
2024-03-06 23:44:59,800 INFO  [org.keycloak.exportimport.singlefile.SingleFileImportProvider] (main) Full importing from file /opt/keycloak/bin/../data/import/realm-export.json
2024-03-06 23:45:02,062 INFO  [org.keycloak.exportimport.util.ImportUtils] (main) Realm 'self-serve-portal' imported
2024-03-06 23:45:02,114 INFO  [org.keycloak.exportimport.dir.DirImportProvider] (main) Importing from directory /opt/keycloak/bin/../data/import
2024-03-06 23:45:02,115 INFO  [org.keycloak.services] (main) KC-SERVICES0030: Full model import requested. Strategy: IGNORE_EXISTING
2024-03-06 23:45:02,115 INFO  [org.keycloak.services] (main) KC-SERVICES0032: Import finished successfully
2024-03-06 23:45:02,187 INFO  [io.quarkus] (main) Keycloak 24.0.0 on JVM (powered by Quarkus 3.8.1) started in 10.790s. Listening on: http://0.0.0.0:8080/
2024-03-06 23:45:02,187 INFO  [io.quarkus] (main) Profile dev activated.
2024-03-06 23:45:02,187 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, jdbc-h2, keycloak, logging-gelf, micrometer, narayana-jta, reactive-routes, resteasy-reactive, resteasy-reactive-jackson, smallrye-context-propagation, smallrye-health, vertx]
2024-03-06 23:45:02,192 WARN  [org.keycloak.quarkus.runtime.KeycloakMain] (main) Running the server in development mode. DO NOT use this configuration in production.
```