### PR TITLE
Extend keycloak admin action expiry

### DIFF
--- a/keycloak/realm/realm-export.json
+++ b/keycloak/realm/realm-export.json
@@ -23,7 +23,7 @@
   "accessCodeLifespan": 60,
   "accessCodeLifespanUserAction": 300,
   "accessCodeLifespanLogin": 1800,
-  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByAdminLifespan": 604800,
   "actionTokenGeneratedByUserLifespan": 300,
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,

--- a/keycloak/themes/uid2-theme/email/html/executeActions.ftl
+++ b/keycloak/themes/uid2-theme/email/html/executeActions.ftl
@@ -5,7 +5,7 @@
 <#import "template.ftl" as layout>
 <@layout.emailLayout>
 <#if  requiredActions?seq_contains("UPDATE_PASSWORD")>
-${kcSanitize(msg("inviteBodyHtml", user.firstName, link))?no_esc}
+${kcSanitize(msg("inviteBodyHtml", user.firstName, link, linkExpirationFormatter(linkExpiration)))?no_esc}
 <#else>
 ${kcSanitize(msg("executeActionsBodyHtml",link, linkExpiration, realmName, requiredActionsText, linkExpirationFormatter(linkExpiration)))?no_esc}
 </#if>

--- a/keycloak/themes/uid2-theme/email/messages/messages_en.properties
+++ b/keycloak/themes/uid2-theme/email/messages/messages_en.properties
@@ -4,5 +4,5 @@ emailVerificationBody=Please verify your email address\n\nClick the link below t
 passwordResetSubject=Reset password
 passwordResetBodyHtml=<p> Hey {0}, </p> <p> We received a request to reset your password for your account. </p> <p> Please use the button below to reset your password. </p> <div class="footer"> <a href="{1}" class="button" >Reset Password</a > </div>
 passwordResetBody=Hey {0}, We received a request to reset your password for your account. Please use the link below to reset your password.{1}
-inviteBodyHtml=<p> Hey {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: this invitation will expire in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
+inviteBodyHtml=<p> Hey {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: This invitation will expire in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
 inviteBody=Hey {0}, You’ve been added to the UID2 Portal. Click the button to accept your invitation and create a password for your account.{1}

--- a/keycloak/themes/uid2-theme/email/messages/messages_en.properties
+++ b/keycloak/themes/uid2-theme/email/messages/messages_en.properties
@@ -4,5 +4,5 @@ emailVerificationBody=Please verify your email address\n\nClick the link below t
 passwordResetSubject=Reset password
 passwordResetBodyHtml=<p> Hey {0}, </p> <p> We received a request to reset your password for your account. </p> <p> Please use the button below to reset your password. </p> <div class="footer"> <a href="{1}" class="button" >Reset Password</a > </div>
 passwordResetBody=Hey {0}, We received a request to reset your password for your account. Please use the link below to reset your password.{1}
-inviteBodyHtml=<p> Hey {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
+inviteBodyHtml=<p> Hey {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: this invitation will expire in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
 inviteBody=Hey {0}, You’ve been added to the UID2 Portal. Click the button to accept your invitation and create a password for your account.{1}

--- a/keycloak/themes/uid2-theme/email/messages/messages_en.properties
+++ b/keycloak/themes/uid2-theme/email/messages/messages_en.properties
@@ -2,7 +2,7 @@
 emailVerificationBodyHtml=<h1> Please verify your email address </h1> <p class="content-text" > Click the button to verify this email. We’ll review your account and be in touch within the next few business days. </p> <div class="footer"> <a href="{0}" class="button" >Verify Email</a > </div>
 emailVerificationBody=Please verify your email address\n\nClick the link below to verify this email and complete your account creation for Unified ID.\n\n{0}
 passwordResetSubject=Reset password
-passwordResetBodyHtml=<p> Hey {0}, </p> <p> We received a request to reset your password for your account. </p> <p> Please use the button below to reset your password. </p> <div class="footer"> <a href="{1}" class="button" >Reset Password</a > </div>
-passwordResetBody=Hey {0}, We received a request to reset your password for your account. Please use the link below to reset your password.{1}
-inviteBodyHtml=<p> Hey {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: This invitation will expire in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
-inviteBody=Hey {0}, You’ve been added to the UID2 Portal. Click the button to accept your invitation and create a password for your account.{1}
+passwordResetBodyHtml=<p> Hi {0}, </p> <p> We received a request to reset your password for your account. </p> <p> Please use the button below to reset your password. </p> <div class="footer"> <a href="{1}" class="button" >Reset Password</a > </div>
+passwordResetBody=Hi {0}, We received a request to reset your password for your account. Please use the link below to reset your password.{1}
+inviteBodyHtml=<p> Hi {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: This invitation will expire in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
+inviteBody=Hi {0}, You’ve been added to the UID2 Portal. Click the button to accept your invitation and create a password for your account.{1}

--- a/keycloak/themes/uid2-theme/email/messages/messages_en.properties
+++ b/keycloak/themes/uid2-theme/email/messages/messages_en.properties
@@ -4,5 +4,5 @@ emailVerificationBody=Please verify your email address\n\nClick the link below t
 passwordResetSubject=Reset password
 passwordResetBodyHtml=<p> Hi {0}, </p> <p> We received a request to reset your password for your account. </p> <p> Please use the button below to reset your password. </p> <div class="footer"> <a href="{1}" class="button" >Reset Password</a > </div>
 passwordResetBody=Hi {0}, We received a request to reset your password for your account. Please use the link below to reset your password.{1}
-inviteBodyHtml=<p> Hi {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: This invitation will expire in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
+inviteBodyHtml=<p> Hi {0}, </p> <p> You’ve been added to the UID2 Portal. </p> <p> Click the button to accept your invitation and create a password for your account. </p> <p>Note: This invitation expires in {2}.</p> <div class="footer"> <a href="{1}" class="button" >Accept Invitation</a > </div>
 inviteBody=Hi {0}, You’ve been added to the UID2 Portal. Click the button to accept your invitation and create a password for your account.{1}


### PR DESCRIPTION
- Extend "Default Admin-Initiated Action Lifespan" from 12 hours to 7 days
- Display this expiry in the email
- Change "Hey" to "Hi" for all the messages
- Improve some other copy

## Before

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/a2058766-cc37-4463-93e0-a0b69b00ee28)

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/7bb120dc-2e65-4f3b-ac8f-a7610ee09600)

## After

![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/258b2cb0-c7bd-419a-95d0-4efc3ac17307)


![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/1f5e6d46-7b6f-46ba-a043-5ef727006173)


