### PR TITLE
Ensure `user-event` library is used correctly in react tests

### DIFF
--- a/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.spec.tsx
@@ -12,48 +12,54 @@ const validationInlineBanner = async (messageTestId: string) => {
 };
 
 const validateRecommendDomain = async (recommendDomain: string) => {
+  const user = userEvent.setup();
   await validationInlineBanner('domain-input-recommended-message');
   expect(await screen.findByTestId('banner-message')).toHaveTextContent(recommendDomain);
 
-  await userEvent.click(screen.getByTestId('domain-input-recommended-domain'));
+  await user.click(screen.getByTestId('domain-input-recommended-domain'));
   expect(screen.queryByTestId('banner-message')).not.toBeInTheDocument();
 };
 
 describe('CstgDomainInputRow', () => {
   it('should be able to click save if user type in correct domain', async () => {
+    const user = userEvent.setup();
     render(<Default />);
 
-    await userEvent.type(screen.getByTestId('domain-input-field'), 'test.com');
+    await user.type(screen.getByTestId('domain-input-field'), 'test.com');
 
     expect(screen.getByTestId('domain-input-save-btn')).toBeEnabled();
     expect(screen.queryByTestId('banner-message')).not.toBeInTheDocument();
   });
 
   it('renders recommended domain when user type in url', async () => {
+    const user = userEvent.setup();
     render(<Default />);
 
-    await userEvent.type(screen.getByTestId('domain-input-field'), 'https://test.com/docs/');
+    await user.type(screen.getByTestId('domain-input-field'), 'https://test.com/docs/');
     await validateRecommendDomain('test.com');
   });
 
   it('renders recommended domain when user type in subdomain', async () => {
+    const user = userEvent.setup();
     render(<Default />);
 
-    await userEvent.type(screen.getByTestId('domain-input-field'), 'https://abc.test.com/docs/');
+    await user.type(screen.getByTestId('domain-input-field'), 'https://abc.test.com/docs/');
     await validateRecommendDomain('test.com');
   });
 
   it('renders error when user type in invalid format', async () => {
+    const user = userEvent.setup();
     render(<Default />);
 
-    await userEvent.type(screen.getByTestId('domain-input-field'), 'https://abctest');
+    await user.type(screen.getByTestId('domain-input-field'), 'https://abctest');
     await validationInlineBanner('domain-input-error-message');
   });
 
   it('renders error when user type in invalid suffix', async () => {
+    const user = userEvent.setup();
     render(<Default />);
 
-    await userEvent.type(screen.getByTestId('domain-input-field'), 'https://abctest.bbbbb');
+    await user.type(screen.getByTestId('domain-input-field'), 'https://abctest.bbbbb');
 
     await validationInlineBanner('domain-input-error-message');
   });

--- a/src/web/components/Core/Form.spec.tsx
+++ b/src/web/components/Core/Form.spec.tsx
@@ -99,7 +99,7 @@ describe('Form Component', () => {
       expect(screen.getByDisplayValue('Option 1')).toBeInTheDocument();
     });
 
-    user.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(async () => {
       expect(mockOnSubmit).toBeCalledWith(defaultFormData);

--- a/src/web/components/Core/Form.spec.tsx
+++ b/src/web/components/Core/Form.spec.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/testing-react';
-import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 
@@ -17,39 +17,37 @@ describe('Form Component', () => {
   });
 
   test('should load inputs and able to get formData from it', async () => {
-    userEvent.setup();
+    const user = userEvent.setup();
     render(<WithInputFields onSubmit={mockOnSubmit} />);
 
     const textInput = screen.getByTestId('text-input');
 
-    userEvent.type(textInput, 'New value');
+    await user.type(textInput, 'New value');
     await waitFor(() => {
       expect(screen.getByDisplayValue('New value')).toBeInTheDocument();
     });
 
     const radio2 = screen.getByLabelText('No');
-    userEvent.click(radio2);
+    await user.click(radio2);
     await waitFor(() => {
       expect(radio2).toBeChecked();
     });
 
     const checkbox1 = screen.getByRole('checkbox', { name: 'Checkbox 1' });
-    userEvent.click(checkbox1);
+    await user.click(checkbox1);
     await waitFor(() => {
       expect(checkbox1).toBeChecked();
     });
 
-    userEvent.click(screen.getByRole('combobox', { name: 'selectInputValue' }));
+    await user.click(screen.getByRole('combobox', { name: 'selectInputValue' }));
 
     await waitFor(async () => {
       const option = screen.getByRole('option', { name: 'Option 2' });
       expect(option).toBeInTheDocument();
     });
-    userEvent.click(screen.getByRole('option', { name: 'Option 2' }));
+    await user.click(screen.getByRole('option', { name: 'Option 2' }));
 
-    await waitForElementToBeRemoved(screen.queryByRole('option', { name: 'Option 2' }));
-
-    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     const expectFormData = {
       checkboxInputValue: ['1'],
@@ -69,7 +67,7 @@ describe('Form Component', () => {
   });
 
   test('should render input with default value', async () => {
-    userEvent.setup();
+    const user = userEvent.setup();
     const defaultFormData = {
       checkboxInputValue: ['1', '2'],
       radioInputValue: 0,
@@ -101,7 +99,7 @@ describe('Form Component', () => {
       expect(screen.getByDisplayValue('Option 1')).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(async () => {
       expect(mockOnSubmit).toBeCalledWith(defaultFormData);
@@ -109,9 +107,10 @@ describe('Form Component', () => {
   });
 
   test('should render error with user click submit', async () => {
+    const user = userEvent.setup();
     render(<SubmitWithError />);
     const button = await screen.findByRole('button');
-    userEvent.click(button);
+    await user.click(button);
     const formError = await screen.findByTestId('formError');
     expect(formError).toHaveTextContent('Something went wrong, please try again');
   });
@@ -131,9 +130,10 @@ describe('Form Component', () => {
       throw errorMessage;
     });
 
+    const user = userEvent.setup();
     render(<WithDefaultData onSubmit={mockOnSubmit} />);
     const button = await screen.findByRole('button');
-    userEvent.click(button);
+    await user.click(button);
     const formError = await screen.findByTestId('formError');
     expect(formError).toHaveTextContent(serverErrorMessage);
   });
@@ -150,9 +150,10 @@ describe('Form Component', () => {
       throw error;
     });
 
+    const user = userEvent.setup();
     render(<WithDefaultData onSubmit={mockOnSubmit} />);
     const button = await screen.findByRole('button');
-    userEvent.click(button);
+    await user.click(button);
     const formError = await screen.findByTestId('formError');
     expect(formError).toHaveTextContent('Something went wrong, please try again');
   });

--- a/src/web/components/Core/PortalHeader.spec.tsx
+++ b/src/web/components/Core/PortalHeader.spec.tsx
@@ -10,7 +10,7 @@ test('when the drop is clicked, a gravatar is displayed', async () => {
   const user = userEvent.setup();
   render(<ValidEmailAddress />);
   const button = await screen.findByRole('button');
-  user.click(button);
+  await user.click(button);
   const menu = await screen.findByRole('menu');
   const avatar = await within(menu).findByRole('img');
   expect(avatar).toHaveAttribute('src', expect.stringContaining('//www.gravatar.com/avatar/'));

--- a/src/web/components/Input/MultiCheckboxInput.spec.tsx
+++ b/src/web/components/Input/MultiCheckboxInput.spec.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/testing-react';
-import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Form } from '../Core/Form';
@@ -47,12 +47,13 @@ describe('CheckboxInput', () => {
   it.each(checkBoxOptionsList)(
     'Should submit correctly when one option selected',
     async (checkboxOptions) => {
+      const user = userEvent.setup();
       const onSubmitMock = loadComponent(checkboxOptions);
 
-      await userEvent.click(screen.getByRole('checkbox', { name: checkboxOptions[0].optionLabel }));
+      await user.click(screen.getByRole('checkbox', { name: checkboxOptions[0].optionLabel }));
 
       const submitButton = screen.getByRole('button', { name: 'Submit' });
-      await userEvent.click(submitButton);
+      await user.click(submitButton);
 
       expect(onSubmitMock).toHaveBeenLastCalledWith({ default: [checkboxOptions[0].value] });
     }
@@ -61,14 +62,15 @@ describe('CheckboxInput', () => {
   it.each(checkBoxOptionsList)(
     'Should submit correctly when all options are selected',
     async (checkboxOptions) => {
+      const user = userEvent.setup();
       const onSubmitMock = loadComponent(checkboxOptions);
 
       checkboxOptions.map(async (checkboxOption) => {
-        await userEvent.click(screen.getByRole('checkbox', { name: checkboxOption.optionLabel }));
+        await user.click(screen.getByRole('checkbox', { name: checkboxOption.optionLabel }));
       });
 
       const submitButton = screen.getByRole('button', { name: 'Submit' });
-      await userEvent.click(submitButton);
+      await user.click(submitButton);
 
       expect(onSubmitMock).toHaveBeenLastCalledWith({
         default: checkboxOptions.map((checkboxOption) => checkboxOption.value),
@@ -79,10 +81,11 @@ describe('CheckboxInput', () => {
   it.each(checkBoxOptionsList)(
     'Should submit correctly when no options are selected',
     async (checkboxOptions) => {
+      const user = userEvent.setup();
       const onSubmitMock = loadComponent(checkboxOptions);
 
       const submitButton = screen.getByRole('button', { name: 'Submit' });
-      await userEvent.click(submitButton);
+      await user.click(submitButton);
 
       expect(onSubmitMock).toHaveBeenLastCalledWith({
         default: [],
@@ -92,6 +95,7 @@ describe('CheckboxInput', () => {
 
   it('should show default values as selected if given', async () => {
     const onSubmitMock = jest.fn(() => {});
+    const user = userEvent.setup();
 
     render(
       <Form onSubmit={onSubmitMock} defaultValues={{ default: ['option1', 'option2'] }}>
@@ -114,25 +118,26 @@ describe('CheckboxInput', () => {
     expect(option2).toBeChecked();
 
     const submitButton = screen.getByRole('button', { name: 'Submit' });
-    await userEvent.click(submitButton);
+    await user.click(submitButton);
 
     expect(onSubmitMock).toHaveBeenLastCalledWith({ default: ['option1', 'option2'] });
   });
 
   it('Verifies field based on rule', async () => {
+    const user = userEvent.setup();
     render(<WithValidation />);
 
-    userEvent.click(screen.getByRole('checkbox', { name: 'Option 2' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Option 2' }));
     await waitFor(() => {
       const option2 = screen.getByLabelText('Option 2');
       expect(option2).toBeChecked();
     });
     const submitButton = screen.getByRole('button', { name: 'Submit' });
-    userEvent.click(submitButton);
+    await user.click(submitButton);
     const errorMessage = await screen.findByRole('alert');
     expect(errorMessage).toHaveTextContent('At least two options are required');
 
-    userEvent.click(screen.getByRole('checkbox', { name: 'Option 3' }));
-    await waitForElementToBeRemoved(screen.queryByRole('alert'));
+    await user.click(screen.getByRole('checkbox', { name: 'Option 3' }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/src/web/components/Input/RadioInput.spec.tsx
+++ b/src/web/components/Input/RadioInput.spec.tsx
@@ -8,9 +8,11 @@ const { WithValidation, WithLabel } = composeStories(stories);
 
 describe('RadioInput', () => {
   it('verifies field based on rule', async () => {
+    const user = userEvent.setup();
+
     render(<WithValidation />);
     const submitButton = screen.getByRole('button', { name: 'Submit' });
-    userEvent.click(submitButton);
+    await user.click(submitButton);
     const errorMessage = await screen.findByRole('alert');
     expect(errorMessage).toHaveTextContent('This field is required');
 

--- a/src/web/components/Input/SelectInput.spec.tsx
+++ b/src/web/components/Input/SelectInput.spec.tsx
@@ -8,18 +8,19 @@ const { WithValidation } = composeStories(stories);
 
 describe('SelectInput', () => {
   it('verifies field based on rule', async () => {
+    const user = userEvent.setup();
     render(<WithValidation />);
     const submitButton = screen.getByRole('button', { name: 'Submit' });
-    userEvent.click(submitButton);
+    await user.click(submitButton);
     const errorMessage = await screen.findByRole('alert');
     expect(errorMessage).toHaveTextContent('This field is required');
 
-    userEvent.click(screen.getByRole('combobox', { name: 'select' }));
+    await user.click(screen.getByRole('combobox', { name: 'select' }));
     await waitFor(async () => {
       const option = screen.getByRole('option', { name: 'Option 2' });
       expect(option).toBeInTheDocument();
     });
-    userEvent.click(screen.getByRole('option', { name: 'Option 2' }));
+    await user.click(screen.getByRole('option', { name: 'Option 2' }));
 
     expect(screen.queryByRole('alert')).toBeNull();
   });

--- a/src/web/components/Input/TextInput.spec.tsx
+++ b/src/web/components/Input/TextInput.spec.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/testing-react';
-import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import * as stories from './TextInput.stories';
@@ -8,17 +8,18 @@ const { WithValidation } = composeStories(stories);
 
 describe('TextInput', () => {
   it('verifies field based on rule', async () => {
+    const user = userEvent.setup();
     render(<WithValidation />);
     const textInput = screen.getByTestId('text-input');
-    userEvent.type(textInput, '123');
+    await user.type(textInput, '123');
     await waitFor(async () => expect(await screen.findByDisplayValue('123')).toBeInTheDocument());
 
     const submitButton = screen.getByRole('button', { name: 'Submit' });
-    userEvent.click(submitButton);
+    await user.click(submitButton);
     const errorMessage = await screen.findByRole('alert');
     expect(errorMessage).toHaveTextContent('Too many characters');
 
-    userEvent.keyboard('[backspace]');
-    await waitForElementToBeRemoved(screen.queryByRole('alert'));
+    await user.keyboard('[backspace]');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Ensure all usages of `userEvent` API are awaited
- Use best practice of using `const user = userEvent.setup();` before the component is rendered
- Change some `waitForElementToBeRemoved()` calls to actual assertions.

Source: https://testing-library.com/docs/user-event/intro/