### PR TITLE
Update Faro config to be supplied in the client.

### DIFF
--- a/src/web/initializeFaro.ts
+++ b/src/web/initializeFaro.ts
@@ -1,10 +1,12 @@
 import { Faro, initializeFaro as coreInit } from '@grafana/faro-react';
 
 import config from '../../package.json';
+import { GetClientConfig } from './services/environmentVariables';
 
+const { faroUrl } = GetClientConfig();
 export async function initializeFaro(): Promise<Faro> {
   const faro = coreInit({
-    url: process.env.REACT_APP_FARO_URL,
+    url: faroUrl,
     app: {
       name: config.name,
       version: config.version,

--- a/src/web/initializeFaro.ts
+++ b/src/web/initializeFaro.ts
@@ -3,14 +3,14 @@ import { Faro, initializeFaro as coreInit } from '@grafana/faro-react';
 import config from '../../package.json';
 import { GetClientConfig } from './services/environmentVariables';
 
-const { faroUrl } = GetClientConfig();
+const { faroUrl, environment } = GetClientConfig();
 export async function initializeFaro(): Promise<Faro> {
   const faro = coreInit({
     url: faroUrl,
     app: {
       name: config.name,
       version: config.version,
-      environment: process.env.NODE_ENV,
+      environment,
     },
   });
 

--- a/src/web/services/environmentVariables.ts
+++ b/src/web/services/environmentVariables.ts
@@ -9,6 +9,7 @@ export type EnvironmentVariable = {
 
 export type ClientConfig = {
   faroUrl: string;
+  environment: string;
 };
 
 const hostedFaroUrl =
@@ -17,12 +18,15 @@ const hostedFaroUrl =
 const configMaps: { [index: string]: ClientConfig } = {
   'portal.integ.unifiedid.com': {
     faroUrl: hostedFaroUrl,
+    environment: 'integ',
   },
   'portal.unifiedid.com': {
     faroUrl: hostedFaroUrl,
+    environment: 'prod',
   },
   localhost: {
     faroUrl: '',
+    environment: 'dev',
   },
 };
 

--- a/src/web/services/environmentVariables.ts
+++ b/src/web/services/environmentVariables.ts
@@ -7,6 +7,31 @@ export type EnvironmentVariable = {
   isDevelopment: boolean;
 };
 
+export type ClientConfig = {
+  faroUrl: string;
+};
+
+const hostedFaroUrl =
+  'https://faro-collector-prod-us-east-0.grafana.net/collect/0e0a878597e4df4ead54287f1152af30';
+
+const configMaps: { [index: string]: ClientConfig } = {
+  'portal.integ.unifiedid.com': {
+    faroUrl: hostedFaroUrl,
+  },
+  'portal.unifiedid.com': {
+    faroUrl: hostedFaroUrl,
+  },
+  localhost: {
+    faroUrl: '',
+  },
+};
+
+export function GetClientConfig() {
+  const url = new URL(document.URL).hostname;
+  if (Object.hasOwn(configMaps, url)) return configMaps[url];
+  throw Error(`Could not find client settings for hostname ${url}.`);
+}
+
 export async function GetEnvironmentVariables() {
   try {
     const result = await axios.get<EnvironmentVariable>(`/envars`, {


### PR DESCRIPTION
Add a way to supply client-only settings that don't require an API call.
Supply the faro config this way.