### PR TITLE
Show all invalid domains in add domains dialog 

### DIFF
--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -215,7 +215,7 @@ export function configureAndStartApi(useMetrics: boolean = true, portNumber: num
 
     if (code === 400) {
       res.status(400).json({
-        message: 'Invalid request.',
+        message: currentMessage,
         errorHash: req.headers.traceId,
       });
     } else if (code === 401) {

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
@@ -13,7 +13,7 @@ describe('CstgDomainAddDomainDialog', () => {
     const user = userEvent.setup();
 
     const onAddDomainsMock = jest.fn(() => {
-      return Promise.resolve();
+      return Promise.resolve([]);
     });
 
     render(
@@ -21,7 +21,6 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={[]}
       />
     );
 
@@ -42,7 +41,7 @@ describe('CstgDomainAddDomainDialog', () => {
     const user = userEvent.setup();
 
     const onAddDomainsMock = jest.fn(() => {
-      return Promise.resolve();
+      return Promise.resolve([]);
     });
 
     render(
@@ -50,7 +49,6 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={[]}
       />
     );
 
@@ -68,7 +66,7 @@ describe('CstgDomainAddDomainDialog', () => {
 
   it('should render error when user types single incorrect domain', async () => {
     const onAddDomainsMock = jest.fn(() => {
-      return Promise.resolve();
+      return Promise.resolve(['newDomains']);
     });
 
     render(
@@ -76,7 +74,6 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={['newDomains']}
       />
     );
 
@@ -87,7 +84,7 @@ describe('CstgDomainAddDomainDialog', () => {
 
   it('should render error if user types in at least one incorrect domain in a list', async () => {
     const onAddDomainsMock = jest.fn(() => {
-      return Promise.resolve();
+      return Promise.resolve(['test', 'test2']);
     });
 
     render(
@@ -95,7 +92,6 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={['test', 'test2']}
       />
     );
 
@@ -106,7 +102,7 @@ describe('CstgDomainAddDomainDialog', () => {
 
   it('should render error if user submits empty text box for domain names', async () => {
     const onAddDomainsMock = jest.fn(() => {
-      return Promise.resolve();
+      return Promise.resolve([]);
     });
 
     render(
@@ -114,7 +110,6 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={[]}
       />
     );
     await submitDialog();

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
@@ -61,6 +61,11 @@ describe('CstgDomainAddDomainDialog', () => {
 
     await submitDialog();
 
+    expect(onAddDomainsMock).toHaveBeenCalledWith(
+      ['test.com', 'test2.com', 'test3.com', 'test4.com'],
+      expect.anything()
+    );
+
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
@@ -65,6 +65,8 @@ describe('CstgDomainAddDomainDialog', () => {
   });
 
   it('should render error when user types single incorrect domain', async () => {
+    const user = userEvent.setup();
+
     const onAddDomainsMock = jest.fn(() => {
       return Promise.resolve(['newDomains']);
     });
@@ -77,14 +79,20 @@ describe('CstgDomainAddDomainDialog', () => {
       />
     );
 
+    await user.type(screen.getByRole('textbox', { name: 'newDomains' }), 'newDomains');
+
     await submitDialog();
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(
+      screen.getByText('The domains entered are invalid root-level domains', { exact: false })
+    ).toBeInTheDocument();
   });
 
   it('should render error if user types in at least one incorrect domain in a list', async () => {
+    const user = userEvent.setup();
+
     const onAddDomainsMock = jest.fn(() => {
-      return Promise.resolve(['test', 'test2']);
+      return Promise.resolve(['test1', 'test2']);
     });
 
     render(
@@ -95,9 +103,13 @@ describe('CstgDomainAddDomainDialog', () => {
       />
     );
 
+    await user.type(screen.getByRole('textbox', { name: 'newDomains' }), 'newDomains');
+
     await submitDialog();
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(
+      screen.getByText('The domains entered are invalid root-level domains', { exact: false })
+    ).toBeInTheDocument();
   });
 
   it('should render error if user submits empty text box for domain names', async () => {

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
@@ -21,6 +21,7 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
+        invalidDomains={[]}
       />
     );
 
@@ -49,6 +50,7 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
+        invalidDomains={[]}
       />
     );
 
@@ -83,6 +85,7 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
+        invalidDomains={[]}
       />
     );
 
@@ -104,6 +107,7 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
+        invalidDomains={[]}
       />
     );
 
@@ -124,6 +128,7 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
+        invalidDomains={[]}
       />
     );
     await submitDialog();

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import CstgAddDomainDialog from './CstgAddDomainDialog';
 
 const submitDialog = async () => {
-  const createButton = screen.getByRole('button', { name: 'Add Domains' });
-  await userEvent.click(createButton);
+  const submitButton = screen.getByRole('button', { name: 'Add Domains' });
+  await userEvent.click(submitButton);
 };
 
 describe('CstgDomainAddDomainDialog', () => {

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.spec.tsx
@@ -63,19 +63,10 @@ describe('CstgDomainAddDomainDialog', () => {
 
     await submitDialog();
 
-    await waitFor(() => {
-      expect(onAddDomainsMock).toHaveBeenCalledWith(
-        ['test.com', 'test2.com', 'test3.com', 'test4.com'],
-        expect.anything()
-      );
-    });
-
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('should render error when user types single incorrect domain', async () => {
-    const user = userEvent.setup();
-
     const onAddDomainsMock = jest.fn(() => {
       return Promise.resolve();
     });
@@ -85,11 +76,9 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={[]}
+        invalidDomains={['newDomains']}
       />
     );
-
-    await user.type(screen.getByRole('textbox', { name: 'newDomains' }), 'test');
 
     await submitDialog();
 
@@ -97,7 +86,6 @@ describe('CstgDomainAddDomainDialog', () => {
   });
 
   it('should render error if user types in at least one incorrect domain in a list', async () => {
-    const user = userEvent.setup();
     const onAddDomainsMock = jest.fn(() => {
       return Promise.resolve();
     });
@@ -107,11 +95,9 @@ describe('CstgDomainAddDomainDialog', () => {
         onAddDomains={onAddDomainsMock}
         onOpenChange={() => {}}
         existingDomains={[]}
-        invalidDomains={[]}
+        invalidDomains={['test', 'test2']}
       />
     );
-
-    await user.type(screen.getByRole('textbox', { name: 'newDomains' }), 'test, test2.com');
 
     await submitDialog();
 

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.stories.tsx
@@ -20,16 +20,14 @@ export const Default = () => {
         <CstgAddDomainDialog
           onOpenChange={() => setIsOpen(!isOpen)}
           existingDomains={[]}
-          invalidDomains={[]}
           onAddDomains={(newDomainsFormatted, deleteExistingList) => {
             setIsOpen(!isOpen);
-            return Promise.resolve(
-              console.log(
-                `Adding Domains ${JSON.stringify(newDomainsFormatted)}, ${
-                  deleteExistingList ? `Deleting existing list` : `Keeping existing list`
-                }`
-              )
+            console.log(
+              `Adding Domains ${JSON.stringify(newDomainsFormatted)}, ${
+                deleteExistingList ? `Deleting existing list` : `Keeping existing list`
+              }`
             );
+            return Promise.resolve([]);
           }}
         />
       )}

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.stories.tsx
@@ -20,6 +20,7 @@ export const Default = () => {
         <CstgAddDomainDialog
           onOpenChange={() => setIsOpen(!isOpen)}
           existingDomains={[]}
+          invalidDomains={[]}
           onAddDomains={(newDomainsFormatted, deleteExistingList) => {
             setIsOpen(!isOpen);
             return Promise.resolve(

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDomainDialog.tsx
@@ -11,7 +11,6 @@ import { Dialog } from '../Core/Dialog';
 import { RootFormErrors } from '../Input/FormError';
 import { MultilineTextInput } from '../Input/MultilineTextInput';
 import { StyledCheckbox } from '../Input/StyledCheckbox';
-import { extractTopLevelDomain, isValidDomain } from './CstgDomainHelper';
 
 import './CstgAddDomainDialog.scss';
 

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.spec.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.spec.ts
@@ -1,4 +1,4 @@
-import { extractTopLevelDomain, getPagedDomains, isValidDomain } from './CstgDomainHelper';
+import { extractTopLevelDomain, getPagedDomains } from './CstgDomainHelper';
 
 const validDomainsList = ['test.com', 'https://test.com', 'http://test.com'];
 const longDomainsList = [
@@ -37,17 +37,6 @@ describe('test domain helper functions', () => {
   describe('turn valid domains into root-level domains', () => {
     it.each(validDomainsList)('should return a root-level domain', (stringsList) => {
       expect(extractTopLevelDomain(stringsList)).toEqual('test.com');
-    });
-  });
-  describe('validate domains', () => {
-    it.each(['test.c', 'https://test', '', 't    st.com', 'test'])(
-      'should check the domain is invalid',
-      (stringsList) => {
-        expect(isValidDomain(stringsList)).toEqual(false);
-      }
-    );
-    it.each(validDomainsList)('should return the domain is valid', (stringList) => {
-      expect(isValidDomain(stringList)).toEqual(true);
     });
   });
 

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
@@ -4,7 +4,7 @@ import { RowsPerPageValues } from '../Core/PagingToolHelper';
 
 export type UpdateDomainNamesResponse = {
   domains: string[];
-  isValid: boolean;
+  isValidDomains: boolean;
 };
 
 export const extractTopLevelDomain = (domainName: string) => {

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
@@ -26,3 +26,15 @@ export const getPagedDomains = (
       index < (pageNumber - 1) * rowsPerPage + rowsPerPage
   );
 };
+
+export const getUniqueDomains = (
+  newDomains: string[],
+  existingDomains: string[],
+  deleteExistingList: boolean
+) => {
+  // filter out domain names that already exist in the list unless existing list is being deleted
+  const uniqueDomains = deleteExistingList
+    ? newDomains
+    : newDomains.filter((domain) => !existingDomains?.includes(domain));
+  return uniqueDomains;
+};

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
@@ -2,20 +2,9 @@ import { parse } from 'tldts';
 
 import { RowsPerPageValues } from '../Core/PagingToolHelper';
 
-type DomainProps = {
-  isIcann: boolean | null;
-  isPrivate: boolean | null;
-  domain?: string | null;
-};
-
 export type UpdateDomainNamesResponse = {
   domains: string[];
   isValid: boolean;
-};
-
-export const isValidDomain = (domainName: string) => {
-  const domainProps: DomainProps = parse(domainName);
-  return Boolean((domainProps.isIcann || domainProps.isPrivate) && domainProps.domain);
 };
 
 export const extractTopLevelDomain = (domainName: string) => {

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainHelper.ts
@@ -8,6 +8,11 @@ type DomainProps = {
   domain?: string | null;
 };
 
+export type UpdateDomainNamesResponse = {
+  domains: string[];
+  isValid: boolean;
+};
+
 export const isValidDomain = (domainName: string) => {
   const domainProps: DomainProps = parse(domainName);
   return Boolean((domainProps.isIcann || domainProps.isPrivate) && domainProps.domain);

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 import CstgDeleteDomainDialog from './CstgDeleteDomainDialog';
@@ -23,16 +23,10 @@ export function CstgDomainItem({
   onDelete,
   onEditDomain,
   checked,
-  invalidDomains,
   onCloseEditDomainDialog,
 }: CstgDomainItemProps) {
   const [showEditDialog, setShowEditDialog] = useState<boolean>(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
-  const [isEditedValid, setIsEditedValid] = useState<boolean>(invalidDomains.length === 0);
-
-  useEffect(() => {
-    setIsEditedValid(invalidDomains.length === 0);
-  }, [invalidDomains]);
 
   const onEditDialogChange = () => {
     setShowEditDialog(!showEditDialog);

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
@@ -12,6 +12,7 @@ type CstgDomainItemProps = Readonly<{
   onEditDomain: (newDomain: string, originalDomainName: string) => void;
   onDelete: () => void;
   checked: boolean;
+  isEditedValid: boolean;
 }>;
 
 export function CstgDomainItem({
@@ -21,6 +22,7 @@ export function CstgDomainItem({
   onDelete,
   onEditDomain,
   checked,
+  isEditedValid,
 }: CstgDomainItemProps) {
   const [showEditDialog, setShowEditDialog] = useState<boolean>(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
@@ -56,6 +58,7 @@ export function CstgDomainItem({
               existingDomains={existingDomains}
               onEditDomainName={onEditDomain}
               onOpenChange={onEditDialogChange}
+              isEditedValid={isEditedValid}
             />
           )}
           <button

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
@@ -12,8 +12,6 @@ type CstgDomainItemProps = Readonly<{
   onEditDomain: (newDomain: string, originalDomainName: string) => Promise<boolean>;
   onDelete: () => void;
   checked: boolean;
-  invalidDomains: string[];
-  onCloseEditDomainDialog: () => void;
 }>;
 
 export function CstgDomainItem({
@@ -23,14 +21,12 @@ export function CstgDomainItem({
   onDelete,
   onEditDomain,
   checked,
-  onCloseEditDomainDialog,
 }: CstgDomainItemProps) {
   const [showEditDialog, setShowEditDialog] = useState<boolean>(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
 
   const onEditDialogChange = () => {
     setShowEditDialog(!showEditDialog);
-    onCloseEditDomainDialog();
   };
 
   const onDeleteDialogChange = () => {

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainItem.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 import CstgDeleteDomainDialog from './CstgDeleteDomainDialog';
@@ -9,10 +9,11 @@ type CstgDomainItemProps = Readonly<{
   domain: string;
   existingDomains: string[];
   onClick: () => void;
-  onEditDomain: (newDomain: string, originalDomainName: string) => void;
+  onEditDomain: (newDomain: string, originalDomainName: string) => Promise<boolean>;
   onDelete: () => void;
   checked: boolean;
-  isEditedValid: boolean;
+  invalidDomains: string[];
+  onCloseEditDomainDialog: () => void;
 }>;
 
 export function CstgDomainItem({
@@ -22,13 +23,20 @@ export function CstgDomainItem({
   onDelete,
   onEditDomain,
   checked,
-  isEditedValid,
+  invalidDomains,
+  onCloseEditDomainDialog,
 }: CstgDomainItemProps) {
   const [showEditDialog, setShowEditDialog] = useState<boolean>(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
+  const [isEditedValid, setIsEditedValid] = useState<boolean>(invalidDomains.length === 0);
+
+  useEffect(() => {
+    setIsEditedValid(invalidDomains.length === 0);
+  }, [invalidDomains]);
 
   const onEditDialogChange = () => {
     setShowEditDialog(!showEditDialog);
+    onCloseEditDomainDialog();
   };
 
   const onDeleteDialogChange = () => {
@@ -58,7 +66,6 @@ export function CstgDomainItem({
               existingDomains={existingDomains}
               onEditDomainName={onEditDomain}
               onOpenChange={onEditDialogChange}
-              isEditedValid={isEditedValid}
             />
           )}
           <button

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.stories.tsx
@@ -16,7 +16,7 @@ export const WithDomains: Story = {
     onUpdateDomains: (domains: string[]) => {
       Promise.resolve(console.log('update domains to:', domains));
       return new Promise<UpdateDomainNamesResponse | undefined>((resolve) => {
-        resolve({ domains, isValid: true });
+        resolve({ domains, isValidDomains: true });
       });
     },
   },
@@ -28,7 +28,7 @@ export const WithoutDomains: Story = {
     onUpdateDomains: (domains: string[]) => {
       Promise.resolve(console.log('update domains to:', domains));
       return new Promise<UpdateDomainNamesResponse | undefined>((resolve) => {
-        resolve({ domains: [''], isValid: true });
+        resolve({ domains: [''], isValidDomains: true });
       });
     },
   },

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import { UpdateDomainNamesResponse } from './CstgDomainHelper';
 import { CstgDomainsTable } from './CstgDomainsTable';
 
 export default {
@@ -12,10 +13,10 @@ type Story = StoryObj<typeof CstgDomainsTable>;
 export const WithDomains: Story = {
   args: {
     domains: ['test.com', 'abc.com', '123.com'],
-    onUpdateDomains: (domains) => {
+    onUpdateDomains: (domains: string[]) => {
       Promise.resolve(console.log('update domains to:', domains));
-      return new Promise<string[] | undefined>((resolve) => {
-        resolve(['']);
+      return new Promise<UpdateDomainNamesResponse | undefined>((resolve) => {
+        resolve({ domains, isValid: true });
       });
     },
   },
@@ -24,10 +25,10 @@ export const WithDomains: Story = {
 export const WithoutDomains: Story = {
   args: {
     domains: [],
-    onUpdateDomains: (domains) => {
+    onUpdateDomains: (domains: string[]) => {
       Promise.resolve(console.log('update domains to:', domains));
-      return new Promise<string[] | undefined>((resolve) => {
-        resolve(['']);
+      return new Promise<UpdateDomainNamesResponse | undefined>((resolve) => {
+        resolve({ domains: [''], isValid: true });
       });
     },
   },

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.stories.tsx
@@ -14,10 +14,8 @@ export const WithDomains: Story = {
   args: {
     domains: ['test.com', 'abc.com', '123.com'],
     onUpdateDomains: (domains: string[]) => {
-      Promise.resolve(console.log('update domains to:', domains));
-      return new Promise<UpdateDomainNamesResponse | undefined>((resolve) => {
-        resolve({ domains, isValidDomains: true });
-      });
+      console.log('update domains to:', domains);
+      return Promise.resolve({ domains, isValidDomains: true });
     },
   },
 };

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -43,8 +43,6 @@ export function CstgDomainsTable({
   const [pageNumber, setPageNumber] = useState<number>(initialPageNumber);
   const [rowsPerPage, setRowsPerPage] = useState<RowsPerPageValues>(initialRowsPerPage);
 
-  const [invalidDomains, setInvalidDomains] = useState<string[]>([]);
-
   const isSelectedAll = domains.length && domains.every((d) => selectedDomains.includes(d));
 
   useEffect(() => {
@@ -130,10 +128,8 @@ export function CstgDomainsTable({
     if (editedDomains)
       if (isValidDomains) {
         setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
-        setInvalidDomains([]);
         return true;
       } else {
-        setInvalidDomains(editedDomains);
         return false;
       }
     return false;
@@ -141,7 +137,6 @@ export function CstgDomainsTable({
 
   const onOpenChangeAddDomainDialog = () => {
     setShowAddDomainsDialog(!showAddDomainsDialog);
-    setInvalidDomains([]);
   };
 
   const onOpenChangeDeleteDomainDialog = () => {
@@ -151,7 +146,7 @@ export function CstgDomainsTable({
   const onSubmitAddDomainDialog = async (
     newDomainsFormatted: string[],
     deleteExistingList: boolean
-  ) => {
+  ): Promise<string[]> => {
     const newDomainsResponse = await onAddDomains(newDomainsFormatted, deleteExistingList);
     const newDomains = newDomainsResponse?.domains;
     const isValidDomains = newDomainsResponse?.isValidDomains;
@@ -160,16 +155,17 @@ export function CstgDomainsTable({
       setSearchedDomains(domains);
       setSelectedDomains([]);
       setSearchText('');
-      setInvalidDomains([]);
       if (newDomains) {
         setPageNumber(initialPageNumber);
         setRowsPerPage(initialRowsPerPage);
         setPagedDomains(getPagedDomains(newDomains, initialPageNumber, initialRowsPerPage));
         setSearchedDomains(newDomains);
+        return [];
       }
     } else if (newDomains) {
-      setInvalidDomains(newDomains);
+      return newDomains;
     }
+    return [];
   };
 
   const onChangeDisplayedDomains = (
@@ -179,10 +175,6 @@ export function CstgDomainsTable({
     setPageNumber(currentPageNumber);
     setRowsPerPage(currentRowsPerPage);
     setPagedDomains(getPagedDomains(searchedDomains, currentPageNumber, currentRowsPerPage));
-  };
-
-  const handleCloseEditDomainDialog = () => {
-    setInvalidDomains([]);
   };
 
   return (
@@ -240,7 +232,6 @@ export function CstgDomainsTable({
                 onAddDomains={onSubmitAddDomainDialog}
                 onOpenChange={onOpenChangeAddDomainDialog}
                 existingDomains={domains}
-                invalidDomains={invalidDomains}
               />
             )}
           </div>
@@ -264,8 +255,6 @@ export function CstgDomainsTable({
               onDelete={() => handleBulkDeleteDomains([domain])}
               onEditDomain={handleEditDomain}
               checked={isDomainSelected(domain)}
-              invalidDomains={invalidDomains}
-              onCloseEditDomainDialog={handleCloseEditDomainDialog}
             />
           ))}
         </tbody>

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -123,9 +123,14 @@ export function CstgDomainsTable({
       'edited'
     );
     const editedDomains = editedDomainsResponse?.domains;
-    if (editedDomains) {
-      setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
-    }
+    const isValid = editedDomainsResponse?.isValid;
+    if (editedDomains)
+      if (isValid) {
+        setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
+        setInvalidDomains([]);
+      } else {
+        setInvalidDomains(editedDomains);
+      }
   };
 
   const onOpenChangeAddDomainDialog = () => {
@@ -249,6 +254,7 @@ export function CstgDomainsTable({
               onDelete={() => handleBulkDeleteDomains([domain])}
               onEditDomain={handleEditDomain}
               checked={isDomainSelected(domain)}
+              isEditedValid={invalidDomains.length === 0}
             />
           ))}
         </tbody>

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -125,13 +125,10 @@ export function CstgDomainsTable({
     );
     const editedDomains = editedDomainsResponse?.domains;
     const isValidDomains = editedDomainsResponse?.isValidDomains;
-    if (editedDomains)
-      if (isValidDomains) {
-        setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
-        return true;
-      } else {
-        return false;
-      }
+    if (editedDomains && isValidDomains) {
+      setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
+      return true;
+    }
     return false;
   };
 
@@ -160,9 +157,10 @@ export function CstgDomainsTable({
         setRowsPerPage(initialRowsPerPage);
         setPagedDomains(getPagedDomains(newDomains, initialPageNumber, initialRowsPerPage));
         setSearchedDomains(newDomains);
-        return [];
       }
-    } else if (newDomains) {
+      return [];
+    }
+    if (newDomains) {
       return newDomains;
     }
     return [];

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -113,7 +113,10 @@ export function CstgDomainsTable({
     setPagedDomains(getPagedDomains(newSearchDomains, initialPageNumber, initialRowsPerPage));
   };
 
-  const handleEditDomain = async (updatedDomainName: string, originalDomainName: string) => {
+  const handleEditDomain = async (
+    updatedDomainName: string,
+    originalDomainName: string
+  ): Promise<boolean> => {
     // removes original domain name from list and adds new domain name
     const editedDomainsResponse = await onUpdateDomains(
       [
@@ -128,9 +131,12 @@ export function CstgDomainsTable({
       if (isValidDomains) {
         setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
         setInvalidDomains([]);
+        return true;
       } else {
         setInvalidDomains(editedDomains);
+        return false;
       }
+    return false;
   };
 
   const onOpenChangeAddDomainDialog = () => {
@@ -173,6 +179,10 @@ export function CstgDomainsTable({
     setPageNumber(currentPageNumber);
     setRowsPerPage(currentRowsPerPage);
     setPagedDomains(getPagedDomains(searchedDomains, currentPageNumber, currentRowsPerPage));
+  };
+
+  const handleCloseEditDomainDialog = () => {
+    setInvalidDomains([]);
   };
 
   return (
@@ -254,7 +264,8 @@ export function CstgDomainsTable({
               onDelete={() => handleBulkDeleteDomains([domain])}
               onEditDomain={handleEditDomain}
               checked={isDomainSelected(domain)}
-              isEditedValid={invalidDomains.length === 0}
+              invalidDomains={invalidDomains}
+              onCloseEditDomainDialog={handleCloseEditDomainDialog}
             />
           ))}
         </tbody>

--- a/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDomainsTable.tsx
@@ -123,9 +123,9 @@ export function CstgDomainsTable({
       'edited'
     );
     const editedDomains = editedDomainsResponse?.domains;
-    const isValid = editedDomainsResponse?.isValid;
+    const isValidDomains = editedDomainsResponse?.isValidDomains;
     if (editedDomains)
-      if (isValid) {
+      if (isValidDomains) {
         setPagedDomains(getPagedDomains(editedDomains, pageNumber, rowsPerPage));
         setInvalidDomains([]);
       } else {
@@ -148,8 +148,8 @@ export function CstgDomainsTable({
   ) => {
     const newDomainsResponse = await onAddDomains(newDomainsFormatted, deleteExistingList);
     const newDomains = newDomainsResponse?.domains;
-    const isValid = newDomainsResponse?.isValid;
-    if (isValid) {
+    const isValidDomains = newDomainsResponse?.isValidDomains;
+    if (isValidDomains) {
       setShowAddDomainsDialog(false);
       setSearchedDomains(domains);
       setSelectedDomains([]);

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.stories.tsx
@@ -26,6 +26,7 @@ export const Default = () => {
             Promise.resolve(console.log('Domain edited: ', updatedDomain));
             setIsOpen(!isOpen);
           }}
+          isEditedValid
         />
       )}
     </div>

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.stories.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.stories.tsx
@@ -23,10 +23,10 @@ export const Default = () => {
           domain='testdomain.com'
           existingDomains={['test.com', 'test2.com']}
           onEditDomainName={(updatedDomain) => {
-            Promise.resolve(console.log('Domain edited: ', updatedDomain));
+            console.log('Domain edited: ', updatedDomain);
             setIsOpen(!isOpen);
+            return Promise.resolve(true);
           }}
-          isEditedValid
         />
       )}
     </div>

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { EditDomainFormProps } from '../../services/domainNamesService';
@@ -10,9 +9,8 @@ import { extractTopLevelDomain } from './CstgDomainHelper';
 type EditDomainDialogProps = Readonly<{
   domain: string;
   existingDomains: string[];
-  onEditDomainName: (newDomain: string, originalDomainName: string) => void;
+  onEditDomainName: (newDomain: string, originalDomainName: string) => Promise<boolean>;
   onOpenChange: () => void;
-  isEditedValid: boolean;
 }>;
 
 function EditDomainDialog({
@@ -20,7 +18,6 @@ function EditDomainDialog({
   onEditDomainName,
   onOpenChange,
   existingDomains,
-  isEditedValid,
 }: EditDomainDialogProps) {
   const formMethods = useForm<EditDomainFormProps>({
     defaultValues: {
@@ -34,15 +31,6 @@ function EditDomainDialog({
     formState: { errors },
   } = formMethods;
 
-  useEffect(() => {
-    if (!isEditedValid) {
-      setError('root.serverError', {
-        type: '400',
-        message: 'Edited domain is an invalid root-level domain.',
-      });
-    }
-  }, [isEditedValid, setError]);
-
   const onSubmit = async (formData: EditDomainFormProps) => {
     const updatedDomainName = formData.domainName;
     const originalDomainName = domain;
@@ -55,7 +43,13 @@ function EditDomainDialog({
         message: 'Domain name already exists.',
       });
     } else {
-      onEditDomainName(updatedTopLevelDomain, originalDomainName);
+      const editDomainSuccess = await onEditDomainName(updatedTopLevelDomain, originalDomainName);
+      if (!editDomainSuccess) {
+        setError('root.serverError', {
+          type: '400',
+          message: 'Edited domain is an invalid root-level domain.',
+        });
+      }
     }
   };
 

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDomainDialog.tsx
@@ -1,16 +1,18 @@
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { EditDomainFormProps } from '../../services/domainNamesService';
 import { Dialog } from '../Core/Dialog';
 import { RootFormErrors } from '../Input/FormError';
 import { TextInput } from '../Input/TextInput';
-import { extractTopLevelDomain, isValidDomain } from './CstgDomainHelper';
+import { extractTopLevelDomain } from './CstgDomainHelper';
 
 type EditDomainDialogProps = Readonly<{
   domain: string;
   existingDomains: string[];
   onEditDomainName: (newDomain: string, originalDomainName: string) => void;
   onOpenChange: () => void;
+  isEditedValid: boolean;
 }>;
 
 function EditDomainDialog({
@@ -18,6 +20,7 @@ function EditDomainDialog({
   onEditDomainName,
   onOpenChange,
   existingDomains,
+  isEditedValid,
 }: EditDomainDialogProps) {
   const formMethods = useForm<EditDomainFormProps>({
     defaultValues: {
@@ -31,16 +34,18 @@ function EditDomainDialog({
     formState: { errors },
   } = formMethods;
 
+  useEffect(() => {
+    if (!isEditedValid) {
+      setError('root.serverError', {
+        type: '400',
+        message: 'Edited domain is an invalid root-level domain.',
+      });
+    }
+  }, [isEditedValid, setError]);
+
   const onSubmit = async (formData: EditDomainFormProps) => {
     const updatedDomainName = formData.domainName;
     const originalDomainName = domain;
-    if (!isValidDomain(updatedDomainName)) {
-      setError('root.serverError', {
-        type: '400',
-        message: 'Domain name must be valid.',
-      });
-      return;
-    }
     const updatedTopLevelDomain = extractTopLevelDomain(updatedDomainName);
     if (updatedTopLevelDomain === originalDomainName) {
       onOpenChange();

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -86,19 +86,18 @@ function ClientSideIntegration() {
   ): Promise<UpdateDomainNamesResponse | undefined> => {
     try {
       const response = await UpdateDomainNames(updatedDomainNames);
-      let domains = response;
-      let isValid = true;
-      if (domains.length === 1 && domains[0].includes('Invalid Domains')) {
-        const invalidDomains = separateStringsList(domains[0].replace('Invalid Domains', ''));
+      let domains = response?.domains;
+      const isValidDomains = response?.isValidDomains;
+      if (!isValidDomains) {
+        const invalidDomains = separateStringsList(domains[0]);
         domains = invalidDomains;
-        isValid = false;
       } else {
-        setDomainNames(sortStringsAlphabetically(response));
+        setDomainNames(sortStringsAlphabetically(domains));
         SuccessToast(`Domain names ${action}.`);
       }
       const updatedDomainNamesResponse: UpdateDomainNamesResponse = {
         domains,
-        isValid,
+        isValidDomains,
       };
       return updatedDomainNamesResponse;
     } catch (e) {

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -88,8 +88,8 @@ function ClientSideIntegration() {
       const response = await UpdateDomainNames(updatedDomainNames);
       let domains = response;
       let isValid = true;
-      if (typeof response === 'string') {
-        const invalidDomains = separateStringsList(response);
+      if (domains.length === 1 && domains[0].includes('Invalid Domains')) {
+        const invalidDomains = separateStringsList(domains[0].replace('Invalid Domains', ''));
         domains = invalidDomains;
         isValid = false;
       } else {

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { ClientSideCompletion } from '../components/ClientSideCompletion/ClientSideCompletion';
+import { UpdateDomainNamesResponse } from '../components/ClientSideTokenGeneration/CstgDomainHelper';
 import { CstgDomainsTable } from '../components/ClientSideTokenGeneration/CstgDomainsTable';
 import { ScreenContentContainer } from '../components/Core/ScreenContentContainer';
 import { SuccessToast } from '../components/Core/Toast';
@@ -17,7 +18,7 @@ import {
 } from '../services/keyPairService';
 import { handleErrorToast } from '../utils/apiError';
 import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
-import { sortStringsAlphabetically } from '../utils/textHelpers';
+import { separateStringsList, sortStringsAlphabetically } from '../utils/textHelpers';
 import { PortalRoute } from './routeUtils';
 
 function ClientSideIntegration() {
@@ -79,12 +80,27 @@ function ClientSideIntegration() {
       handleErrorToast(e);
     }
   };
-  const handleUpdateDomainNames = async (updatedDomainNames: string[], action: string) => {
+  const handleUpdateDomainNames = async (
+    updatedDomainNames: string[],
+    action: string
+  ): Promise<UpdateDomainNamesResponse | undefined> => {
     try {
       const response = await UpdateDomainNames(updatedDomainNames);
-      setDomainNames(sortStringsAlphabetically(response));
-      SuccessToast(`Domain names ${action}.`);
-      return response;
+      let domains = response;
+      let isValid = true;
+      if (typeof response === 'string') {
+        const invalidDomains = separateStringsList(response);
+        domains = invalidDomains;
+        isValid = false;
+      } else {
+        setDomainNames(sortStringsAlphabetically(response));
+        SuccessToast(`Domain names ${action}.`);
+      }
+      const updatedDomainNamesResponse: UpdateDomainNamesResponse = {
+        domains,
+        isValid,
+      };
+      return updatedDomainNamesResponse;
     } catch (e) {
       handleErrorToast(e);
     }

--- a/src/web/services/domainNamesService.ts
+++ b/src/web/services/domainNamesService.ts
@@ -36,8 +36,8 @@ export async function UpdateDomainNames(
     );
     return result.data;
   } catch (e: unknown) {
-    if (e instanceof AxiosError) {
-      return e?.response?.data.message;
+    if (e instanceof AxiosError && e?.response?.status === 400) {
+      return [e?.response?.data.message];
     }
 
     throw backendError(e, 'Could not set domain names');

--- a/src/web/services/domainNamesService.ts
+++ b/src/web/services/domainNamesService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios';
 
+import { UpdateDomainNamesResponse } from '../components/ClientSideTokenGeneration/CstgDomainHelper';
 import { backendError } from '../utils/apiError';
 
 export type AddDomainNamesFormProps = {
@@ -26,7 +27,7 @@ export async function GetDomainNames(participantId?: number) {
 export async function UpdateDomainNames(
   domainNames: string[],
   participantId?: number
-): Promise<string[]> {
+): Promise<UpdateDomainNamesResponse> {
   try {
     const result = await axios.post<string[]>(
       `/participants/${participantId ?? 'current'}/domainNames`,
@@ -34,10 +35,11 @@ export async function UpdateDomainNames(
         domainNames,
       }
     );
-    return result.data;
+    return { domains: result.data, isValidDomains: true };
   } catch (e: unknown) {
     if (e instanceof AxiosError && e?.response?.status === 400) {
-      return [e?.response?.data.message];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      return { domains: [e?.response?.data.message], isValidDomains: false };
     }
 
     throw backendError(e, 'Could not set domain names');

--- a/src/web/services/domainNamesService.ts
+++ b/src/web/services/domainNamesService.ts
@@ -37,9 +37,17 @@ export async function UpdateDomainNames(
     );
     return { domains: result.data, isValidDomains: true };
   } catch (e: unknown) {
-    if (e instanceof AxiosError && e?.response?.status === 400) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      return { domains: [e?.response?.data.message], isValidDomains: false };
+    if (
+      e instanceof AxiosError &&
+      e?.response?.status === 400 &&
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      e?.response?.data.message.includes('Invalid Domain Names')
+    ) {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        domains: [e?.response?.data.message.replace('Invalid Domain Names:', '')],
+        isValidDomains: false,
+      };
     }
 
     throw backendError(e, 'Could not set domain names');

--- a/src/web/services/domainNamesService.ts
+++ b/src/web/services/domainNamesService.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import { backendError } from '../utils/apiError';
 
@@ -36,6 +36,10 @@ export async function UpdateDomainNames(
     );
     return result.data;
   } catch (e: unknown) {
+    if (e instanceof AxiosError) {
+      return e?.response?.data.message;
+    }
+
     throw backendError(e, 'Could not set domain names');
   }
 }

--- a/src/web/utils/textHelpers.ts
+++ b/src/web/utils/textHelpers.ts
@@ -26,8 +26,9 @@ export function formatUnixDate(timeValue: number) {
 
 export const separateStringsList = (strings: string): string[] => {
   if (strings === '') return [];
-  const stringsTrimmed = strings.replace(/, |,| {2}|\n|;/gi, ' ').trim();
-  return stringsTrimmed.split(/[ ]+/);
+  const stringsTrimmed = strings.replace(/, |,| {2}|\n|;|]|\[/gi, ' ').trim();
+  const ts = stringsTrimmed.split(/[ ]+/);
+  return ts;
 };
 
 export const deduplicateStrings = (strings: string[]) => {

--- a/src/web/utils/textHelpers.ts
+++ b/src/web/utils/textHelpers.ts
@@ -27,8 +27,7 @@ export function formatUnixDate(timeValue: number) {
 export const separateStringsList = (strings: string): string[] => {
   if (strings === '') return [];
   const stringsTrimmed = strings.replace(/, |,| {2}|\n|;|]|\[/gi, ' ').trim();
-  const ts = stringsTrimmed.split(/[ ]+/);
-  return ts;
+  return stringsTrimmed.split(/[ ]+/);
 };
 
 export const deduplicateStrings = (strings: string[]) => {


### PR DESCRIPTION
What Changed:

- Domain validation all happening on the backend in admin (removed domain validation from front end)
- All types of invalid root-level domains entered will show in both Add Domain dialog and Edit Domain Dialog
- Created an UpdatedDomainResponse type that returns the domains and if they are valid or invalid
- Added removal for '[' and ']' in the trim function



Test Plan:

- Test adding invalid domain with typo (example: test....com)
- Test adding invalid domain that is not valid root-level (examples: blogspot.com, github.io, wmflabs.org)
- Test adding multiple invalid domains 
- Test editing a valid domain to an invalid domain
- Test AddDomainDialog and EditDomainDialog storybook components