### PR TITLE
Only call `/envar` endpoint on local dev

### DIFF
--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -23,7 +23,6 @@ export function App() {
   const logout = useCallback(() => {
     keycloak?.logout();
   }, [keycloak]);
-
   const setDarkMode = (darkMode: boolean) => {
     if (darkMode) rootRef.current!.classList.add('darkmode');
     else rootRef.current!.classList.remove('darkmode');
@@ -33,6 +32,8 @@ export function App() {
     LoggedInUser?.profile.firstName || LoggedInUser?.profile.lastName
       ? `${LoggedInUser?.profile.firstName ?? ''} ${LoggedInUser?.profile.lastName ?? ''}`
       : undefined;
+  const isLocalDev = process.env.NODE_ENV === 'development';
+
   return (
     <StrictMode>
       <PortalErrorBoundary>
@@ -44,7 +45,7 @@ export function App() {
               setDarkMode={setDarkMode}
               logout={logout}
             />
-            <EnvironmentBanner />
+            {!isLocalDev && <EnvironmentBanner />}
             <Outlet />
             <ToastContainerWrapper />
           </div>

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -45,7 +45,7 @@ export function App() {
               setDarkMode={setDarkMode}
               logout={logout}
             />
-            {!isLocalDev && <EnvironmentBanner />}
+            {isLocalDev && <EnvironmentBanner />}
             <Outlet />
             <ToastContainerWrapper />
           </div>


### PR DESCRIPTION
**Before**

Note the call to `/envars`

![chrome_oJtZlArpmw](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/da9d11ba-73dc-4843-9b7c-6361dd1879ad)


**After**

Note there is no call to `/envars` (temporarily changed condition locally to mimic prod)

![6EbMnhsUIX](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/e479bee8-df69-429a-80e0-6a736ebaf98d)
