### PR TITLE
New dialog pattern part two

### DIFF
--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -61,6 +61,7 @@ export async function validateParticipantCreationRequest(
       errorMessage = 'Requested site name already exists';
     }
   }
+  console.log(errorMessage);
   return errorMessage;
 }
 

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -61,7 +61,7 @@ export async function validateParticipantCreationRequest(
       errorMessage = 'Requested site name already exists';
     }
   }
-  console.log(errorMessage);
+
   return errorMessage;
 }
 

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -61,7 +61,6 @@ export async function validateParticipantCreationRequest(
       errorMessage = 'Requested site name already exists';
     }
   }
-
   return errorMessage;
 }
 

--- a/src/web/components/Account/CreateAccountForm.tsx
+++ b/src/web/components/Account/CreateAccountForm.tsx
@@ -15,10 +15,10 @@ import { TextInput } from '../Input/TextInput';
 import './createAccountForm.scss';
 import '../../styles/forms.scss';
 
-export type CreateAccountFormProps = {
+export type CreateAccountFormProps = Readonly<{
   resolvedParticipantTypes: ParticipantTypeDTO[];
   onSubmit: (data: CreateParticipantForm) => Promise<string[] | void>;
-};
+}>;
 export function CreateAccountForm({ resolvedParticipantTypes, onSubmit }: CreateAccountFormProps) {
   const [showTermsDialog, setShowTermsDialog] = useState(false);
   const formMethods = useForm<CreateParticipantForm>({
@@ -90,7 +90,7 @@ export function CreateAccountForm({ resolvedParticipantTypes, onSubmit }: Create
             (must click link)
           </span>
           {showTermsDialog && (
-            <Dialog open onOpenChange={setShowTermsDialog} className='terms-conditions-dialog'>
+            <Dialog onOpenChange={setShowTermsDialog} className='terms-conditions-dialog'>
               <TermsAndConditionsForm
                 onAccept={handleAccept}
                 onCancel={() => setShowTermsDialog(false)}

--- a/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
@@ -117,7 +117,7 @@ function ShowApiKeySecrets({ keySecrets, closeDialog }: ApiKeySecretsProps) {
 
       <div className='button-container'>
         {showWarningDialog && (
-          <Dialog open onOpenChange={onOpenChangeWarningDialog} closeButtonText='Cancel'>
+          <Dialog onOpenChange={onOpenChangeWarningDialog} closeButtonText='Cancel'>
             <p>
               Make sure you&apos;ve copied your API secret and key to a secure location. After you
               close this page, they are no longer accessible.
@@ -148,7 +148,7 @@ function KeyCreationDialog({
 
   return (
     <div className='key-creation-dialog'>
-      <Dialog open onOpenChange={onOpenChange} hideCloseButtons>
+      <Dialog onOpenChange={onOpenChange} hideCloseButtons>
         {!keySecrets ? (
           <CreateApiKeyForm
             onFormSubmit={onFormSubmit}

--- a/src/web/components/ApiKeyManagement/KeyDisableDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyDisableDialog.tsx
@@ -27,7 +27,6 @@ function KeyDisableDialog({ onDisable, onOpenChange, apiKey }: KeyDisableDialogP
   return (
     <Dialog
       closeButtonText='Cancel'
-      open
       onOpenChange={onOpenChange}
       title={`Delete API Key: ${apiKey.name}`}
     >

--- a/src/web/components/ApiKeyManagement/KeyEditDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyEditDialog.tsx
@@ -52,7 +52,6 @@ function KeyEditDialog({
     <div className='key-edit-dialog'>
       <Dialog
         closeButtonText='Cancel'
-        open
         onOpenChange={onOpenChange}
         title={`Edit API Key: ${apiKey.name}`}
       >

--- a/src/web/components/BusinessContacts/BusinessContact.tsx
+++ b/src/web/components/BusinessContacts/BusinessContact.tsx
@@ -25,7 +25,6 @@ function DeleteBusinessContactDialog({
   return (
     <Dialog
       title='Are you sure you want to delete this email contact?'
-      open
       onOpenChange={onOpenChange}
       closeButtonText='Cancel'
     >

--- a/src/web/components/BusinessContacts/BusinessContactDialog.tsx
+++ b/src/web/components/BusinessContacts/BusinessContactDialog.tsx
@@ -32,7 +32,6 @@ function BusinessContactDialog({
     <Dialog
       title={`${contact ? 'Edit' : 'Add'} Email Contact`}
       closeButtonText='Cancel'
-      open
       onOpenChange={onOpenChange}
     >
       <FormProvider {...formMethods}>

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.tsx
@@ -77,7 +77,7 @@ function CstgAddDomainDialog({
 
   return (
     <div className='add-domain-dialog'>
-      <Dialog title='Add Domains' closeButtonText='Cancel' open onOpenChange={onOpenChange}>
+      <Dialog title='Add Domains' closeButtonText='Cancel' onOpenChange={onOpenChange}>
         <RootFormErrors fieldErrors={errors} />
         <FormProvider {...formMethods}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/web/components/ClientSideTokenGeneration/CstgDeleteDomainDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDeleteDomainDialog.tsx
@@ -20,7 +20,6 @@ function DeleteConfirmationDialog({
   return (
     <Dialog
       title='Are you sure you want to delete these domains?'
-      open
       onOpenChange={onOpenChange}
       closeButtonText='Cancel'
     >

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.tsx
@@ -55,12 +55,7 @@ function EditDomainDialog({
   };
 
   return (
-    <Dialog
-      title={`Edit Domain: ${domain}`}
-      open
-      onOpenChange={onOpenChange}
-      closeButtonText='Cancel'
-    >
+    <Dialog title={`Edit Domain: ${domain}`} onOpenChange={onOpenChange} closeButtonText='Cancel'>
       <RootFormErrors fieldErrors={errors} />
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/web/components/Core/Dialog.spec.tsx
+++ b/src/web/components/Core/Dialog.spec.tsx
@@ -8,8 +8,6 @@ const { Default, WithoutCloseText, WithoutCloseButtons } = composeStories(storie
 describe('Dialog', () => {
   it('renders correctly with default props', () => {
     render(<Default />);
-    const openButton = screen.getByText('Open Dialog');
-    fireEvent.click(openButton);
 
     expect(screen.getByText('Dialog Title')).toBeInTheDocument();
     expect(screen.getByText('Dialog content goes here')).toBeInTheDocument();
@@ -19,8 +17,6 @@ describe('Dialog', () => {
 
   it('does not render text close button if closeButton is undefined', () => {
     render(<WithoutCloseText />);
-    const openButton = screen.getByText('Open Dialog');
-    fireEvent.click(openButton);
 
     expect(screen.queryByRole('button', { name: 'Close Button' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Close Icon' })).toBeInTheDocument();
@@ -28,8 +24,6 @@ describe('Dialog', () => {
 
   it('does not render close buttons if hideCloseButtons', () => {
     render(<WithoutCloseButtons />);
-    const openButton = screen.getByText('Open Dialog');
-    fireEvent.click(openButton);
 
     expect(screen.queryByRole('button', { name: 'Close Button' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close Icon' })).not.toBeInTheDocument();
@@ -37,7 +31,7 @@ describe('Dialog', () => {
 
   it('open dialog with external button', () => {
     render(<stories.WithOpenAndOnOpenChange />);
-    const openButton = screen.getByText('Open');
+    const openButton = screen.getByText('Open Dialog');
 
     fireEvent.click(openButton);
     expect(screen.getByText('Dialog Title')).toBeInTheDocument();

--- a/src/web/components/Core/Dialog.stories.tsx
+++ b/src/web/components/Core/Dialog.stories.tsx
@@ -12,11 +12,6 @@ const Template: ComponentStory<typeof Dialog> = (args) => <Dialog {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  triggerButton: (
-    <button className='small-button' type='button'>
-      Open Dialog
-    </button>
-  ),
   title: 'Dialog Title',
   closeButtonText: 'Close',
   children: 'Dialog content goes here',
@@ -42,26 +37,19 @@ WithoutCloseButtons.args = {
 };
 
 export const WithOpenAndOnOpenChange = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const handleOpenChange = (open: boolean) => setIsOpen(open);
 
   return (
     <div>
-      <Dialog
-        title='Dialog Title'
-        triggerButton={
-          <button className='small-button' type='button'>
-            Open Dialog
-          </button>
-        }
-        open={isOpen}
-        onOpenChange={handleOpenChange}
-      >
-        Dialog content goes here
-      </Dialog>
-      <button type='button' onClick={() => setIsOpen(true)}>
-        Open
+      <button className='small-button' type='button' onClick={() => setIsOpen(true)}>
+        Open Dialog
       </button>
+      {isOpen && (
+        <Dialog title='Dialog Title' onOpenChange={handleOpenChange}>
+          Dialog content goes here
+        </Dialog>
+      )}
     </div>
   );
 };

--- a/src/web/components/Core/Dialog.stories.tsx
+++ b/src/web/components/Core/Dialog.stories.tsx
@@ -38,11 +38,14 @@ WithoutCloseButtons.args = {
 
 export const WithOpenAndOnOpenChange = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const handleOpenChange = (open: boolean) => setIsOpen(open);
+
+  const handleOpenChange = () => {
+    setIsOpen(!isOpen);
+  };
 
   return (
     <div>
-      <button className='small-button' type='button' onClick={() => setIsOpen(true)}>
+      <button className='small-button' type='button' onClick={handleOpenChange}>
         Open Dialog
       </button>
       {isOpen && (

--- a/src/web/components/Core/Dialog.tsx
+++ b/src/web/components/Core/Dialog.tsx
@@ -6,11 +6,9 @@ import { ReactNode } from 'react';
 import './Dialog.scss';
 
 export type DialogProps = Readonly<{
-  triggerButton?: JSX.Element;
   children: ReactNode;
   title?: string;
   closeButtonText?: string;
-  open?: boolean;
   onOpenChange?: (open: boolean) => void;
   fullScreen?: boolean;
   className?: string;
@@ -18,11 +16,9 @@ export type DialogProps = Readonly<{
   hideActionCloseButtonOnly?: boolean;
 }>;
 export function Dialog({
-  triggerButton,
   children,
   title,
   closeButtonText,
-  open,
   onOpenChange,
   fullScreen,
   className,
@@ -30,8 +26,7 @@ export function Dialog({
   hideActionCloseButtonOnly = false,
 }: DialogProps) {
   return (
-    <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
-      {triggerButton && <RadixDialog.Trigger asChild>{triggerButton}</RadixDialog.Trigger>}
+    <RadixDialog.Root onOpenChange={onOpenChange}>
       <RadixDialog.Overlay className='dialog-overlay' />
       <RadixDialog.Content
         className='dialog-container'

--- a/src/web/components/Core/Dialog.tsx
+++ b/src/web/components/Core/Dialog.tsx
@@ -5,7 +5,7 @@ import { ReactNode } from 'react';
 
 import './Dialog.scss';
 
-export type DialogProps = {
+export type DialogProps = Readonly<{
   triggerButton?: JSX.Element;
   children: ReactNode;
   title?: string;
@@ -16,7 +16,7 @@ export type DialogProps = {
   className?: string;
   hideCloseButtons?: boolean;
   hideActionCloseButtonOnly?: boolean;
-};
+}>;
 export function Dialog({
   triggerButton,
   children,

--- a/src/web/components/Core/Dialog.tsx
+++ b/src/web/components/Core/Dialog.tsx
@@ -26,7 +26,7 @@ export function Dialog({
   hideActionCloseButtonOnly = false,
 }: DialogProps) {
   return (
-    <RadixDialog.Root onOpenChange={onOpenChange}>
+    <RadixDialog.Root open onOpenChange={onOpenChange}>
       <RadixDialog.Overlay className='dialog-overlay' />
       <RadixDialog.Content
         className='dialog-container'

--- a/src/web/components/Core/TermsAndConditions.stories.tsx
+++ b/src/web/components/Core/TermsAndConditions.stories.tsx
@@ -9,7 +9,7 @@ export default {
 } as ComponentMeta<typeof TermsAndConditionsForm | typeof TermsAndConditions>;
 
 const Template: ComponentStory<typeof TermsAndConditionsForm> = (args) => (
-  <Dialog open className='terms-conditions-dialog'>
+  <Dialog className='terms-conditions-dialog'>
     <TermsAndConditionsForm {...args} />
   </Dialog>
 );

--- a/src/web/components/KeyPairs/KeyPairDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairDialog.tsx
@@ -35,7 +35,7 @@ function KeyPairDialog({
 
   return (
     <div className='key-pair-dialog'>
-      <Dialog title='Add Key Pair' closeButtonText='Cancel' open onOpenChange={onOpenChange}>
+      <Dialog title='Add Key Pair' closeButtonText='Cancel' onOpenChange={onOpenChange}>
         <FormProvider {...formMethods}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <TextInput

--- a/src/web/components/KeyPairs/KeyPairDisableDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairDisableDialog.tsx
@@ -27,7 +27,6 @@ function KeyPairDisableDialog({ onDisable, keyPair, onOpenChange }: KeyPairDisab
   return (
     <Dialog
       closeButtonText='Cancel'
-      open
       onOpenChange={onOpenChange}
       title={`Delete Key Pair: ${keyPair.name}`}
     >

--- a/src/web/components/KeyPairs/KeyPairEditDialog.tsx
+++ b/src/web/components/KeyPairs/KeyPairEditDialog.tsx
@@ -53,7 +53,6 @@ function KeyPairEditDialog({
     <div>
       <Dialog
         closeButtonText='Cancel'
-        open
         onOpenChange={onOpenChange}
         title={`Edit Key Pair: ${keyPair.name}`}
       >

--- a/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
@@ -57,7 +57,6 @@ function AddParticipantDialog({
     setValue,
     watch,
     handleSubmit,
-    reset,
     setError,
     formState: { errors },
   } = formMethods;
@@ -78,18 +77,7 @@ function AddParticipantDialog({
       }
     });
     return () => subscription.unsubscribe();
-  }, [watch, setValue, open]);
-
-  useEffect(() => {
-    if (!open) {
-      // the dialog doesn't de-render on close, so we need to clean up our state
-      setSearchText('');
-      setSiteSearchResults(undefined);
-      setSelectedSite(undefined);
-      setNewSite(false);
-      reset();
-    }
-  }, [open, reset]);
+  }, [watch, setValue]);
 
   const onSubmit = useCallback(
     async (formData: AddParticipantForm) => {
@@ -99,7 +87,7 @@ function AddParticipantDialog({
       }
       onOpenChange();
     },
-    [onAddParticipant]
+    [onAddParticipant, onOpenChange]
   );
 
   const submit = useCallback(

--- a/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
@@ -26,17 +26,17 @@ import { HighlightedResult } from './ParticipantApprovalForm';
 import './AddParticipantDialog.scss';
 
 type AddParticipantDialogProps = Readonly<{
-  triggerButton: JSX.Element;
   onAddParticipant: (form: AddParticipantForm) => Promise<AxiosResponse>;
   apiRoles: ApiRoleDTO[];
   participantTypes: ParticipantTypeDTO[];
+  onOpenChange: () => void;
 }>;
 
 function AddParticipantDialog({
-  triggerButton,
   onAddParticipant,
   apiRoles,
   participantTypes,
+  onOpenChange,
 }: AddParticipantDialogProps) {
   const { sites } = useSiteList();
   const fuse = useMemo(
@@ -46,7 +46,7 @@ function AddParticipantDialog({
         : null,
     [sites]
   );
-  const [open, setOpen] = useState(false);
+
   const [siteSearchResults, setSiteSearchResults] = useState<Fuse.FuseResult<SiteDTO>[]>();
   const [searchText, setSearchText] = useState('');
   const [selectedSite, setSelectedSite] = useState<SiteDTO>();
@@ -97,7 +97,7 @@ function AddParticipantDialog({
       if (response.status === 200) {
         SuccessToast('Participant Added.');
       }
-      setOpen(false);
+      onOpenChange();
     },
     [onAddParticipant]
   );
@@ -139,11 +139,9 @@ function AddParticipantDialog({
 
   return (
     <Dialog
-      triggerButton={triggerButton}
       title='Add Participant'
       closeButtonText='Cancel'
-      open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       className='add-participant-dialog'
       hideActionCloseButtonOnly
     >
@@ -292,7 +290,7 @@ function AddParticipantDialog({
             <div className='action-container'>
               <FormSubmitButton>Add Participant</FormSubmitButton>
               <div className='cancel-button'>
-                <button type='button' className='transparent-button' onClick={() => setOpen(false)}>
+                <button type='button' className='transparent-button' onClick={onOpenChange}>
                   Cancel
                 </button>
               </div>

--- a/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
+++ b/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
@@ -24,10 +24,10 @@ export function ApprovedParticipantItem({
   participantTypes,
   onUpdateParticipant,
 }: ApprovedParticipantProps) {
-  const [showUpdateParticipantDialog, setShowUpdateParticipantDialog] = useState<boolean>(false);
+  const [showEditParticipantDialog, setShowEditParticipantDialog] = useState<boolean>(false);
 
-  const onOpenChangeUpdateParticipantDialog = () => {
-    setShowUpdateParticipantDialog(!showUpdateParticipantDialog);
+  const onOpenChangeEditParticipantDialog = () => {
+    setShowEditParticipantDialog(!showEditParticipantDialog);
   };
 
   function getParticipantTypes(
@@ -76,17 +76,17 @@ export function ApprovedParticipantItem({
           <button
             type='button'
             className='transparent-button'
-            onClick={onOpenChangeUpdateParticipantDialog}
+            onClick={onOpenChangeEditParticipantDialog}
           >
             <FontAwesomeIcon icon='pencil' />
           </button>
-          {showUpdateParticipantDialog && (
+          {showEditParticipantDialog && (
             <EditParticipantDialog
               apiRoles={apiRoles}
               onEditParticipant={onUpdateParticipant}
               participant={participant}
               participantTypes={participantTypes}
-              onOpenChange={onOpenChangeUpdateParticipantDialog}
+              onOpenChange={onOpenChangeEditParticipantDialog}
             />
           )}
         </div>

--- a/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
+++ b/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
@@ -1,4 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useState } from 'react';
 
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantDTO } from '../../../api/entities/Participant';
@@ -6,7 +7,7 @@ import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { UserDTO } from '../../../api/entities/User';
 import { UpdateParticipantForm } from '../../services/participant';
 import ApiRolesCell from '../ApiKeyManagement/ApiRolesCell';
-import UpdateParticipantDialog from './UpdateParticipantDialog';
+import UpdateParticipantDialog from './EditParticipantDialog';
 
 import './ParticipantManagementItem.scss';
 
@@ -23,6 +24,12 @@ export function ApprovedParticipantItem({
   participantTypes,
   onUpdateParticipant,
 }: ApprovedParticipantProps) {
+  const [showUpdateParticipantDialog, setShowUpdateParticipantDialog] = useState<boolean>(false);
+
+  const onOpenChangeUpdateParticipantDialog = () => {
+    setShowUpdateParticipantDialog(!showUpdateParticipantDialog);
+  };
+
   function getParticipantTypes(
     currentParticipantTypes?: ApprovedParticipantProps['participant']['types']
   ) {
@@ -66,17 +73,22 @@ export function ApprovedParticipantItem({
       <td>{participant.crmAgreementNumber}</td>
       <td className='action'>
         <div className='action-cell'>
-          <UpdateParticipantDialog
-            apiRoles={apiRoles}
-            onUpdateParticipant={onUpdateParticipant}
-            participant={participant}
-            participantTypes={participantTypes}
-            triggerButton={
-              <button type='button' className='transparent-button'>
-                <FontAwesomeIcon icon='pencil' />
-              </button>
-            }
-          />
+          <button
+            type='button'
+            className='transparent-button'
+            onClick={onOpenChangeUpdateParticipantDialog}
+          >
+            <FontAwesomeIcon icon='pencil' />
+          </button>
+          {showUpdateParticipantDialog && (
+            <UpdateParticipantDialog
+              apiRoles={apiRoles}
+              onUpdateParticipant={onUpdateParticipant}
+              participant={participant}
+              participantTypes={participantTypes}
+              onOpenChange={onOpenChangeUpdateParticipantDialog}
+            />
+          )}
         </div>
       </td>
     </tr>

--- a/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
+++ b/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
@@ -7,7 +7,7 @@ import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
 import { UserDTO } from '../../../api/entities/User';
 import { UpdateParticipantForm } from '../../services/participant';
 import ApiRolesCell from '../ApiKeyManagement/ApiRolesCell';
-import UpdateParticipantDialog from './EditParticipantDialog';
+import EditParticipantDialog from './EditParticipantDialog';
 
 import './ParticipantManagementItem.scss';
 
@@ -81,9 +81,9 @@ export function ApprovedParticipantItem({
             <FontAwesomeIcon icon='pencil' />
           </button>
           {showUpdateParticipantDialog && (
-            <UpdateParticipantDialog
+            <EditParticipantDialog
               apiRoles={apiRoles}
-              onUpdateParticipant={onUpdateParticipant}
+              onEditParticipant={onUpdateParticipant}
               participant={participant}
               participantTypes={participantTypes}
               onOpenChange={onOpenChangeUpdateParticipantDialog}

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
@@ -2,15 +2,15 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
 import { UserRole } from '../../../api/entities/User';
-import UpdateParticipantDialog from './EditParticipantDialog';
+import EditParticipantDialog from './EditParticipantDialog';
 
-const meta: Meta<typeof UpdateParticipantDialog> = {
-  component: UpdateParticipantDialog,
+const meta: Meta<typeof EditParticipantDialog> = {
+  component: EditParticipantDialog,
   title: 'Manage Participants/Update Participant Dialog',
 };
 export default meta;
 
-type Story = StoryObj<typeof UpdateParticipantDialog>;
+type Story = StoryObj<typeof EditParticipantDialog>;
 
 export const ParticipantWithExistingRoles: Story = {
   args: {
@@ -55,7 +55,7 @@ export const ParticipantWithExistingRoles: Story = {
         },
       ],
     },
-    onUpdateParticipant: (form) => {
+    onEditParticipant: (form) => {
       console.log(form);
       return Promise.resolve();
     },
@@ -96,7 +96,7 @@ export const ParticipantWithNoRolesOrTypes: Story = {
         },
       ],
     },
-    onUpdateParticipant: (form) => {
+    onEditParticipant: (form) => {
       console.log(form);
       return Promise.resolve();
     },

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
 import { UserRole } from '../../../api/entities/User';
-import UpdateParticipantDialog from './UpdateParticipantDialog';
+import UpdateParticipantDialog from './EditParticipantDialog';
 
 const meta: Meta<typeof UpdateParticipantDialog> = {
   component: UpdateParticipantDialog,
@@ -59,7 +59,6 @@ export const ParticipantWithExistingRoles: Story = {
       console.log(form);
       return Promise.resolve();
     },
-    triggerButton: <button type='button'>Open</button>,
   },
 };
 
@@ -101,6 +100,5 @@ export const ParticipantWithNoRolesOrTypes: Story = {
       console.log(form);
       return Promise.resolve();
     },
-    triggerButton: <button type='button'>Open</button>,
   },
 };

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
@@ -6,7 +6,7 @@ import EditParticipantDialog from './EditParticipantDialog';
 
 const meta: Meta<typeof EditParticipantDialog> = {
   component: EditParticipantDialog,
-  title: 'Manage Participants/Update Participant Dialog',
+  title: 'Manage Participants/Edit Participant Dialog',
 };
 export default meta;
 

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
@@ -47,7 +47,6 @@ function EditParticipantDialog({
     <Dialog
       title={`Edit Participant: ${participant.name}`}
       closeButtonText='Cancel'
-      open
       onOpenChange={onOpenChange}
     >
       <FormProvider {...formMethods}>

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
@@ -13,29 +12,23 @@ import { TextInput } from '../Input/TextInput';
 import { validateEditcrmAgreementNumber } from './AddParticipantDialogHelper';
 
 type UpdateParticipantDialogProps = Readonly<{
-  triggerButton: JSX.Element;
   participant: ParticipantDTO;
   onUpdateParticipant: (form: UpdateParticipantForm, participant: ParticipantDTO) => Promise<void>;
   apiRoles: ApiRoleDTO[];
   participantTypes: ParticipantTypeDTO[];
+  onOpenChange: () => void;
 }>;
 
 function UpdateParticipantDialog({
-  triggerButton,
   participant,
   onUpdateParticipant,
   apiRoles,
   participantTypes,
+  onOpenChange,
 }: UpdateParticipantDialogProps) {
-  const [open, setOpen] = useState(false);
-
   const onSubmit = async (formData: UpdateParticipantForm) => {
     await onUpdateParticipant(formData, participant);
-    setOpen(false);
-  };
-
-  const onOpenChange = () => {
-    setOpen(!open);
+    onOpenChange();
   };
 
   const originalFormValues: UpdateParticipantForm = {
@@ -52,10 +45,9 @@ function UpdateParticipantDialog({
 
   return (
     <Dialog
-      triggerButton={triggerButton}
       title={`Edit Participant: ${participant.name}`}
       closeButtonText='Cancel'
-      open={open}
+      open
       onOpenChange={onOpenChange}
     >
       <FormProvider {...formMethods}>

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
@@ -11,23 +11,23 @@ import { MultiCheckboxInput } from '../Input/MultiCheckboxInput';
 import { TextInput } from '../Input/TextInput';
 import { validateEditcrmAgreementNumber } from './AddParticipantDialogHelper';
 
-type UpdateParticipantDialogProps = Readonly<{
+type EditParticipantDialogProps = Readonly<{
   participant: ParticipantDTO;
-  onUpdateParticipant: (form: UpdateParticipantForm, participant: ParticipantDTO) => Promise<void>;
+  onEditParticipant: (form: UpdateParticipantForm, participant: ParticipantDTO) => Promise<void>;
   apiRoles: ApiRoleDTO[];
   participantTypes: ParticipantTypeDTO[];
   onOpenChange: () => void;
 }>;
 
-function UpdateParticipantDialog({
+function EditParticipantDialog({
   participant,
-  onUpdateParticipant,
+  onEditParticipant,
   apiRoles,
   participantTypes,
   onOpenChange,
-}: UpdateParticipantDialogProps) {
+}: EditParticipantDialogProps) {
   const onSubmit = async (formData: UpdateParticipantForm) => {
-    await onUpdateParticipant(formData, participant);
+    await onEditParticipant(formData, participant);
     onOpenChange();
   };
 
@@ -94,4 +94,4 @@ function UpdateParticipantDialog({
   );
 }
 
-export default UpdateParticipantDialog;
+export default EditParticipantDialog;

--- a/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
@@ -24,7 +24,7 @@ export function ParticipantRequestItem({
   onApprove,
 }: ParticipantRequestProps) {
   const [hasError, setHasError] = useState<boolean>(false);
-  const [open, setOpen] = useState(false);
+  const [showApproveParticipantDialog, setShowApproveParticipantDialog] = useState(false);
 
   function getParticipantTypes(
     currentParticipantTypes?: ParticipantRequestProps['participantRequest']['types']
@@ -43,6 +43,10 @@ export function ParticipantRequestItem({
     } catch (err) {
       setHasError(true);
     }
+  };
+
+  const onOpenChangeApproveParticipantDialog = () => {
+    setShowApproveParticipantDialog(!showApproveParticipantDialog);
   };
 
   return (
@@ -68,16 +72,16 @@ export function ParticipantRequestItem({
           <button
             type='button'
             className='transparent-button approve-button'
-            onClick={() => setOpen(true)}
+            onClick={onOpenChangeApproveParticipantDialog}
           >
             Approve
           </button>
-          {open && (
+          {showApproveParticipantDialog && (
             <Dialog
               title='Approve Participant Request'
               closeButtonText='Cancel'
               open
-              onOpenChange={setOpen}
+              onOpenChange={onOpenChangeApproveParticipantDialog}
               className='participants-request-dialog'
             >
               <ParticipantApprovalForm

--- a/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
@@ -80,7 +80,6 @@ export function ParticipantRequestItem({
             <Dialog
               title='Approve Participant Request'
               closeButtonText='Cancel'
-              open
               onOpenChange={onOpenChangeApproveParticipantDialog}
               className='participants-request-dialog'
             >

--- a/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
@@ -10,12 +10,12 @@ import ParticipantApprovalForm from './ParticipantApprovalForm';
 
 import './ParticipantManagementItem.scss';
 
-type ParticipantRequestProps = {
+type ParticipantRequestProps = Readonly<{
   participantRequest: ParticipantRequestDTO;
   participantTypes: ParticipantTypeDTO[];
   apiRoles: ApiRoleDTO[];
   onApprove: (participantId: number, formData: ParticipantApprovalFormDetails) => Promise<void>;
-};
+}>;
 
 export function ParticipantRequestItem({
   participantRequest: participant,
@@ -72,20 +72,22 @@ export function ParticipantRequestItem({
           >
             Approve
           </button>
-          <Dialog
-            title='Approve Participant Request'
-            closeButtonText='Cancel'
-            open={open}
-            onOpenChange={setOpen}
-            className='participants-request-dialog'
-          >
-            <ParticipantApprovalForm
-              onApprove={handleApprove}
-              participant={participant}
-              participantTypes={participantTypes}
-              apiRoles={apiRoles}
-            />
-          </Dialog>
+          {open && (
+            <Dialog
+              title='Approve Participant Request'
+              closeButtonText='Cancel'
+              open
+              onOpenChange={setOpen}
+              className='participants-request-dialog'
+            >
+              <ParticipantApprovalForm
+                onApprove={handleApprove}
+                participant={participant}
+                participantTypes={participantTypes}
+                apiRoles={apiRoles}
+              />
+            </Dialog>
+          )}
         </div>
       </td>
     </tr>

--- a/src/web/components/ParticipantManagement/ParticipantRequestsTable.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestsTable.tsx
@@ -7,12 +7,12 @@ import { ParticipantRequestItem } from './ParticipantRequestItem';
 
 import './ParticipantManagementTable.scss';
 
-type ParticipantRequestsTableProps = {
+type ParticipantRequestsTableProps = Readonly<{
   participantRequests: ParticipantRequestDTO[];
   participantTypes: ParticipantTypeDTO[];
   apiRoles: ApiRoleDTO[];
   onApprove: (participantId: number, formData: ParticipantApprovalFormDetails) => Promise<void>;
-};
+}>;
 
 function NoParticipantRequests() {
   return (

--- a/src/web/components/SharingPermission/SearchAndAddParticipants.tsx
+++ b/src/web/components/SharingPermission/SearchAndAddParticipants.tsx
@@ -83,7 +83,6 @@ export function SearchAndAddParticipants({
         {showAddPermissionsDialog && (
           <Dialog
             title='Please review the following changes'
-            open
             onOpenChange={onOpenChangeAddPermissionsDialog}
             closeButtonText='Cancel'
           >

--- a/src/web/components/SharingPermission/SearchAndAddParticipants.tsx
+++ b/src/web/components/SharingPermission/SearchAndAddParticipants.tsx
@@ -9,21 +9,27 @@ import { ParticipantSearchBar } from './ParticipantSearchBar';
 
 import './SearchAndAddParticipants.scss';
 
-type SearchAndAddParticipantsProps = {
+type SearchAndAddParticipantsProps = Readonly<{
   onSharingPermissionsAdded: (selectedSiteIds: number[]) => Promise<void>;
   sharedSiteIds: number[];
-};
+}>;
+
 export function SearchAndAddParticipants({
   onSharingPermissionsAdded,
   sharedSiteIds,
 }: SearchAndAddParticipantsProps) {
   const { sites, isLoading } = useAvailableSiteList();
-  const [openConfirmation, setOpenConfirmation] = useState(false);
+  const [showAddPermissionsDialog, setShowAddPermissionsDialog] = useState(false);
   const [selectedSites, setSelectedSites] = useState<Set<number>>(new Set());
   const [openSearchResult, setOpenSearchResult] = useState<boolean>(false);
   const { participant } = useContext(ParticipantContext);
+
+  const onOpenChangeAddPermissionsDialog = () => {
+    setShowAddPermissionsDialog(!showAddPermissionsDialog);
+  };
+
   const onHandleAddSites = () => {
-    setOpenConfirmation(false);
+    onOpenChangeAddPermissionsDialog();
     setSelectedSites(new Set());
     onSharingPermissionsAdded(Array.from(selectedSites));
   };
@@ -66,33 +72,34 @@ export function SearchAndAddParticipants({
       />
       <div className='action-section'>
         {selectedSites.size > 0 && <p>{getSitesText(selectedSites.size)} selected</p>}
-        <Dialog
-          title='Please review the following changes'
-          triggerButton={
-            <button
-              type='button'
-              className='primary-button add-participant-button'
-              disabled={!selectedSites.size}
-            >
-              Add Permissions
-            </button>
-          }
-          open={openConfirmation}
-          onOpenChange={setOpenConfirmation}
-          closeButtonText='Cancel'
+        <button
+          type='button'
+          className='primary-button add-participant-button'
+          disabled={!selectedSites.size}
+          onClick={onOpenChangeAddPermissionsDialog}
         >
-          Adding permissions for the following participants:
-          <ul className='dot-list'>
-            {selectedSiteList.map((selectedParticipant) => (
-              <li key={selectedParticipant.id}>{selectedParticipant.name}</li>
-            ))}
-          </ul>
-          <div className='dialog-footer-section'>
-            <button type='button' className='primary-button' onClick={onHandleAddSites}>
-              Save
-            </button>
-          </div>
-        </Dialog>
+          Add Permissions
+        </button>
+        {showAddPermissionsDialog && (
+          <Dialog
+            title='Please review the following changes'
+            open
+            onOpenChange={onOpenChangeAddPermissionsDialog}
+            closeButtonText='Cancel'
+          >
+            Adding permissions for the following participants:
+            <ul className='dot-list'>
+              {selectedSiteList.map((selectedParticipant) => (
+                <li key={selectedParticipant.id}>{selectedParticipant.name}</li>
+              ))}
+            </ul>
+            <div className='dialog-footer-section'>
+              <button type='button' className='primary-button' onClick={onHandleAddSites}>
+                Save
+              </button>
+            </div>
+          </Dialog>
+        )}
       </div>
     </div>
   );

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -86,7 +86,6 @@ function DeletePermissionDialog({
       {showDeletePermissionsDialog && (
         <Dialog
           title='Are you sure you want to delete these permissions?'
-          open
           onOpenChange={onOpenChangeDeletePermissionsDialog}
           closeButtonText='Cancel'
         >

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -39,19 +39,23 @@ function NoParticipant() {
   );
 }
 
-type DeletePermissionDialogProps = {
+type DeletePermissionDialogProps = Readonly<{
   onDeleteSharingPermission: () => void;
   selectedSiteList: SharingSiteWithSource[];
-};
+}>;
 function DeletePermissionDialog({
   onDeleteSharingPermission,
   selectedSiteList,
 }: DeletePermissionDialogProps) {
-  const [openConfirmation, setOpenConfirmation] = useState(false);
+  const [showDeletePermissionsDialog, setShowDeletePermissionsDialog] = useState(false);
+
+  const onOpenChangeDeletePermissionsDialog = () => {
+    setShowDeletePermissionsDialog(!showDeletePermissionsDialog);
+  };
 
   const handleDeletePermissions = () => {
     onDeleteSharingPermission();
-    setOpenConfirmation(false);
+    onOpenChangeDeletePermissionsDialog();
   };
 
   const showDeletionNotice = (participant: SharingSiteWithSource) => {
@@ -70,44 +74,47 @@ function DeletePermissionDialog({
   };
 
   return (
-    <Dialog
-      title='Are you sure you want to delete these permissions?'
-      triggerButton={
-        <button className='transparent-button sharing-permission-delete-button' type='button'>
-          <FontAwesomeIcon
-            icon={['far', 'trash-can']}
-            className='sharing-permission-trashcan-icon'
-          />
-          Delete Permissions
-        </button>
-      }
-      open={openConfirmation}
-      onOpenChange={setOpenConfirmation}
-      closeButtonText='Cancel'
-    >
-      <div className='dialog-body-section'>
-        <ul className='dot-list'>
-          {selectedSiteList.map((participant) => (
-            <li key={participant.id}>
-              {participant.name}
-              {showDeletionNotice(participant)}
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div className='dialog-footer-section'>
-        <button type='button' className='primary-button' onClick={handleDeletePermissions}>
-          Delete Permissions
-        </button>
-      </div>
-    </Dialog>
+    <div>
+      <button
+        className='transparent-button sharing-permission-delete-button'
+        type='button'
+        onClick={onOpenChangeDeletePermissionsDialog}
+      >
+        <FontAwesomeIcon icon={['far', 'trash-can']} className='sharing-permission-trashcan-icon' />
+        Delete Permissions
+      </button>
+      {showDeletePermissionsDialog && (
+        <Dialog
+          title='Are you sure you want to delete these permissions?'
+          open
+          onOpenChange={onOpenChangeDeletePermissionsDialog}
+          closeButtonText='Cancel'
+        >
+          <div className='dialog-body-section'>
+            <ul className='dot-list'>
+              {selectedSiteList.map((participant) => (
+                <li key={participant.id}>
+                  {participant.name}
+                  {showDeletionNotice(participant)}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className='dialog-footer-section'>
+            <button type='button' className='primary-button' onClick={handleDeletePermissions}>
+              Delete Permissions
+            </button>
+          </div>
+        </Dialog>
+      )}
+    </div>
   );
 }
 
-type SharingPermissionsTableContentProps = {
+type SharingPermissionsTableContentProps = Readonly<{
   sharingSites: SharingSiteWithSource[];
   onDeleteSharingPermission: (siteIds: number[]) => Promise<void>;
-};
+}>;
 
 export function SharingPermissionsTableContent({
   sharingSites,
@@ -210,11 +217,11 @@ export function SharingPermissionsTableContent({
   );
 }
 
-type SharingPermissionsTableProps = {
+type SharingPermissionsTableProps = Readonly<{
   sharedSiteIds: number[];
   sharedTypes: ClientType[];
   onDeleteSharingPermission: (siteIds: number[]) => Promise<void>;
-};
+}>;
 
 export function SharingPermissionsTable({
   sharedSiteIds,

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -10,29 +10,26 @@ import { InlineMessage } from '../Core/InlineMessage';
 import { SuccessToast } from '../Core/Toast';
 import TeamMemberDialog from './TeamMemberDialog';
 
-type DeleteConfirmationDialogProps = {
+type DeleteConfirmationDialogProps = Readonly<{
   person: UserResponse;
   onRemoveTeamMember: () => Promise<void>;
-};
+  onOpenChange: () => void;
+}>;
 
-function DeleteConfirmationDialog({ person, onRemoveTeamMember }: DeleteConfirmationDialogProps) {
-  const [openConfirmation, setOpenConfirmation] = useState(false);
-
+function DeleteConfirmationDialog({
+  person,
+  onRemoveTeamMember,
+  onOpenChange,
+}: DeleteConfirmationDialogProps) {
   const handleRemove = async () => {
-    setOpenConfirmation(false);
     await onRemoveTeamMember();
+    onOpenChange();
   };
 
   return (
     <Dialog
       title='Are you sure you want to delete this team member?'
-      triggerButton={
-        <button className='icon-button' aria-label='delete' type='button'>
-          <FontAwesomeIcon icon='trash-can' />
-        </button>
-      }
-      open={openConfirmation}
-      onOpenChange={setOpenConfirmation}
+      onOpenChange={onOpenChange}
       closeButtonText='Cancel'
     >
       <ul className='dot-list'>
@@ -49,12 +46,12 @@ function DeleteConfirmationDialog({ person, onRemoveTeamMember }: DeleteConfirma
   );
 }
 
-type TeamMemberProps = {
+type TeamMemberProps = Readonly<{
   person: UserResponse;
   resendInvite: (id: number) => Promise<void>;
   onRemoveTeamMember: (id: number) => Promise<void>;
   onUpdateTeamMember: (id: number, form: UpdateTeamMemberForm) => Promise<void>;
-};
+}>;
 
 enum InviteState {
   initial,
@@ -71,6 +68,7 @@ function TeamMember({
   const [reinviteState, setInviteState] = useState<InviteState>(InviteState.initial);
   const [errorMessage, setErrorMessage] = useState<string>();
   const [showTeamMemberDialog, setShowTeamMemberDialog] = useState<boolean>();
+  const [showDeleteTeamMemberDialog, setShowDeleteTeamMemberDialog] = useState<boolean>();
 
   const setErrorInfo = (e: Error) => {
     setErrorMessage(e.message);
@@ -78,6 +76,10 @@ function TeamMember({
 
   const onOpenChangeTeamMemberDialog = () => {
     setShowTeamMemberDialog(!showTeamMemberDialog);
+  };
+
+  const onOpenChangeDeleteTeamMemberDialog = () => {
+    setShowDeleteTeamMemberDialog(!showDeleteTeamMemberDialog);
   };
 
   const onResendInvite = useCallback(async () => {
@@ -143,7 +145,12 @@ function TeamMember({
                 {reinviteState === InviteState.error && 'Try again later'}
               </button>
             )}
-            <button className='icon-button' aria-label='edit' type='button' onClick={onOpenChangeTeamMemberDialog}>
+            <button
+              className='icon-button'
+              aria-label='edit'
+              type='button'
+              onClick={onOpenChangeTeamMemberDialog}
+            >
               <FontAwesomeIcon icon='pencil' />
             </button>
             {showTeamMemberDialog && (
@@ -153,7 +160,21 @@ function TeamMember({
                 onOpenChange={onOpenChangeTeamMemberDialog}
               />
             )}
-            <DeleteConfirmationDialog onRemoveTeamMember={handleRemoveUser} person={person} />
+            <button
+              className='icon-button'
+              aria-label='delete'
+              type='button'
+              onClick={onOpenChangeDeleteTeamMemberDialog}
+            >
+              <FontAwesomeIcon icon='trash-can' />
+            </button>
+            {showDeleteTeamMemberDialog && (
+              <DeleteConfirmationDialog
+                onRemoveTeamMember={handleRemoveUser}
+                person={person}
+                onOpenChange={onOpenChangeDeleteTeamMemberDialog}
+              />
+            )}
           </div>
         </div>
       </td>

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -5,46 +5,10 @@ import { useCallback, useState } from 'react';
 
 import { UpdateTeamMemberForm, UserResponse } from '../../services/userAccount';
 import { handleErrorToast } from '../../utils/apiError';
-import { Dialog } from '../Core/Dialog';
 import { InlineMessage } from '../Core/InlineMessage';
 import { SuccessToast } from '../Core/Toast';
+import TeamMemberDeleteConfirmationDialog from './TeamMemberDeleteDialog';
 import TeamMemberDialog from './TeamMemberDialog';
-
-type DeleteConfirmationDialogProps = Readonly<{
-  person: UserResponse;
-  onRemoveTeamMember: () => Promise<void>;
-  onOpenChange: () => void;
-}>;
-
-function DeleteConfirmationDialog({
-  person,
-  onRemoveTeamMember,
-  onOpenChange,
-}: DeleteConfirmationDialogProps) {
-  const handleRemove = async () => {
-    await onRemoveTeamMember();
-    onOpenChange();
-  };
-
-  return (
-    <Dialog
-      title='Are you sure you want to delete this team member?'
-      onOpenChange={onOpenChange}
-      closeButtonText='Cancel'
-    >
-      <ul className='dot-list'>
-        <li>
-          {person.firstName} {person.lastName}
-        </li>
-      </ul>
-      <div className='dialog-footer-section'>
-        <button type='button' className='primary-button' onClick={handleRemove}>
-          Delete Team Member
-        </button>
-      </div>
-    </Dialog>
-  );
-}
 
 type TeamMemberProps = Readonly<{
   person: UserResponse;
@@ -169,7 +133,7 @@ function TeamMember({
               <FontAwesomeIcon icon='trash-can' />
             </button>
             {showDeleteTeamMemberDialog && (
-              <DeleteConfirmationDialog
+              <TeamMemberDeleteConfirmationDialog
                 onRemoveTeamMember={handleRemoveUser}
                 person={person}
                 onOpenChange={onOpenChangeDeleteTeamMemberDialog}

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -70,9 +70,14 @@ function TeamMember({
 }: TeamMemberProps) {
   const [reinviteState, setInviteState] = useState<InviteState>(InviteState.initial);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [showTeamMemberDialog, setShowTeamMemberDialog] = useState<boolean>();
 
   const setErrorInfo = (e: Error) => {
     setErrorMessage(e.message);
+  };
+
+  const onOpenChangeTeamMemberDialog = () => {
+    setShowTeamMemberDialog(!showTeamMemberDialog);
   };
 
   const onResendInvite = useCallback(async () => {
@@ -138,15 +143,16 @@ function TeamMember({
                 {reinviteState === InviteState.error && 'Try again later'}
               </button>
             )}
-            <TeamMemberDialog
-              onUpdateTeamMember={handleUpdateUser}
-              person={person}
-              triggerButton={
-                <button className='icon-button' aria-label='edit' type='button'>
-                  <FontAwesomeIcon icon='pencil' />
-                </button>
-              }
-            />
+            <button className='icon-button' aria-label='edit' type='button' onClick={onOpenChangeTeamMemberDialog}>
+              <FontAwesomeIcon icon='pencil' />
+            </button>
+            {showTeamMemberDialog && (
+              <TeamMemberDialog
+                onUpdateTeamMember={handleUpdateUser}
+                person={person}
+                onOpenChange={onOpenChangeTeamMemberDialog}
+              />
+            )}
             <DeleteConfirmationDialog onRemoveTeamMember={handleRemoveUser} person={person} />
           </div>
         </div>

--- a/src/web/components/TeamMember/TeamMemberDeleteDialog.tsx
+++ b/src/web/components/TeamMember/TeamMemberDeleteDialog.tsx
@@ -1,0 +1,40 @@
+import { UserResponse } from '../../services/userAccount';
+import { Dialog } from '../Core/Dialog';
+
+type TeamMemberDeleteConfirmationDialogProps = Readonly<{
+  person: UserResponse;
+  onRemoveTeamMember: () => Promise<void>;
+  onOpenChange: () => void;
+}>;
+
+function TeamMemberDeleteConfirmationDialog({
+  person,
+  onRemoveTeamMember,
+  onOpenChange,
+}: TeamMemberDeleteConfirmationDialogProps) {
+  const handleRemove = async () => {
+    await onRemoveTeamMember();
+    onOpenChange();
+  };
+
+  return (
+    <Dialog
+      title='Are you sure you want to delete this team member?'
+      onOpenChange={onOpenChange}
+      closeButtonText='Cancel'
+    >
+      <ul className='dot-list'>
+        <li>
+          {person.firstName} {person.lastName}
+        </li>
+      </ul>
+      <div className='dialog-footer-section'>
+        <button type='button' className='primary-button' onClick={handleRemove}>
+          Delete Team Member
+        </button>
+      </div>
+    </Dialog>
+  );
+}
+
+export default TeamMemberDeleteConfirmationDialog;

--- a/src/web/components/TeamMember/TeamMemberDialog.stories.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.stories.tsx
@@ -12,7 +12,6 @@ type Story = StoryObj<typeof TeamMemberDialog>;
 
 export const Default: Story = {
   args: {
-    triggerButton: <button type='button'>Open</button>,
     onAddTeamMember: (form) => Promise.resolve(console.log(`Add new user ${JSON.stringify(form)}`)),
   },
 };

--- a/src/web/components/TeamMember/TeamMemberDialog.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.tsx
@@ -47,7 +47,6 @@ function TeamMemberDialog(props: TeamMemberDialogProps) {
     <Dialog
       title={`${props.person ? 'Edit' : 'Add'} Team Member`}
       closeButtonText='Cancel'
-      open
       onOpenChange={props.onOpenChange}
     >
       <FormProvider {...formMethods}>

--- a/src/web/components/TeamMember/TeamMemberDialog.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { UserRole } from '../../../api/entities/User';
@@ -14,12 +13,12 @@ import { TextInput } from '../Input/TextInput';
 
 type AddTeamMemberDialogProps = {
   onAddTeamMember: (form: InviteTeamMemberForm) => Promise<void>;
-  triggerButton: JSX.Element;
+  onOpenChange: () => void;
   person?: never;
 };
 type UpdateTeamMemberDialogProps = {
   onUpdateTeamMember: (form: UpdateTeamMemberForm) => Promise<void>;
-  triggerButton: JSX.Element;
+  onOpenChange: () => void;
   person: UserResponse;
 };
 type TeamMemberDialogProps = AddTeamMemberDialogProps | UpdateTeamMemberDialogProps;
@@ -29,8 +28,6 @@ const isUpdateTeamMemberDialogProps = (
 ): props is UpdateTeamMemberDialogProps => 'person' in props;
 
 function TeamMemberDialog(props: TeamMemberDialogProps) {
-  const [open, setOpen] = useState(false);
-
   const formMethods = useForm<InviteTeamMemberForm>({
     defaultValues: props.person as InviteTeamMemberForm,
   });
@@ -43,16 +40,15 @@ function TeamMemberDialog(props: TeamMemberDialogProps) {
     } else {
       await props.onAddTeamMember(formData);
     }
-    setOpen(false);
+    props.onOpenChange();
   };
 
   return (
     <Dialog
-      triggerButton={props.triggerButton}
       title={`${props.person ? 'Edit' : 'Add'} Team Member`}
       closeButtonText='Cancel'
-      open={open}
-      onOpenChange={setOpen}
+      open
+      onOpenChange={props.onOpenChange}
     >
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/web/components/TeamMember/TeamMembersTable.tsx
+++ b/src/web/components/TeamMember/TeamMembersTable.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import {
   InviteTeamMemberForm,
   UpdateTeamMemberForm,
@@ -23,6 +25,12 @@ function TeamMembersTable({
   onRemoveTeamMember,
   onUpdateTeamMember,
 }: TeamMembersTableProps) {
+  const [showTeamMemberDialog, setShowTeamMemberDialog] = useState<boolean>(false);
+
+  const onOpenChangeTeamMemberDialog = () => {
+    setShowTeamMemberDialog(!showTeamMemberDialog);
+  };
+
   return (
     <div className='portal-team'>
       <table className='portal-team-table'>
@@ -47,14 +55,15 @@ function TeamMembersTable({
         </tbody>
       </table>
       <div className='add-team-member'>
-        <TeamMemberDialog
-          onAddTeamMember={onAddTeamMember}
-          triggerButton={
-            <button className='small-button' type='button'>
-              Add Team Member
-            </button>
-          }
-        />
+        <button className='small-button' type='button' onClick={onOpenChangeTeamMemberDialog}>
+          Add Team Member
+        </button>
+        {showTeamMemberDialog && (
+          <TeamMemberDialog
+            onAddTeamMember={onAddTeamMember}
+            onOpenChange={onOpenChangeTeamMemberDialog}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/web/screens/dashboard.tsx
+++ b/src/web/screens/dashboard.tsx
@@ -75,7 +75,7 @@ function Dashboard() {
       <div className='dashboard-content'>
         <SnailTrail location={currentLocationDescription} />
         {!LoggedInUser?.user?.acceptedTerms ? (
-          <Dialog open className='terms-conditions-dialog'>
+          <Dialog className='terms-conditions-dialog'>
             <TermsAndConditionsForm onAccept={handleAccept} onCancel={handleCancel}>
               {showMustAccept && (
                 <div className='accept-error'>

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 import { Await, defer, useLoaderData, useRevalidator } from 'react-router-dom';
 
 import { ApiRoleDTO } from '../../api/entities/ApiRole';
@@ -28,6 +28,8 @@ import { PortalRoute } from './routeUtils';
 import './manageParticipants.scss';
 
 function ManageParticipants() {
+  const [showAddParticipantsDialog, setShowAddParticipantsDialog] = useState<boolean>(false);
+
   const data = useLoaderData() as {
     results: [ParticipantRequestDTO[], ParticipantDTO[], ParticipantTypeDTO[], ApiRoleDTO[]];
   };
@@ -62,6 +64,10 @@ function ManageParticipants() {
     return response;
   };
 
+  const onOpenChangeAddParticipantDialog = () => {
+    setShowAddParticipantsDialog(!showAddParticipantsDialog);
+  };
+
   return (
     <div>
       <Suspense fallback={<Loading />}>
@@ -81,11 +87,14 @@ function ManageParticipants() {
                   </p>
                 </div>
                 <div className='manage-participants-header-right'>
+                  <button type='button' onClick={onOpenChangeAddParticipantDialog}>
+                    Add Participant
+                  </button>
                   <AddParticipantDialog
                     apiRoles={apiRoles}
                     participantTypes={participantTypes}
                     onAddParticipant={onAddParticipant}
-                    triggerButton={<button type='button'>Add Participant</button>}
+                    onOpenChange={onOpenChangeAddParticipantDialog}
                   />
                 </div>
               </div>

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -90,12 +90,14 @@ function ManageParticipants() {
                   <button type='button' onClick={onOpenChangeAddParticipantDialog}>
                     Add Participant
                   </button>
-                  <AddParticipantDialog
-                    apiRoles={apiRoles}
-                    participantTypes={participantTypes}
-                    onAddParticipant={onAddParticipant}
-                    onOpenChange={onOpenChangeAddParticipantDialog}
-                  />
+                  {showAddParticipantsDialog && (
+                    <AddParticipantDialog
+                      apiRoles={apiRoles}
+                      participantTypes={participantTypes}
+                      onAddParticipant={onAddParticipant}
+                      onOpenChange={onOpenChangeAddParticipantDialog}
+                    />
+                  )}
                 </div>
               </div>
               <ParticipantRequestsTable


### PR DESCRIPTION
What Changed:

- Components changed to new dialog pattern:

1. AddParticipantDialog
2.  EditParticipantDialog (renamed from UpdateParticipantDialog to match the pattern better)
3.  Add Permisssions Dialog in SearchAndAddParticipants.tsx
4.  Delete Permissions Dialog in SharingPermissionsTable.tsx
5.  Add Team Member Dialog
6. Edit Team Member Dialog
7.  Delete Team Member Dialog 


- Edited Dialog component, test file and storybook - open and triggerButton props no longer needed
- Removed open prop from every component that renders a dialog
- Sonarlint Readonly props changes