### PR TITLE
Show site ID & contact information in Edit Participant dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ values
 select * from dbo.approvers where email = @email 
 ```
 
+You will then want to assign some API Permissions to your participant in the `Manage Participants` screen. This will allow you to use the full functionality of the `API Keys` screen.
+
 ### Connecting to local Admin service
 
 1. Run `uid2-admin` locally by following the README: https://github.com/IABTechLab/uid2-admin

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -81,7 +81,7 @@ export const getAttachedSiteIDs = async (): Promise<SiteIdType[]> => {
 export const getParticipantsApproved = async (): Promise<Participant[]> => {
   return Participant.query()
     .where('status', ParticipantStatus.Approved)
-    .withGraphFetched('[apiRoles, approver, types]');
+    .withGraphFetched('[apiRoles, approver, types, users]');
 };
 
 export const getParticipantsBySiteIds = async (siteIds: number[]) => {

--- a/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
@@ -20,7 +20,7 @@ import { RadioInput } from '../Input/RadioInput';
 import { SelectInput } from '../Input/SelectInput';
 import { TextInput } from '../Input/TextInput';
 import { SearchBarContainer, SearchBarFormInput, SearchBarResults } from '../Search/SearchBar';
-import { validatecrmAgreementNumber } from './AddParticipantDialogHelper';
+import { validateCrmAgreementNumber } from './AddParticipantDialogHelper';
 import { HighlightedResult } from './ParticipantApprovalForm';
 
 import './AddParticipantDialog.scss';
@@ -226,7 +226,7 @@ function AddParticipantDialog({
               className='text-input'
               maxLength={8}
               rules={{
-                validate: validatecrmAgreementNumber,
+                validate: validateCrmAgreementNumber,
               }}
             />
             <div>

--- a/src/web/components/ParticipantManagement/AddParticipantDialogHelper.spec.ts
+++ b/src/web/components/ParticipantManagement/AddParticipantDialogHelper.spec.ts
@@ -1,23 +1,23 @@
-import { validatecrmAgreementNumber } from './AddParticipantDialogHelper';
+import { validateCrmAgreementNumber } from './AddParticipantDialogHelper';
 
 describe('#validatecrmAgreementNumber', () => {
   test('returns true for valid 8-digit number', () => {
     const validNumber = '12345678';
-    expect(validatecrmAgreementNumber(validNumber)).toBe(true);
+    expect(validateCrmAgreementNumber(validNumber)).toBe(true);
   });
 
   test('returns error message for less than 8 digits', () => {
     const lessThanEightDigits = '1234567';
-    expect(validatecrmAgreementNumber(lessThanEightDigits)).toBe('Please enter an 8-digit number.');
+    expect(validateCrmAgreementNumber(lessThanEightDigits)).toBe('Please enter an 8-digit number.');
   });
 
   test('returns error message for more than 8 digits', () => {
     const moreThanEightDigits = '123456789';
-    expect(validatecrmAgreementNumber(moreThanEightDigits)).toBe('Please enter an 8-digit number.');
+    expect(validateCrmAgreementNumber(moreThanEightDigits)).toBe('Please enter an 8-digit number.');
   });
 
   test('returns error message for non-numeric input', () => {
     const nonNumericInput = 'abc';
-    expect(validatecrmAgreementNumber(nonNumericInput)).toBe('Please enter an 8-digit number.');
+    expect(validateCrmAgreementNumber(nonNumericInput)).toBe('Please enter an 8-digit number.');
   });
 });

--- a/src/web/components/ParticipantManagement/AddParticipantDialogHelper.ts
+++ b/src/web/components/ParticipantManagement/AddParticipantDialogHelper.ts
@@ -1,9 +1,9 @@
-export const validatecrmAgreementNumber = (value: string): boolean | string => {
+export const validateCrmAgreementNumber = (value: string): boolean | string => {
   const regex = /^\d{8}$/;
   return regex.test(value) ? true : 'Please enter an 8-digit number.';
 };
 
-export const validateEditcrmAgreementNumber = (
+export const validateEditCrmAgreementNumber = (
   value: string,
   initialValue: string | null
 ): boolean | string => {

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.scss
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.scss
@@ -1,0 +1,12 @@
+.edit-participant-dialog {
+  max-height: calc(100vh - 10px);
+
+  .contact-name {
+    display: flex;
+    justify-content: space-between;
+
+    .input-wrapper {
+      width: 45%;
+    }
+  }
+}

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
@@ -49,6 +49,7 @@ const participant = {
       acceptedTerms: false,
     },
   ],
+  siteId: 123,
 };
 
 export const ParticipantWithExistingRoles = () => {

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
@@ -12,6 +12,8 @@ import { TextInput } from '../Input/TextInput';
 import { validateEditCrmAgreementNumber } from './AddParticipantDialogHelper';
 import { getContactInformation } from './EditParticipantDialogHelpers';
 
+import './EditParticipantDialog.scss';
+
 type EditParticipantDialogProps = Readonly<{
   participant: ParticipantDTO;
   onEditParticipant: (form: UpdateParticipantForm, participant: ParticipantDTO) => Promise<void>;
@@ -53,6 +55,7 @@ function EditParticipantDialog({
     <Dialog
       title={`Edit Participant: ${participant.name}`}
       closeButtonText='Cancel'
+      className='edit-participant-dialog'
       onOpenChange={onOpenChange}
     >
       <FormProvider {...formMethods}>
@@ -93,8 +96,10 @@ function EditParticipantDialog({
                 validateEditCrmAgreementNumber(value, originalFormValues.crmAgreementNumber),
             }}
           />
-          <TextInput inputName='contactFirstName' label='Contact First Name' disabled />
-          <TextInput inputName='contactLastName' label='Contact Last Name' disabled />
+          <div className='contact-name'>
+            <TextInput inputName='contactFirstName' label='Contact First Name' disabled />
+            <TextInput inputName='contactLastName' label='Contact Last Name' disabled />
+          </div>
           <TextInput inputName='contactEmail' label='Contact Email' disabled />
           <FormSubmitButton>Save Participant</FormSubmitButton>
         </form>

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
@@ -10,6 +10,7 @@ import FormSubmitButton from '../Core/FormSubmitButton';
 import { MultiCheckboxInput } from '../Input/MultiCheckboxInput';
 import { TextInput } from '../Input/TextInput';
 import { validateEditCrmAgreementNumber } from './AddParticipantDialogHelper';
+import { getContactInformation } from './EditParticipantDialogHelpers';
 
 type EditParticipantDialogProps = Readonly<{
   participant: ParticipantDTO;
@@ -31,11 +32,16 @@ function EditParticipantDialog({
     onOpenChange();
   };
 
+  const contact = getContactInformation(participant);
   const originalFormValues: UpdateParticipantForm = {
     apiRoles: participant.apiRoles ? participant.apiRoles.map((apiRole) => apiRole.id) : [],
     participantTypes: participant.types ? participant.types.map((pType) => pType.id) : [],
     participantName: participant.name,
     crmAgreementNumber: participant.crmAgreementNumber,
+    siteId: participant.siteId!,
+    contactFirstName: contact.firstName,
+    contactLastName: contact.lastName,
+    contactEmail: contact.email,
   };
 
   const formMethods = useForm<UpdateParticipantForm>({
@@ -66,6 +72,7 @@ function EditParticipantDialog({
             }))}
             rules={{ required: 'Please specify Participant Types.' }}
           />
+          <TextInput inputName='siteId' label='Site ID' disabled />
           <MultiCheckboxInput
             inputName='apiRoles'
             label='API Permissions'
@@ -86,6 +93,9 @@ function EditParticipantDialog({
                 validateEditCrmAgreementNumber(value, originalFormValues.crmAgreementNumber),
             }}
           />
+          <TextInput inputName='contactFirstName' label='Contact First Name' disabled />
+          <TextInput inputName='contactLastName' label='Contact Last Name' disabled />
+          <TextInput inputName='contactEmail' label='Contact Email' disabled />
           <FormSubmitButton>Save Participant</FormSubmitButton>
         </form>
       </FormProvider>

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.tsx
@@ -9,7 +9,7 @@ import { Dialog } from '../Core/Dialog';
 import FormSubmitButton from '../Core/FormSubmitButton';
 import { MultiCheckboxInput } from '../Input/MultiCheckboxInput';
 import { TextInput } from '../Input/TextInput';
-import { validateEditcrmAgreementNumber } from './AddParticipantDialogHelper';
+import { validateEditCrmAgreementNumber } from './AddParticipantDialogHelper';
 
 type EditParticipantDialogProps = Readonly<{
   participant: ParticipantDTO;
@@ -83,7 +83,7 @@ function EditParticipantDialog({
             maxLength={8}
             rules={{
               validate: (value: string) =>
-                validateEditcrmAgreementNumber(value, originalFormValues.crmAgreementNumber),
+                validateEditCrmAgreementNumber(value, originalFormValues.crmAgreementNumber),
             }}
           />
           <FormSubmitButton>Save Participant</FormSubmitButton>

--- a/src/web/components/ParticipantManagement/EditParticipantDialogHelpers.ts
+++ b/src/web/components/ParticipantManagement/EditParticipantDialogHelpers.ts
@@ -1,0 +1,12 @@
+import { ParticipantDTO } from '../../../api/entities/Participant';
+
+export const getContactInformation = (participant: ParticipantDTO) => {
+  const defaultMessage = 'Information not available';
+  return participant.users && participant.users.length > 0
+    ? participant.users[0]
+    : {
+        firstName: defaultMessage,
+        lastName: defaultMessage,
+        email: defaultMessage,
+      };
+};

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -162,6 +162,10 @@ export type UpdateParticipantForm = {
   participantTypes: number[];
   participantName: string;
   crmAgreementNumber: string | null;
+  siteId: number;
+  contactFirstName: string;
+  contactLastName: string;
+  contactEmail: string;
 };
 
 export type AddParticipantForm = {


### PR DESCRIPTION
- Update service to also return related users
- Add fields to the form, for ease of display and in case we want to allow them to be editable later
- Display the fields
- Extract a helper method - though it's probably more defensive than it needs to be - this case should only happen locally with seed data.

### Unrelated changes (first commit only)
- Fix name of method
- Improve README

## Manual tests
https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/c1f6a48e-3fba-4f58-99d8-b7ce25885e37

Styling update:
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/137864392/a74a2ebe-5fe3-440b-9bdb-2f62326285ff)

