### PR TITLE
Introduce an async error pattern for customizing loader error display.

### DIFF
--- a/src/api/helpers/errorHelpers.ts
+++ b/src/api/helpers/errorHelpers.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express';
+
+import { getTraceId } from './loggingHelpers';
+
+export function errorResponse(
+  req: Request,
+  res: Response,
+  errorCode: number,
+  response?: { message: string } & Record<string, unknown>
+) {
+  const traceId = getTraceId(req);
+
+  return res.status(errorCode).json({
+    errorHash: traceId,
+    ...response,
+  });
+}
+
+export const siteIdNotSetError = (req: Request, res: Response) =>
+  errorResponse(req, res, 400, { message: 'Site id is not set' });

--- a/src/api/routers/participants/participantsDomainNames.ts
+++ b/src/api/routers/participants/participantsDomainNames.ts
@@ -2,6 +2,7 @@ import { Response } from 'express';
 import { z } from 'zod';
 
 import { AuditAction } from '../../entities/AuditTrail';
+import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getSite, setSiteDomainNames } from '../../services/adminServiceClient';
 import {
@@ -13,7 +14,7 @@ import { ParticipantRequest, UserParticipantRequest } from '../../services/parti
 export async function getParticipantDomainNames(req: ParticipantRequest, res: Response) {
   const { participant } = req;
   if (!participant?.siteId) {
-    return res.status(400).send('Site id is not set');
+    return siteIdNotSetError(req, res);
   }
   const participantSite = await getSite(participant.siteId);
   return res.status(200).json(participantSite.domain_names ?? []);
@@ -24,7 +25,7 @@ const domainNamesParser = z.object({ domainNames: z.array(z.string()) });
 export async function setParticipantDomainNames(req: UserParticipantRequest, res: Response) {
   const { participant, user } = req;
   if (!participant?.siteId) {
-    return res.status(400).send('Site id is not set');
+    return siteIdNotSetError(req, res);
   }
   const { domainNames } = domainNamesParser.parse(req.body);
   const traceId = getTraceId(req);

--- a/src/api/routers/participants/participantsKeyPairs.spec.ts
+++ b/src/api/routers/participants/participantsKeyPairs.spec.ts
@@ -78,7 +78,6 @@ describe('#getParticipantKeyPairs', () => {
     await getParticipantKeyPairs(participantRequest, res);
 
     expect(res.status).toHaveBeenLastCalledWith(400);
-    expect(res.send).toHaveBeenLastCalledWith('Site id is not set');
   });
 
   test.each([

--- a/src/api/routers/participants/participantsKeyPairs.ts
+++ b/src/api/routers/participants/participantsKeyPairs.ts
@@ -1,12 +1,13 @@
 import { Response } from 'express';
 
+import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getKeyPairsList } from '../../services/adminServiceClient';
 import { ParticipantRequest } from '../../services/participantsService';
 
 export async function getParticipantKeyPairs(req: ParticipantRequest, res: Response) {
   const { participant } = req;
   if (!participant?.siteId) {
-    return res.status(400).send('Site id is not set');
+    return siteIdNotSetError(req, res);
   }
   const siteId = participant?.siteId;
   const allKeyPairs = await getKeyPairsList(siteId!);

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -12,7 +12,7 @@ import {
   ParticipantStatus,
 } from '../../entities/Participant';
 import { UserDTO, UserRole } from '../../entities/User';
-import { errorResponse, siteIdNotSetError } from '../../helpers/errorHelpers';
+import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { isApproverCheck } from '../../middleware/approversMiddleware';

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -12,6 +12,7 @@ import {
   ParticipantStatus,
 } from '../../entities/Participant';
 import { UserDTO, UserRole } from '../../entities/User';
+import { errorResponse, siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { isApproverCheck } from '../../middleware/approversMiddleware';
@@ -262,7 +263,7 @@ export function createParticipantsRouter() {
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
       const traceId = getTraceId(req);
       try {
@@ -284,7 +285,7 @@ export function createParticipantsRouter() {
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
 
       const adminApiKeys = await getApiKeysBySite(participant.siteId);
@@ -302,7 +303,7 @@ export function createParticipantsRouter() {
     async (req: ParticipantRequest, res: Response) => {
       const { participant } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
 
       const { keyId } = apiKeyIdParser.parse(req.query);
@@ -329,7 +330,7 @@ export function createParticipantsRouter() {
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
 
       const { keyId, newName, newApiRoles } = apiKeyEditInputParser.parse(req.body);
@@ -391,7 +392,7 @@ export function createParticipantsRouter() {
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
 
       const { keyId } = apiKeyDeleteInputParser.parse(req.body);
@@ -439,7 +440,7 @@ export function createParticipantsRouter() {
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
 
       const { name: keyName, roles: apiRoles } = apiKeyCreateInputParser.parse(req.body);
@@ -475,7 +476,7 @@ export function createParticipantsRouter() {
       const { participant, user } = req;
       const traceId = getTraceId(req);
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
       const { newParticipantSites } = sharingRelationParser.parse(req.body);
       const auditTrail = await insertSharingAuditTrails(
@@ -514,7 +515,7 @@ export function createParticipantsRouter() {
       const { participant, user } = req;
       const traceId = getTraceId(req);
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
       const { name } = addKeyPairParser.parse(req.body);
       const disabled = false;
@@ -541,7 +542,7 @@ export function createParticipantsRouter() {
       const { participant, user } = req;
       const traceId = getTraceId(req);
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
       const { name, subscriptionId, disabled } = keyPairParser.parse(req.body);
       const auditTrail = await insertKeyPairAuditTrails(
@@ -566,7 +567,7 @@ export function createParticipantsRouter() {
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
 
       const { name, subscriptionId } = keyPairParser.parse(req.body.keyPair);
@@ -610,7 +611,7 @@ export function createParticipantsRouter() {
       const { participant, user } = req;
       const traceId = getTraceId(req);
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
       const { sharingSitesToRemove } = removeSharingRelationParser.parse(req.body);
       const auditTrail = await insertSharingAuditTrails(
@@ -643,7 +644,7 @@ export function createParticipantsRouter() {
       const { participant, user } = req;
       const traceId = getTraceId(req);
       if (!participant?.siteId) {
-        return res.status(400).send('Site id is not set');
+        return siteIdNotSetError(req, res);
       }
       const { types } = sharingTypesParser.parse(req.body);
       const auditTrail = await insertSharingTypesAuditTrail(

--- a/src/web/components/Core/EnvironmentBanner.tsx
+++ b/src/web/components/Core/EnvironmentBanner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { EnvironmentVariable, GetEnvironmentVariables } from '../../services/environmentVariables';
 import { ApiError } from '../../utils/apiError';
-import { useAsyncError } from '../../utils/errorHandler';
+import { useAsyncThrowError } from '../../utils/errorHandler';
 import { Banner } from './Banner';
 
 function EnvironmentBanner() {
@@ -10,7 +10,7 @@ function EnvironmentBanner() {
     baseUrl: '',
     isDevelopment: false,
   });
-  const throwError = useAsyncError();
+  const throwError = useAsyncThrowError();
 
   useEffect(() => {
     const loadEnvironmentVariables = async () => {

--- a/src/web/components/Core/ErrorView.stories.tsx
+++ b/src/web/components/Core/ErrorView.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import ErrorView from './ErrorView';
+import { ErrorView } from './ErrorView';
 
 import '../../utils/errorHandler.scss';
 

--- a/src/web/components/Core/ErrorView.tsx
+++ b/src/web/components/Core/ErrorView.tsx
@@ -1,4 +1,8 @@
-import { analyticsIdentifier } from '../../utils/errorHelpers';
+import axios from 'axios';
+import { useAsyncError } from 'react-router-dom';
+
+import { ApiError, getErrorHash } from '../../utils/apiError';
+import { analyticsIdentifier, extractMessageFromAxiosError } from '../../utils/errorHelpers';
 
 type ErrorViewProps = {
   message?: string;
@@ -6,18 +10,27 @@ type ErrorViewProps = {
   errorHash?: string;
 };
 
-function ErrorView({ message, errorId, errorHash }: ErrorViewProps) {
+export function ErrorView({ message, errorId, errorHash }: ErrorViewProps) {
   return (
     <div className='error-content'>
       <img alt='Error icon' src='/uid2-logo.png' />
-      <div>Error</div>
-      <div>
-        {message ??
-          'There was an unexpected error. Please try again. If the problem persists, contact Support and provide the following information: '}
-      </div>
+      <div>There was an unexpected error. Please try again.</div>
+      <div>If the problem persists, contact Support and provide the following information:</div>
+      {!!message && <div>Error message: {message}</div>}
       <div>({analyticsIdentifier(errorId, errorHash)})</div>
     </div>
   );
 }
 
-export default ErrorView;
+export function AsyncErrorView() {
+  const err = useAsyncError();
+  if (axios.isAxiosError(err)) {
+    const message = extractMessageFromAxiosError(err);
+    const hash = getErrorHash(err);
+    return <ErrorView errorHash={hash} message={message} />;
+  }
+  if (err instanceof ApiError) {
+    return <ErrorView errorHash={err.errorHash} message={err.message} />;
+  }
+  return <ErrorView />;
+}

--- a/src/web/contexts/CurrentUserProvider.tsx
+++ b/src/web/contexts/CurrentUserProvider.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Loading } from '../components/Core/Loading';
 import { GetLoggedInUserAccount, UserAccount } from '../services/userAccount';
-import { useAsyncError } from '../utils/errorHandler';
+import { useAsyncThrowError } from '../utils/errorHandler';
 
 type UserContextWithSetter = {
   LoggedInUser: UserAccount | null;
@@ -23,7 +23,7 @@ function CurrentUserProvider({ children }: { children: ReactNode }) {
   const [LoggedInUser, SetLoggedInUser] = useState<UserAccount | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
-  const throwError = useAsyncError();
+  const throwError = useAsyncThrowError();
 
   const loadUser = useCallback(async () => {
     setIsLoading(true);

--- a/src/web/contexts/ParticipantProvider.tsx
+++ b/src/web/contexts/ParticipantProvider.tsx
@@ -5,7 +5,7 @@ import { ParticipantDTO, ParticipantStatus } from '../../api/entities/Participan
 import { Loading } from '../components/Core/Loading';
 import { GetCurrentUsersParticipant } from '../services/participant';
 import { ApiError } from '../utils/apiError';
-import { useAsyncError } from '../utils/errorHandler';
+import { useAsyncThrowError } from '../utils/errorHandler';
 import { CurrentUserContext } from './CurrentUserProvider';
 
 type ParticipantWithSetter = {
@@ -23,7 +23,7 @@ function ParticipantProvider({ children }: { children: ReactNode }) {
   const { LoggedInUser } = useContext(CurrentUserContext);
   const location = useLocation();
   const navigate = useNavigate();
-  const throwError = useAsyncError();
+  const throwError = useAsyncThrowError();
   const user = LoggedInUser?.user || null;
 
   useEffect(() => {

--- a/src/web/screens/home.tsx
+++ b/src/web/screens/home.tsx
@@ -4,7 +4,7 @@ import { Suspense, useContext } from 'react';
 import { defer, makeLoader, useLoaderData } from 'react-router-typesafe';
 
 import { ClientType } from '../../api/services/adminServiceHelpers';
-import ErrorView from '../components/Core/ErrorView';
+import { AsyncErrorView } from '../components/Core/ErrorView';
 import { Loading } from '../components/Core/Loading';
 import DocumentationCard from '../components/Home/DocumentationCard';
 import SharingPermissionCard from '../components/Home/SharingPermissionCard';
@@ -61,7 +61,7 @@ function Home() {
       <h1>Welcome back, {LoggedInUser?.profile.firstName}</h1>
       <div className='dashboard-cards-container'>
         <Suspense fallback={<Loading />}>
-          <AwaitTypesafe resolve={data.counts} errorElement={<ErrorView />}>
+          <AwaitTypesafe resolve={data.counts} errorElement={<AsyncErrorView />}>
             {(counts) => (
               <SharingPermissionCard
                 sharingPermissionsCount={counts.sharingPermissionsCount}

--- a/src/web/screens/sharingPermissions.tsx
+++ b/src/web/screens/sharingPermissions.tsx
@@ -18,7 +18,7 @@ import {
   UpdateSharingTypes,
 } from '../services/participant';
 import { handleErrorToast } from '../utils/apiError';
-import { useAsyncError } from '../utils/errorHandler';
+import { useAsyncThrowError } from '../utils/errorHandler';
 import { RouteErrorBoundary } from '../utils/RouteErrorBoundary';
 import { PortalRoute } from './routeUtils';
 
@@ -39,7 +39,7 @@ function SharingPermissions() {
   const { participant, setParticipant } = useContext(ParticipantContext);
   const [sharedSiteIds, setSharedSiteIds] = useState<number[]>([]);
   const [sharedTypes, setSharedTypes] = useState<ClientType[]>([]);
-  const throwError = useAsyncError();
+  const throwError = useAsyncThrowError();
 
   const handleSaveSharingType = async (selectedTypes: ClientType[]) => {
     try {

--- a/src/web/utils/PortalErrorBoundary.test.tsx
+++ b/src/web/utils/PortalErrorBoundary.test.tsx
@@ -42,9 +42,7 @@ describe('Error boundary', () => {
       </TestContextProvider>
     );
     expect(
-      await screen.findByText(
-        'There was an unexpected error. Please try again. If the problem persists, contact Support and provide the following information:'
-      )
+      await screen.findByText('There was an unexpected error. Please try again.')
     ).toBeInTheDocument();
     portalSpy.mockRestore();
   });

--- a/src/web/utils/PortalErrorBoundary.tsx
+++ b/src/web/utils/PortalErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import ErrorView from '../components/Core/ErrorView';
+import { ErrorView } from '../components/Core/ErrorView';
 import { errorHandler, RenderedErrorProps } from './errorHandler';
 
 function PortalErrorComponent(props: RenderedErrorProps) {

--- a/src/web/utils/RouteErrorBoundary.tsx
+++ b/src/web/utils/RouteErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { useRouteError } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 
-import ErrorView from '../components/Core/ErrorView';
+import { ErrorView } from '../components/Core/ErrorView';
 
 interface RouteError {
   errorHash?: string;

--- a/src/web/utils/apiError.tsx
+++ b/src/web/utils/apiError.tsx
@@ -30,7 +30,7 @@ export function backendError(e: unknown, overrideMessage: string) {
 
 const isError = (obj: unknown): obj is Error => obj instanceof Error;
 
-const getHash = (e: Error) => {
+export const getErrorHash = (e: Error) => {
   let result = '';
   if (e instanceof ApiError) {
     result = e.errorHash ?? '';
@@ -43,7 +43,7 @@ const getHash = (e: Error) => {
 
 export const handleErrorToast = (e: unknown) => {
   if (isError(e)) {
-    const hash = getHash(e);
+    const hash = getErrorHash(e);
     const hashMessage = hash.length > 0 ? `: (${hash})` : '';
     ErrorToast(`${e.message}${hashMessage}`);
   }

--- a/src/web/utils/errorHandler.tsx
+++ b/src/web/utils/errorHandler.tsx
@@ -86,7 +86,7 @@ export function errorHandler<P extends ErrorBoundaryPropType>(
  * This is needed to make the react render loop aware of errors in async events.
  * Refer [this issue](https://github.com/facebook/react/issues/14981#issuecomment-468460187)
  */
-export function useAsyncError() {
+export function useAsyncThrowError() {
   const [, setError] = React.useState();
   return React.useCallback(
     (e: Error) => {

--- a/src/web/utils/errorHelpers.ts
+++ b/src/web/utils/errorHelpers.ts
@@ -10,15 +10,15 @@ export const analyticsIdentifier = (errorId?: string, errorHash?: string) => {
 export const extractMessageFromAxiosError = (err: Error) => {
   // message does not exist on the data field for Axios Error.Response, but we add it
   // in our API for custom messages
-  let message = null;
   if (axios.isAxiosError(err)) {
     if (err.response?.data?.message) {
-      message = err.response?.data?.message as string;
-    } else if ((err.response?.data ?? [])[0]?.message) {
-      message = err.response?.data[0]?.message as string;
-    } else if (err.response?.data) {
-      message = err.response?.data as string;
+      return err.response?.data?.message as string;
+    }
+    if ((err.response?.data ?? [])[0]?.message) {
+      return err.response?.data[0]?.message as string;
+    }
+    if (err.response?.data) {
+      return err.response?.data as string;
     }
   }
-  return message;
 };


### PR DESCRIPTION
Some refactoring to support async front-end errors. Notably, renamed our useAsyncError function because the name colided with a framework function and I wanted to avoid confusion.

Introduce an async error pattern for customizing display of errors that occur during route loaders and use this for the home screen.

Full route failure, default behaviour:
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/111951647/3ad652e7-e7e8-4e7b-a4aa-9678695e3190)

Custom async handler (i.e. home.tsx):
![image](https://github.com/IABTechLab/uid2-self-serve-portal/assets/111951647/8e832c71-dca3-420b-8472-994d13aa2fc0)
