### PR TITLE
Improve scroll behaviour in Add Participant dialog

### DIFF
--- a/src/web/components/ParticipantManagement/AddParticipantDialog.scss
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.scss
@@ -1,4 +1,5 @@
 .add-participant-dialog {
+  max-height: calc(100vh - 100px);
   max-width: 1100px;
   overflow-y: auto;
 
@@ -34,6 +35,8 @@
       position: absolute;
       padding: 10px;
       width: 378px;
+      max-height: 350px;
+      overflow-y: auto;
 
       & > button {
         padding: 10px;


### PR DESCRIPTION
- Ensure dialog is tall for the given screen. This should reduce the need for the scrollbar (on non-errored state) for most screens
- Make the search results for the site id remain within the dialog. The scrollbar will only appear in the search results when needed.

**Before**

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/5f4d8d4d-e387-445d-86ac-8f28af6389af)

**After**

![chrome_Saivv1A1Rp](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/0b7a9ecb-1830-4778-a0b5-0a8527ee4031)
