### PR TITLE
Remove condition to render Sharing permissions table

### DIFF
--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -145,13 +145,12 @@ function SharingPermissions() {
             />
           </>
         </Collapsible>
-        {(participant?.completedRecommendations || sharedSiteIds.length > 0) && (
-          <SharingPermissionsTable
-            sharedSiteIds={sharedSiteIds}
-            sharedTypes={sharedTypes}
-            onDeleteSharingPermission={handleDeleteSharingSite}
-          />
-        )}
+
+        <SharingPermissionsTable
+          sharedSiteIds={sharedSiteIds}
+          sharedTypes={sharedTypes}
+          onDeleteSharingPermission={handleDeleteSharingSite}
+        />
       </div>
     </SharingPermissionPageContainer>
   );


### PR DESCRIPTION
No need for this condition to render the SharingPermissionsTable and no UX changes occur 