### PR TITLE
Wording and grammar changes to match docs on client side integration

### DIFF
--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -165,7 +165,7 @@ export function CstgDomainsTable({ domains, onUpdateDomains }: CstgDomainsTableP
       </table>
       {!domains.length && !showNewRow && (
         <TableNoDataPlaceholder title='No Top-Level Domains'>
-          <span>There are no Top-Level Domains.</span>
+          <span>There are no top-level domains.</span>
         </TableNoDataPlaceholder>
       )}
     </div>

--- a/src/web/components/KeyPairs/KeyPairDisableDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairDisableDialog.tsx
@@ -38,7 +38,7 @@ function KeyPairDisableDialog({ onDisable, triggerButton, keyPair }: KeyPairDisa
       </p>
       <Form onSubmit={onSubmit} submitButtonText='Delete Key' disableSubmitWhenInvalid>
         <TextInput
-          inputName='Subscription Id'
+          inputName='Subscription ID'
           placeholder={keyPair.subscriptionId}
           rules={{
             validate: (value) => {

--- a/src/web/components/KeyPairs/KeyPairsTable.tsx
+++ b/src/web/components/KeyPairs/KeyPairsTable.tsx
@@ -44,7 +44,7 @@ function KeyPairsTable({
         <thead>
           <tr>
             <th className='name'>Name</th>
-            <th className='subscription-id'>Subscription Id</th>
+            <th className='subscription-id'>Subscription ID</th>
             <th className='public-key'>Public Key</th>
             <th className='created'>Created</th>
             <th className='action'>Actions</th>

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -85,9 +85,9 @@ function ClientSideIntegration() {
 
   return (
     <>
-      <h1>Client Side Integration</h1>
+      <h1>Client-Side Integration</h1>
       <p className='heading-details'>
-        View and manage Client Side Integration Key Pairs and domain names. For more information,
+        View and manage client-side integration key pairs and domain names. For more information,
         see{' '}
         <a
           className='outside-link'
@@ -95,7 +95,7 @@ function ClientSideIntegration() {
           href='https://unifiedid.com/docs/guides/publisher-client-side'
           rel='noreferrer'
         >
-          Client-Side Integration Guide
+          Client-Side Integration Guide for JavaScript
         </a>
         .
       </p>
@@ -115,7 +115,7 @@ function ClientSideIntegration() {
 }
 
 export const ClientSideIntegrationRoute: PortalRoute = {
-  description: 'Client Side Integration',
+  description: 'Client-Side Integration',
   element: <ClientSideIntegration />,
   errorElement: <RouteErrorBoundary />,
   path: '/dashboard/clientSideIntegration',


### PR DESCRIPTION
What changed:

- Hyphenated client-side integration where necesary
- Changed certain words to lower case if they are not in the title
- Capitalized ID in Subscription ID
- Changed title to match title in the docs for link to Client Side Integration