### PR TITLE
Unique Key Pair Names per Site

### DIFF
--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -563,6 +563,9 @@ export function createParticipantsRouter() {
       }
 
       const { name, subscriptionId } = keyPairParser.parse(req.body.keyPair);
+
+      const disabledDate = new Date().toISOString();
+      const disabledKeyPairName = `${name}-disabled-${disabledDate}`;
       const disabled = true;
 
       const traceId = getTraceId(req);
@@ -576,7 +579,7 @@ export function createParticipantsRouter() {
         traceId
       );
 
-      await updateKeyPair(subscriptionId, name, disabled);
+      await updateKeyPair(subscriptionId, disabledKeyPairName, disabled);
 
       await updateAuditTrailToProceed(auditTrail.id);
 

--- a/src/web/components/KeyPairs/KeyPair.tsx
+++ b/src/web/components/KeyPairs/KeyPair.tsx
@@ -7,11 +7,12 @@ import { KeyPairModel } from './KeyPairModel';
 
 type KeyPairProps = Readonly<{
   keyPair: KeyPairModel;
+  existingKeyPairs: KeyPairModel[];
   onEdit: OnKeyPairEdit;
   onDisable: OnKeyPairDisable;
 }>;
 
-function KeyPair({ keyPair, onEdit, onDisable }: KeyPairProps) {
+function KeyPair({ keyPair, existingKeyPairs, onEdit, onDisable }: KeyPairProps) {
   return (
     <tr>
       <td className='name'>{keyPair.name}</td>
@@ -24,6 +25,7 @@ function KeyPair({ keyPair, onEdit, onDisable }: KeyPairProps) {
         <div className='action-cell'>
           <KeyPairEditDialog
             keyPair={keyPair}
+            existingKeyPairs={existingKeyPairs}
             onEdit={onEdit}
             triggerButton={
               <button type='button' className='icon-button' title='Edit'>

--- a/src/web/components/KeyPairs/KeyPairDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairDialog.tsx
@@ -5,6 +5,7 @@ import { AddKeyPairFormProps } from '../../services/keyPairService';
 import { Dialog } from '../Core/Dialog';
 import { Form } from '../Core/Form';
 import { TextInput } from '../Input/TextInput';
+import { validateUniqueKeyPairName } from './KeyPairHelper';
 import { KeyPairModel } from './KeyPairModel';
 
 import './KeyPairDialog.scss';
@@ -13,6 +14,7 @@ type AddKeyPairDialogProps = {
   onAddKeyPair: (form: AddKeyPairFormProps) => Promise<void>;
   triggerButton: JSX.Element;
   keyPair?: KeyPairModel;
+  existingKeyPairs: KeyPairModel[] | undefined;
 };
 
 type KeyPairDialogProps = AddKeyPairDialogProps;
@@ -40,7 +42,14 @@ function KeyPairDialog(props: KeyPairDialogProps) {
           submitButtonText='Create Key Pair'
           defaultValues={keyPair}
         >
-          <TextInput inputName='name' label='Name' required />
+          <TextInput
+            inputName='name'
+            label='Name'
+            rules={{
+              required: 'Please specify key pair name.',
+              validate: (value: string) => validateUniqueKeyPairName(value, props.existingKeyPairs),
+            }}
+          />
         </Form>
       </Dialog>
     </div>

--- a/src/web/components/KeyPairs/KeyPairDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairDialog.tsx
@@ -19,9 +19,13 @@ type AddKeyPairDialogProps = {
 
 type KeyPairDialogProps = AddKeyPairDialogProps;
 
-function KeyPairDialog(props: KeyPairDialogProps) {
+function KeyPairDialog({
+  onAddKeyPair,
+  triggerButton,
+  keyPair,
+  existingKeyPairs,
+}: KeyPairDialogProps) {
   const [open, setOpen] = useState(false);
-  const { keyPair, onAddKeyPair } = props;
 
   const onSubmit: SubmitHandler<AddKeyPairFormProps> = async (formData) => {
     await onAddKeyPair(formData);
@@ -31,7 +35,7 @@ function KeyPairDialog(props: KeyPairDialogProps) {
   return (
     <div className='key-pair-dialog'>
       <Dialog
-        triggerButton={props.triggerButton}
+        triggerButton={triggerButton}
         title='Create Key Pair'
         closeButtonText='Cancel'
         open={open}
@@ -47,7 +51,7 @@ function KeyPairDialog(props: KeyPairDialogProps) {
             label='Name'
             rules={{
               required: 'Please specify key pair name.',
-              validate: (value: string) => validateUniqueKeyPairName(value, props.existingKeyPairs),
+              validate: (value: string) => validateUniqueKeyPairName(value, existingKeyPairs),
             }}
           />
         </Form>

--- a/src/web/components/KeyPairs/KeyPairEditDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairEditDialog.tsx
@@ -5,6 +5,7 @@ import { EditKeyPairFormDTO } from '../../../api/services/adminServiceHelpers';
 import { Dialog } from '../Core/Dialog';
 import { Form } from '../Core/Form';
 import { TextInput } from '../Input/TextInput';
+import { validateUniqueKeyPairName } from './KeyPairHelper';
 import { KeyPairModel } from './KeyPairModel';
 
 import '../ApiKeyManagement/KeyEditDialog.scss';
@@ -18,12 +19,14 @@ type KeyPairEditDialogProps = Readonly<{
   onEdit: OnKeyPairEdit;
   triggerButton: JSX.Element;
   keyPair: KeyPairModel;
+  existingKeyPairs: KeyPairModel[];
 }>;
 
 function KeyPairEditDialog({
   onEdit,
   triggerButton,
   keyPair: keyPairInitial,
+  existingKeyPairs,
 }: KeyPairEditDialogProps) {
   const [open, setOpen] = useState(false);
   const [keyPair, setKeyPair] = useState<KeyPairModel>(keyPairInitial);
@@ -53,7 +56,14 @@ function KeyPairEditDialog({
           defaultValues={defaultFormData}
           submitButtonText='Save Key Pair'
         >
-          <TextInput inputName='name' label='Name' required />
+          <TextInput
+            inputName='name'
+            label='Name'
+            rules={{
+              required: 'Please specify key pair name.',
+              validate: (value: string) => validateUniqueKeyPairName(value, existingKeyPairs),
+            }}
+          />
         </Form>
       </Dialog>
     </div>

--- a/src/web/components/KeyPairs/KeyPairHelper.ts
+++ b/src/web/components/KeyPairs/KeyPairHelper.ts
@@ -1,0 +1,12 @@
+import { KeyPairModel } from './KeyPairModel';
+
+export const validateUniqueKeyPairName = (
+  value: string,
+  existingKeyPairs: KeyPairModel[] | undefined
+) => {
+  const existingKeyPairNames = existingKeyPairs?.map((keypair) => keypair.name);
+  if (existingKeyPairNames?.includes(value)) {
+    return 'Please enter a key pair name that does not already exist.';
+  }
+  return true;
+};

--- a/src/web/components/KeyPairs/KeyPairHelper.ts
+++ b/src/web/components/KeyPairs/KeyPairHelper.ts
@@ -4,8 +4,7 @@ export const validateUniqueKeyPairName = (
   value: string,
   existingKeyPairs: KeyPairModel[] | undefined
 ) => {
-  const existingKeyPairNames = existingKeyPairs?.map((keypair) => keypair.name);
-  if (existingKeyPairNames?.includes(value)) {
+  if (existingKeyPairs && existingKeyPairs?.filter((k) => k.name === value).length > 0) {
     return 'Please enter a key pair name that does not already exist.';
   }
   return true;

--- a/src/web/components/KeyPairs/KeyPairsTable.tsx
+++ b/src/web/components/KeyPairs/KeyPairsTable.tsx
@@ -30,6 +30,7 @@ function KeyPairsTable({
         <div className='key-pairs-table-header-right'>
           <div className='add-key-pair'>
             <KeyPairDialog
+              existingKeyPairs={keyPairs}
               onAddKeyPair={onAddKeyPair}
               triggerButton={
                 <button className='small-button' type='button'>
@@ -56,6 +57,7 @@ function KeyPairsTable({
               <KeyPair
                 key={k.publicKey}
                 keyPair={k}
+                existingKeyPairs={keyPairs}
                 onEdit={onKeyPairEdit}
                 onDisable={onKeyPairDisable}
               />


### PR DESCRIPTION
- If a key pair name exists and is enabled for a specific site id, do not allow user to create a new key pair with the same name
- When a key pair gets disabled, rename the key pair to [keyPairName]-disabled-[timestamp]

Test Plan:
- Try and create new key pair with same name as one displayed and make sure it does not create the key pair
- Create a new key pair, delete it, then create a new key pair with the same name and make sure the key pair gets created
- Edit a key pair to the same name as another existing key pair and check that it does not allow this 