### PR TITLE
Signed Participants screen

### DIFF
--- a/src/api/entities/SignedParticipant.ts
+++ b/src/api/entities/SignedParticipant.ts
@@ -1,0 +1,11 @@
+import { BaseModel } from './BaseModel';
+import { ModelObjectOpt } from './ModelObjectOpt';
+
+export class SignedParticipant extends BaseModel {
+  static get tableName() {
+    return 'signedParticipants';
+  }
+  declare name: string;
+}
+
+export type SignedParticipantDTO = ModelObjectOpt<SignedParticipant>;

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -63,6 +63,7 @@ import {
   UpdateSharingTypes,
   UserParticipantRequest,
 } from '../../services/participantsService';
+import { getSignedParticipants } from '../../services/signedParticipantsService';
 import {
   createUserInPortal,
   enrichCurrentUser,
@@ -125,6 +126,12 @@ export function createParticipantsRouter() {
   participantsRouter.get('/approved', isApproverCheck, async (req, res) => {
     const participants = await getParticipantsApproved();
     const result = participants.sort((a, b) => a.name.localeCompare(b.name));
+    return res.status(200).json(result);
+  });
+
+  participantsRouter.get('/signed', async (_req, res) => {
+    const signedParticipants = await getSignedParticipants();
+    const result = signedParticipants.sort((a, b) => a.name.localeCompare(b.name));
     return res.status(200).json(result);
   });
 

--- a/src/api/services/signedParticipantsService.ts
+++ b/src/api/services/signedParticipantsService.ts
@@ -1,0 +1,5 @@
+import { SignedParticipant, SignedParticipantDTO } from '../entities/SignedParticipant';
+
+export const getSignedParticipants = async (): Promise<SignedParticipantDTO[]> => {
+  return SignedParticipant.query();
+};

--- a/src/database/migrations/20240430040721_AddSignedParticipantsTable.ts
+++ b/src/database/migrations/20240430040721_AddSignedParticipantsTable.ts
@@ -1,0 +1,11 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('signedParticipants', (table) => {
+    table.string('name', 256).notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('signedParticipants');
+}

--- a/src/web/components/SignedParticipants/SignedParticipantsTable.tsx
+++ b/src/web/components/SignedParticipants/SignedParticipantsTable.tsx
@@ -1,0 +1,24 @@
+import { SignedParticipantDTO } from '../../../api/entities/SignedParticipant';
+
+type SignedParticipantsTableProps = {
+  signedParticipants: SignedParticipantDTO[];
+};
+
+export function SignedParticipantsTable({ signedParticipants }: SignedParticipantsTableProps) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Participant Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {signedParticipants.map((participant) => (
+          <tr key={participant.name}>
+            <td>{participant.name}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/web/screens/dashboard.tsx
+++ b/src/web/screens/dashboard.tsx
@@ -35,10 +35,9 @@ export const StandardRoutes: PortalRoute[] = [
   TermsOfServiceRoute,
   ApiKeyManagementRoute,
   ClientSideIntegrationRoute,
-  SignedParticipantsRoute,
 ];
 
-export const AdminRoutes: PortalRoute[] = [ManageParticipantsRoute];
+export const AdminRoutes: PortalRoute[] = [ManageParticipantsRoute, SignedParticipantsRoute];
 
 export const DashboardRoutes: PortalRoute[] = [...StandardRoutes, ...AdminRoutes];
 

--- a/src/web/screens/dashboard.tsx
+++ b/src/web/screens/dashboard.tsx
@@ -19,6 +19,7 @@ import { LogoutRoute } from './logout';
 import { ManageParticipantsRoute } from './manageParticipants';
 import { PortalRoute } from './routeUtils';
 import { SharingPermissionsRoute } from './sharingPermissions';
+import { SignedParticipantsRoute } from './signedParticipants';
 import { TeamMembersRoute } from './teamMembers';
 import { TermsOfServiceRoute } from './termsOfService';
 
@@ -34,6 +35,7 @@ export const StandardRoutes: PortalRoute[] = [
   TermsOfServiceRoute,
   ApiKeyManagementRoute,
   ClientSideIntegrationRoute,
+  SignedParticipantsRoute,
 ];
 
 export const AdminRoutes: PortalRoute[] = [ManageParticipantsRoute];

--- a/src/web/screens/signedParticipants.tsx
+++ b/src/web/screens/signedParticipants.tsx
@@ -1,0 +1,41 @@
+import { Suspense } from 'react';
+import { Await, defer, useLoaderData } from 'react-router-dom';
+
+import { SignedParticipantDTO } from '../../api/entities/SignedParticipant';
+import { Loading } from '../components/Core/Loading';
+import { ScreenContentContainer } from '../components/Core/ScreenContentContainer';
+import { SignedParticipantsTable } from '../components/SignedParticipants/SignedParticipantsTable';
+import { GetSignedParticipants } from '../services/participant';
+import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
+import { PortalRoute } from './routeUtils';
+
+export function SignedParticipants() {
+  const data = useLoaderData() as { signedParticipants: SignedParticipantDTO[] };
+
+  return (
+    <>
+      <h1>Signed Participants</h1>
+      <p className='heading-details'>Participants that have signed the UID2 participant policy.</p>
+      <ScreenContentContainer>
+        <Suspense fallback={<Loading />}>
+          <Await resolve={data.signedParticipants}>
+            {(signedParticipants: SignedParticipantDTO[]) => (
+              <SignedParticipantsTable signedParticipants={signedParticipants} />
+            )}
+          </Await>
+        </Suspense>
+      </ScreenContentContainer>
+    </>
+  );
+}
+
+export const SignedParticipantsRoute: PortalRoute = {
+  path: '/dashboard/signedParticipants',
+  description: 'Signed Participants',
+  element: <SignedParticipants />,
+  errorElement: <RouteErrorBoundary />,
+  loader: async () => {
+    const signedParticipants = GetSignedParticipants();
+    return defer({ signedParticipants });
+  },
+};

--- a/src/web/screens/signedParticipants.tsx
+++ b/src/web/screens/signedParticipants.tsx
@@ -15,7 +15,7 @@ export function SignedParticipants() {
   return (
     <>
       <h1>Signed Participants</h1>
-      <p className='heading-details'>Participants that have signed the UID2 participant policy.</p>
+      <p className='heading-details'>Participants that have signed the UID2 Participation Policy.</p>
       <ScreenContentContainer>
         <Suspense fallback={<Loading />}>
           <Await resolve={data.signedParticipants}>

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { BusinessContactSchema } from '../../api/entities/BusinessContact';
 import { ParticipantCreationPartial, ParticipantDTO } from '../../api/entities/Participant';
+import { SignedParticipantDTO } from '../../api/entities/SignedParticipant';
 import { ParticipantRequestDTO } from '../../api/routers/participants/participantsRouter';
 import {
   ApiKeyDTO,
@@ -102,6 +103,17 @@ export async function GetApprovedParticipants() {
     return result.data;
   } catch (e: unknown) {
     throw backendError(e, 'Could not load approved participants');
+  }
+}
+
+export async function GetSignedParticipants() {
+  try {
+    const result = await axios.get<SignedParticipantDTO[]>(`/participants/signed`, {
+      validateStatus: (status) => status === 200,
+    });
+    return result.data;
+  } catch (e: unknown) {
+    throw backendError(e, 'Could not load signed participants');
   }
 }
 

--- a/src/web/services/signedParticipant.ts
+++ b/src/web/services/signedParticipant.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+import { SignedParticipantDTO } from '../../api/entities/SignedParticipant';
+import { backendError } from '../utils/apiError';
+
+export async function GetAllSignedParticipants() {
+  try {
+    const result = await axios.get<SignedParticipantDTO[]>(`/signedParticipant`, {
+      validateStatus: (status) => status === 200,
+    });
+    return result.data;
+  } catch (e: unknown) {
+    throw backendError(e, 'Could not get signed participants');
+  }
+}


### PR DESCRIPTION
- New db table with single string column
- New screen that just displays the names of the signed participants in a table
- Fetch data using the usual pattern via the participantsRouter

## Manual testing
1. Run the migration: `npm run knex:migrate:latest`
2. Populate the table:

   ```
   select * from dbo.signedParticipants
   insert into dbo.signedParticipants (name) values ('Test 3'), ('Test 1'), ('Test 2')
   select * from dbo.signedParticipants
   ```
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/6595696e-abf0-4ddf-8a37-28a62b268c9e)

