### PR TITLE
Added public key and subscription id as uneditable fields

### DIFF
--- a/src/api/services/adminServiceHelpers.ts
+++ b/src/api/services/adminServiceHelpers.ts
@@ -81,6 +81,7 @@ export type EditKeyPairFormDTO = {
   subscriptionId: string;
   name?: string;
   disabled: boolean;
+  publicKey: string;
 };
 
 export const AllowedSiteRolesById: Record<number, number[]> = {

--- a/src/web/components/KeyPairs/KeyPairEditDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairEditDialog.tsx
@@ -35,6 +35,7 @@ function KeyPairEditDialog({
 
   const defaultFormData: EditKeyPairFormDTO = {
     subscriptionId: keyPairInitial.subscriptionId,
+    publicKey: keyPairInitial.publicKey,
     name: keyPairInitial.name,
     disabled: keyPairInitial.disabled,
   };
@@ -54,6 +55,8 @@ function KeyPairEditDialog({
           submitButtonText='Save Key Pair'
         >
           <TextInput inputName='name' label='Name' required />
+          <TextInput inputName='subscriptionId' label='Subscription ID' disabled />
+          <TextInput inputName='publicKey' label='Public Key' disabled />
         </Form>
       </Dialog>
     </div>


### PR DESCRIPTION
Show public key and subscription ID in dialog, but as uneditable field.

TextInput disabled is a very light gray, but preferred for now by Kimberly. 