### PR TITLE
UX improvements for Top-Level Domains

### DIFF
--- a/src/web/components/ClientSideTokenGeneration/CstgDomain.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomain.tsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useState } from 'react';
 
 import { Dialog } from '../Core/Dialog';
@@ -21,7 +22,7 @@ function DeleteConfirmationDialog({ domain, onRemoveDomain }: DeleteConfirmation
       title='Are you sure you want to delete this domain?'
       triggerButton={
         <button type='button' className='transparent-button'>
-          Delete
+          <FontAwesomeIcon icon='trash-can' />
         </button>
       }
       open={openConfirmation}

--- a/src/web/components/ClientSideTokenGeneration/CstgDomain.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomain.tsx
@@ -21,7 +21,7 @@ function DeleteConfirmationDialog({ domain, onRemoveDomain }: DeleteConfirmation
     <Dialog
       title='Are you sure you want to delete this domain?'
       triggerButton={
-        <button type='button' className='transparent-button'>
+        <button type='button' className='icon-button' aria-label='delete-domain-name'>
           <FontAwesomeIcon icon='trash-can' />
         </button>
       }

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.scss
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.scss
@@ -13,6 +13,7 @@
     align-items: center;
 
     .input-container {
+      height: 20px;
       border-radius: 5px;
       border: 1px solid var(--theme-input-border);
     }

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
-import { ChangeEvent, ReactNode, useState } from 'react';
+import { ChangeEvent, ReactNode, useEffect, useRef, useState } from 'react';
 import { parse } from 'tldts';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -31,6 +31,11 @@ type ValidDomainProps = Omit<DomainProps, 'domain'> & { domain: string };
 export function CstgDomainInputRow({ onAdd, onCancel }: CstgDomainInputRowProps) {
   const [newDomain, setNewDomain] = useState<string>('');
   const [validationResult, setValidationResult] = useState<DomainValidationResult | null>();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef?.current?.focus();
+  }, []);
 
   const updateToNormalizedValue = (normalizedValue: string) => {
     setNewDomain(normalizedValue);
@@ -102,6 +107,7 @@ export function CstgDomainInputRow({ onAdd, onCancel }: CstgDomainInputRowProps)
       <td className='domain'>
         <div className='domain-input-wrapper'>
           <input
+            ref={inputRef}
             data-testid='domain-input-field'
             className={clsx('input-container', validationResult?.type)}
             value={newDomain}

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainInputRow.tsx
@@ -114,7 +114,7 @@ export function CstgDomainInputRow({ onAdd, onCancel }: CstgDomainInputRowProps)
             onChange={handleInputChange}
           />
           {validationResult && (
-            <InlineMessage message={validationResult!.message} type={validationResult!.type} />
+            <InlineMessage message={validationResult.message} type={validationResult.type} />
           )}
         </div>
       </td>
@@ -125,7 +125,7 @@ export function CstgDomainInputRow({ onAdd, onCancel }: CstgDomainInputRowProps)
             data-testid='domain-input-save-btn'
             className='transparent-button'
             onClick={() => onAdd(newDomain)}
-            disabled={!!validationResult}
+            disabled={!!validationResult || newDomain === ''}
           >
             Save
           </button>

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.scss
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.scss
@@ -35,4 +35,8 @@
   .cstg-domains-management-icon {
     margin-right: 8px;
   }
+
+  .add-domain-button {
+    margin-top: 20px;
+  }
 }

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.scss
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.scss
@@ -2,6 +2,10 @@
   .cstg-domains-table {
     width: 100%;
 
+    td {
+      padding: 15px 5px 15px 0;
+    }
+
     th:first-of-type,
     td:first-of-type {
       padding-left: 10px;

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -119,15 +119,6 @@ export function CstgDomainsTable({ domains, onUpdateDomains }: CstgDomainsTableP
             selectedDomains={selectedDomains}
           />
         )}
-        <button
-          className='transparent-button table-action-button'
-          type='button'
-          disabled={showNewRow}
-          onClick={toggleAddRow}
-        >
-          <FontAwesomeIcon icon='plus' className='cstg-domains-management-icon' />
-          Add Domain
-        </button>
       </div>
       <table className='cstg-domains-table'>
         <thead>
@@ -158,11 +149,16 @@ export function CstgDomainsTable({ domains, onUpdateDomains }: CstgDomainsTableP
       {!domains.length && !showNewRow && (
         <TableNoDataPlaceholder
           icon={<img src='/group-icon.svg' alt='group-icon' />}
-          title='No Approved Domains'
+          title='No Top-Level Domains'
         >
-          <span>There are no approved domains.</span>
+          <span>There are no Top-Level Domains.</span>
         </TableNoDataPlaceholder>
       )}
+      <div className='add-domain-button'>
+        <button className='small-button' type='button' disabled={showNewRow} onClick={toggleAddRow}>
+          Add Domain
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Styling improvements
- Autofocus input
- Use trash icon instead of "Delete"
- Move "Add" button to the bottom of the table
- Disable the button when the domain is empty
- Update some copy
- Remove unnecessary type assertions

https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/8601d6e9-1b63-4347-b657-928628755431

Note: the functionality shown above is not included in this PR.



