### PR TITLE
Add in-line delete button to Sharing Permissions Table

### DIFF
--- a/src/web/components/SharingPermission/DeletePermissionDialog.tsx
+++ b/src/web/components/SharingPermission/DeletePermissionDialog.tsx
@@ -1,31 +1,29 @@
-import { SharingSiteWithSource } from "../../../api/helpers/siteConvertingHelpers";
-import { ClientType ,
-  ClientTypeDescriptions,
-} from "../../../api/services/adminServiceHelpers";
-import { formatStringsWithSeparator } from "../../utils/textHelpers";
-import { Dialog } from "../Core/Dialog";
-import {
-  MANUALLY_ADDED,
-} from './ParticipantTableHelper';
+import { SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
+import { ClientType, ClientTypeDescriptions } from '../../../api/services/adminServiceHelpers';
+import { formatStringsWithSeparator } from '../../utils/textHelpers';
+import { Dialog } from '../Core/Dialog';
+import { MANUALLY_ADDED } from './ParticipantTableHelper';
 
 type DeletePermissionDialogProps = Readonly<{
-  onDeleteSharingPermission: () => void;
+  onDeleteSharingPermission: (siteIdsToDelete: number[]) => void;
   selectedSiteList: SharingSiteWithSource[];
   onOpenChange: () => void;
 }>;
 export function DeletePermissionDialog({
   onDeleteSharingPermission,
   selectedSiteList,
-  onOpenChange
+  onOpenChange,
 }: DeletePermissionDialogProps) {
   const handleDeletePermissions = () => {
-    onDeleteSharingPermission();
+    onDeleteSharingPermission(selectedSiteList.map((selectedSite) => selectedSite.id));
     onOpenChange();
   };
 
+  console.log(selectedSiteList);
+
   const showDeletionNotice = (participant: SharingSiteWithSource) => {
     const remainSources = participant.addedBy.filter(
-      (source) => source !== MANUALLY_ADDED
+      (source) => source !== MANUALLY_ADDED,
     ) as ClientType[];
     const remainSourceDescriptions = remainSources.map((x) => ClientTypeDescriptions[x]);
     if (remainSourceDescriptions.length) {
@@ -39,28 +37,26 @@ export function DeletePermissionDialog({
   };
 
   return (
-
-        <Dialog
-          title='Are you sure you want to delete these permissions?'
-          onOpenChange={onOpenChange}
-          closeButtonText='Cancel'
-        >
-          <div className='dialog-body-section'>
-            <ul className='dot-list'>
-              {selectedSiteList.map((participant) => (
-                <li key={participant.id}>
-                  {participant.name}
-                  {showDeletionNotice(participant)}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className='dialog-footer-section'>
-            <button type='button' className='primary-button' onClick={handleDeletePermissions}>
-              Delete Permissions
-            </button>
-          </div>
-        </Dialog>
-
+    <Dialog
+      title='Are you sure you want to delete these permissions?'
+      onOpenChange={onOpenChange}
+      closeButtonText='Cancel'
+    >
+      <div className='dialog-body-section'>
+        <ul className='dot-list'>
+          {selectedSiteList.map((participant) => (
+            <li key={participant.id}>
+              {participant.name}
+              {showDeletionNotice(participant)}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className='dialog-footer-section'>
+        <button type='button' className='primary-button' onClick={handleDeletePermissions}>
+          Delete Permissions
+        </button>
+      </div>
+    </Dialog>
   );
 }

--- a/src/web/components/SharingPermission/DeletePermissionDialog.tsx
+++ b/src/web/components/SharingPermission/DeletePermissionDialog.tsx
@@ -19,8 +19,6 @@ export function DeletePermissionDialog({
     onOpenChange();
   };
 
-  console.log(selectedSiteList);
-
   const showDeletionNotice = (participant: SharingSiteWithSource) => {
     const remainSources = participant.addedBy.filter(
       (source) => source !== MANUALLY_ADDED,

--- a/src/web/components/SharingPermission/DeletePermissionDialog.tsx
+++ b/src/web/components/SharingPermission/DeletePermissionDialog.tsx
@@ -1,0 +1,66 @@
+import { SharingSiteWithSource } from "../../../api/helpers/siteConvertingHelpers";
+import { ClientType ,
+  ClientTypeDescriptions,
+} from "../../../api/services/adminServiceHelpers";
+import { formatStringsWithSeparator } from "../../utils/textHelpers";
+import { Dialog } from "../Core/Dialog";
+import {
+  MANUALLY_ADDED,
+} from './ParticipantTableHelper';
+
+type DeletePermissionDialogProps = Readonly<{
+  onDeleteSharingPermission: () => void;
+  selectedSiteList: SharingSiteWithSource[];
+  onOpenChange: () => void;
+}>;
+export function DeletePermissionDialog({
+  onDeleteSharingPermission,
+  selectedSiteList,
+  onOpenChange
+}: DeletePermissionDialogProps) {
+  const handleDeletePermissions = () => {
+    onDeleteSharingPermission();
+    onOpenChange();
+  };
+
+  const showDeletionNotice = (participant: SharingSiteWithSource) => {
+    const remainSources = participant.addedBy.filter(
+      (source) => source !== MANUALLY_ADDED
+    ) as ClientType[];
+    const remainSourceDescriptions = remainSources.map((x) => ClientTypeDescriptions[x]);
+    if (remainSourceDescriptions.length) {
+      return (
+        <span>
+          {' '}
+          (This site will remain shared by {formatStringsWithSeparator(remainSourceDescriptions)})
+        </span>
+      );
+    }
+  };
+
+  return (
+
+        <Dialog
+          title='Are you sure you want to delete these permissions?'
+          onOpenChange={onOpenChange}
+          closeButtonText='Cancel'
+        >
+          <div className='dialog-body-section'>
+            <ul className='dot-list'>
+              {selectedSiteList.map((participant) => (
+                <li key={participant.id}>
+                  {participant.name}
+                  {showDeletionNotice(participant)}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className='dialog-footer-section'>
+            <button type='button' className='primary-button' onClick={handleDeletePermissions}>
+              Delete Permissions
+            </button>
+          </div>
+        </Dialog>
+
+  );
+}

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -44,16 +44,24 @@ export function ParticipantItemSimple({ site }: ParticipantItemSimpleProps) {
 type ParticipantItemProps = ParticipantItemSimpleProps & {
   onClick: () => void;
   checked: boolean;
-  onDelete: () => void;
-  sharingSites: SharingSiteWithSource[]
+  onDelete?: (siteIdsToDelete: number[]) => void;
+  sharingSites?: SharingSiteWithSource[];
 };
 
-export function ParticipantItem({ site, onClick, checked, onDelete, sharingSites }: ParticipantItemProps) {
+export function ParticipantItem({
+  site,
+  onClick,
+  checked,
+  onDelete,
+  sharingSites,
+}: ParticipantItemProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const checkboxDisabled = isSharingParticipant(site) && !isAddedByManual(site);
   const checkbox = (
     <TriStateCheckbox onClick={onClick} status={checked} disabled={checkboxDisabled} />
   );
+
+  console.log('sharingsites:', sharingSites);
 
   const onDeleteDialogChange = () => {
     setShowDeleteDialog(!showDeleteDialog);
@@ -72,23 +80,25 @@ export function ParticipantItem({ site, onClick, checked, onDelete, sharingSites
       </td>
       <ParticipantItemSimple site={site} />
       {isSharingParticipant(site) && <td>{formatSourceColumn(site.addedBy)}</td>}
+      {onDelete && (
         <button
-            type='button'
-            className='icon-button'
-            aria-label='delete-domain-name'
-            onClick={() => {
-              setShowDeleteDialog(true);
-            }}
-          >
-            <FontAwesomeIcon icon='trash-can' />
-          </button>
-          {showDeleteDialog && (
-            <DeletePermissionDialog
-              onDeleteSharingPermission={onDelete}
-              onOpenChange={onDeleteDialogChange}
-              selectedSiteList={sharingSites.filter((p) => site.id === p.id)}
-            />
-          )}
+          type='button'
+          className='icon-button'
+          aria-label='delete-domain-name'
+          onClick={() => {
+            setShowDeleteDialog(true);
+          }}
+        >
+          <FontAwesomeIcon icon='trash-can' />
+        </button>
+      )}
+      {showDeleteDialog && onDelete && sharingSites && (
+        <DeletePermissionDialog
+          onDeleteSharingPermission={onDelete}
+          onOpenChange={onDeleteDialogChange}
+          selectedSiteList={sharingSites.filter((p) => site.id === p.id)}
+        />
+      )}
     </tr>
   );
 }

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -62,8 +62,6 @@ export function ParticipantItem({
     <TriStateCheckbox onClick={onClick} status={checked} disabled={checkboxDisabled} />
   );
 
-  console.log('sharingsites:', sharingSites);
-
   const onDeleteDialogChange = () => {
     setShowDeleteDialog(!showDeleteDialog);
   };

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
 import { AdminSiteDTO, ClientTypeDescriptions } from '../../../api/services/adminServiceHelpers';
@@ -61,26 +61,36 @@ export function ParticipantItem({
     <TriStateCheckbox onClick={onClick} status={checked} disabled={checkboxDisabled} />
   );
 
+  const actionButtonDeletePermissions = (
+    <ActionButton
+      onClick={() => setShowDeleteDialog(true)}
+      icon='trash-can'
+      disabled={checkboxDisabled}
+    />
+  );
+
+  const tooltipNoDelete = (trigger: ReactNode) => {
+    return (
+      <Tooltip trigger={trigger}>
+        Gray indicates participants selected in bulk permissions. To update, adjust bulk permission
+        settings.
+      </Tooltip>
+    );
+  };
+
   const onDeleteDialogChange = () => {
     setShowDeleteDialog(!showDeleteDialog);
   };
   return (
     <tr className='participant-item-with-checkbox'>
-      <td>
-        {checkboxDisabled ? (
-          <Tooltip trigger={checkbox}>
-            Gray indicates participants selected in bulk permissions. To update, adjust bulk
-            permission settings.
-          </Tooltip>
-        ) : (
-          checkbox
-        )}
-      </td>
+      <td>{checkboxDisabled ? tooltipNoDelete(checkbox) : checkbox}</td>
       <ParticipantItemSimple site={site} />
       {isSharingParticipant(site) && <td>{formatSourceColumn(site.addedBy)}</td>}
       {onDelete && (
         <td className='action-cell'>
-          <ActionButton onClick={() => setShowDeleteDialog(true)} icon='trash-can' />
+          {checkboxDisabled
+            ? tooltipNoDelete(actionButtonDeletePermissions)
+            : actionButtonDeletePermissions}
         </td>
       )}
       {showDeleteDialog && onDelete && sharingSites && (

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -1,4 +1,3 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useState } from 'react';
 
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
@@ -79,7 +78,11 @@ export function ParticipantItem({
       </td>
       <ParticipantItemSimple site={site} />
       {isSharingParticipant(site) && <td>{formatSourceColumn(site.addedBy)}</td>}
-      {onDelete && <ActionButton onClick={() => setShowDeleteDialog(true)} icon='trash-can' />}
+      {onDelete && (
+        <td className='action-cell'>
+          <ActionButton onClick={() => setShowDeleteDialog(true)} icon='trash-can' />
+        </td>
+      )}
       {showDeleteDialog && onDelete && sharingSites && (
         <DeletePermissionDialog
           onDeleteSharingPermission={onDelete}

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -1,7 +1,11 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useState } from 'react';
+
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
 import { AdminSiteDTO, ClientTypeDescriptions } from '../../../api/services/adminServiceHelpers';
 import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
+import { DeletePermissionDialog } from './DeletePermissionDialog';
 import {
   formatSourceColumn,
   isAddedByManual,
@@ -19,9 +23,9 @@ function getParticipantTypes(siteTypes?: AdminSiteDTO['clientTypes']) {
   ));
 }
 
-type ParticipantItemSimpleProps = {
+type ParticipantItemSimpleProps = Readonly<{
   site: SharingSiteDTO | SharingSiteWithSource;
-};
+}>;
 
 export function ParticipantItemSimple({ site }: ParticipantItemSimpleProps) {
   return (
@@ -40,13 +44,20 @@ export function ParticipantItemSimple({ site }: ParticipantItemSimpleProps) {
 type ParticipantItemProps = ParticipantItemSimpleProps & {
   onClick: () => void;
   checked: boolean;
+  onDelete: () => void;
+  sharingSites: SharingSiteWithSource[]
 };
 
-export function ParticipantItem({ site, onClick, checked }: ParticipantItemProps) {
+export function ParticipantItem({ site, onClick, checked, onDelete, sharingSites }: ParticipantItemProps) {
+  const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const checkboxDisabled = isSharingParticipant(site) && !isAddedByManual(site);
   const checkbox = (
     <TriStateCheckbox onClick={onClick} status={checked} disabled={checkboxDisabled} />
   );
+
+  const onDeleteDialogChange = () => {
+    setShowDeleteDialog(!showDeleteDialog);
+  };
   return (
     <tr className='participant-item-with-checkbox'>
       <td>
@@ -61,6 +72,23 @@ export function ParticipantItem({ site, onClick, checked }: ParticipantItemProps
       </td>
       <ParticipantItemSimple site={site} />
       {isSharingParticipant(site) && <td>{formatSourceColumn(site.addedBy)}</td>}
+        <button
+            type='button'
+            className='icon-button'
+            aria-label='delete-domain-name'
+            onClick={() => {
+              setShowDeleteDialog(true);
+            }}
+          >
+            <FontAwesomeIcon icon='trash-can' />
+          </button>
+          {showDeleteDialog && (
+            <DeletePermissionDialog
+              onDeleteSharingPermission={onDelete}
+              onOpenChange={onDeleteDialogChange}
+              selectedSiteList={sharingSites.filter((p) => site.id === p.id)}
+            />
+          )}
     </tr>
   );
 }

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
 import { AdminSiteDTO, ClientTypeDescriptions } from '../../../api/services/adminServiceHelpers';
+import ActionButton from '../Core/ActionButton';
 import { Tooltip } from '../Core/Tooltip';
 import { TriStateCheckbox } from '../Core/TriStateCheckbox';
 import { DeletePermissionDialog } from './DeletePermissionDialog';
@@ -80,18 +81,7 @@ export function ParticipantItem({
       </td>
       <ParticipantItemSimple site={site} />
       {isSharingParticipant(site) && <td>{formatSourceColumn(site.addedBy)}</td>}
-      {onDelete && (
-        <button
-          type='button'
-          className='icon-button'
-          aria-label='delete-domain-name'
-          onClick={() => {
-            setShowDeleteDialog(true);
-          }}
-        >
-          <FontAwesomeIcon icon='trash-can' />
-        </button>
-      )}
+      {onDelete && <ActionButton onClick={() => setShowDeleteDialog(true)} icon='trash-can' />}
       {showDeleteDialog && onDelete && sharingSites && (
         <DeletePermissionDialog
           onDeleteSharingPermission={onDelete}

--- a/src/web/components/SharingPermission/ParticipantSearchBar.tsx
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.tsx
@@ -3,7 +3,6 @@ import { ChangeEvent, useCallback, useState } from 'react';
 
 import { SharingSiteDTO } from '../../../api/helpers/siteConvertingHelpers';
 import { ClientType, ClientTypes } from '../../../api/services/adminServiceHelpers';
-import { MultiSelectDropdown } from '../Core/MultiSelectDropdown';
 import { TriStateCheckbox, TriStateCheckboxState } from '../Core/TriStateCheckbox';
 import { SearchBarContainer, SearchBarInput, SearchBarResults } from '../Search/SearchBar';
 import { ParticipantsTable } from './ParticipantsTable';

--- a/src/web/components/SharingPermission/ParticipantSearchBar.tsx
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.tsx
@@ -103,11 +103,6 @@ export function ParticipantSearchBar({
             className='search-bar-participants'
             tableHeader={tableHeader}
           />
-          {/* <MultiSelectDropdown
-            onSelectedChange={onSelectedChange}
-            title='Sharing Test'
-            options={siteOptions}
-          /> */}
           {/* TODO: update the participant not appearing url */}
           {/* <div className='search-bar-footer'>
             <a className='outside-link' href='/'>Participant Not Appearing in Search?</a>

--- a/src/web/components/SharingPermission/ParticipantSearchBar.tsx
+++ b/src/web/components/SharingPermission/ParticipantSearchBar.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent, useCallback, useState } from 'react';
 
 import { SharingSiteDTO } from '../../../api/helpers/siteConvertingHelpers';
 import { ClientType, ClientTypes } from '../../../api/services/adminServiceHelpers';
+import { MultiSelectDropdown } from '../Core/MultiSelectDropdown';
 import { TriStateCheckbox, TriStateCheckboxState } from '../Core/TriStateCheckbox';
 import { SearchBarContainer, SearchBarInput, SearchBarResults } from '../Search/SearchBar';
 import { ParticipantsTable } from './ParticipantsTable';
@@ -11,13 +12,13 @@ import { TypeFilter } from './TypeFilter';
 
 import './ParticipantSearchBar.scss';
 
-type ParticipantSearchBarProps = {
+type ParticipantSearchBarProps = Readonly<{
   sites: SharingSiteDTO[];
   selectedParticipantIds?: Set<number>;
   onSelectedChange: (selectedItems: Set<number>) => void;
   open: boolean;
   onToggleOpen: (open: boolean) => void;
-};
+}>;
 
 export function ParticipantSearchBar({
   sites,
@@ -31,7 +32,7 @@ export function ParticipantSearchBar({
   const filteredSites = filterSites(sites, filterText, selectedTypeIds);
   const checkboxStatus = getSelectAllState(
     isSelectedAll(filteredSites, selectedParticipantIds),
-    selectedParticipantIds
+    selectedParticipantIds,
   );
 
   const handleFilterChange = (typeIds: Set<ClientType>) => {
@@ -102,6 +103,11 @@ export function ParticipantSearchBar({
             className='search-bar-participants'
             tableHeader={tableHeader}
           />
+          {/* <MultiSelectDropdown
+            onSelectedChange={onSelectedChange}
+            title='Sharing Test'
+            options={siteOptions}
+          /> */}
           {/* TODO: update the participant not appearing url */}
           {/* <div className='search-bar-footer'>
             <a className='outside-link' href='/'>Participant Not Appearing in Search?</a>

--- a/src/web/components/SharingPermission/ParticipantsTable.tsx
+++ b/src/web/components/SharingPermission/ParticipantsTable.tsx
@@ -13,8 +13,8 @@ type ParticipantsTableProps = Readonly<{
   onSelectedChange: (selectedItems: Set<number>) => void;
   selectedParticipantIds?: Set<number>;
   className?: string;
-  onDelete: () => void;
-  sharingSites: SharingSiteWithSource[]
+  onDelete?: (siteIdsToDelete: number[]) => void;
+  sharingSites?: SharingSiteWithSource[];
 }>;
 
 function ParticipantsTableContent({
@@ -24,7 +24,7 @@ function ParticipantsTableContent({
   selectedParticipantIds = new Set(),
   className,
   onDelete,
-  sharingSites
+  sharingSites,
 }: ParticipantsTableProps) {
   const { sortData } = useSortable<SharingSiteDTO>();
   const sortedData = sortData(sites);

--- a/src/web/components/SharingPermission/ParticipantsTable.tsx
+++ b/src/web/components/SharingPermission/ParticipantsTable.tsx
@@ -1,19 +1,21 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react';
 
-import { SharingSiteDTO } from '../../../api/helpers/siteConvertingHelpers';
+import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
 import { SortableProvider, useSortable } from '../../contexts/SortableTableProvider';
 import { ParticipantItem } from './ParticipantItem';
 
 import './ParticipantsTable.scss';
 
-type ParticipantsTableProps = {
+type ParticipantsTableProps = Readonly<{
   tableHeader: ReactNode;
   sites: SharingSiteDTO[];
   onSelectedChange: (selectedItems: Set<number>) => void;
   selectedParticipantIds?: Set<number>;
   className?: string;
-};
+  onDelete: () => void;
+  sharingSites: SharingSiteWithSource[]
+}>;
 
 function ParticipantsTableContent({
   tableHeader,
@@ -21,6 +23,8 @@ function ParticipantsTableContent({
   onSelectedChange,
   selectedParticipantIds = new Set(),
   className,
+  onDelete,
+  sharingSites
 }: ParticipantsTableProps) {
   const { sortData } = useSortable<SharingSiteDTO>();
   const sortedData = sortData(sites);
@@ -46,6 +50,8 @@ function ParticipantsTableContent({
             site={participant}
             onClick={() => handleCheckChange(participant)}
             checked={!!selectedParticipantIds.has(participant.id)}
+            onDelete={onDelete}
+            sharingSites={sharingSites}
           />
         ))}
       </tbody>

--- a/src/web/components/SharingPermission/SharingPermissionsTable.scss
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.scss
@@ -1,4 +1,5 @@
 .sharing-permissions-table {
+  width: 100%;
   h2 {
     margin-top: 0;
   }

--- a/src/web/components/SharingPermission/SharingPermissionsTable.scss
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.scss
@@ -1,5 +1,4 @@
 .sharing-permissions-table {
-  width: 100%;
   h2 {
     margin-top: 0;
   }

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -59,8 +59,9 @@ export function SharingPermissionsTableContent({
 
   const checkboxStatus = getSelectAllState(isSelectedAllManualAddedParticipant(), checkedSites);
 
-  const handleDeletePermissions = () => {
-    onDeleteSharingPermission(Array.from(checkedSites));
+  const handleDeletePermissions = (siteIdsToDelete: number[]) => {
+    onDeleteSharingPermission(siteIdsToDelete);
+    // onDeleteSharingPermission(Array.from(checkedSites));
     setCheckedSites(new Set());
   };
   const siteTypeOptions = ClientTypes.map((type) => ({
@@ -116,16 +117,19 @@ export function SharingPermissionsTableContent({
           ) : (
             selectAllCheckbox
           )}
-          {checkedSites.size > 0 &&
-              <button
-        className='transparent-button sharing-permission-delete-button'
-        type='button'
-        onClick={onOpenChangeDeletePermissionsDialog}
-      >
-        <FontAwesomeIcon icon={['far', 'trash-can']} className='sharing-permission-trashcan-icon' />
-        Delete Permissions
-      </button>
-}
+          {checkedSites.size > 0 && (
+            <button
+              className='transparent-button sharing-permission-delete-button'
+              type='button'
+              onClick={onOpenChangeDeletePermissionsDialog}
+            >
+              <FontAwesomeIcon
+                icon={['far', 'trash-can']}
+                className='sharing-permission-trashcan-icon'
+              />
+              Delete Permissions
+            </button>
+          )}
           {showDeletePermissionsDialog && checkedSites.size > 0 && (
             <DeletePermissionDialog
               onDeleteSharingPermission={handleDeletePermissions}

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -8,6 +8,7 @@ import {
   ClientTypes,
 } from '../../../api/services/adminServiceHelpers';
 import { useAllSitesList } from '../../services/site';
+import ActionButton from '../Core/ActionButton';
 import { Loading } from '../Core/Loading';
 import { MultiSelectDropdown } from '../Core/MultiSelectDropdown';
 import { SortableTableHeader } from '../Core/SortableTableHeader';
@@ -117,17 +118,14 @@ export function SharingPermissionsTableContent({
             selectAllCheckbox
           )}
           {checkedSites.size > 0 && (
-            <button
-              className='transparent-button sharing-permission-delete-button'
-              type='button'
+            <ActionButton
+              className='sharing-permission-delete-button'
               onClick={onOpenChangeDeletePermissionsDialog}
+              icon={['far', 'trash-can']}
+              iconClassName='sharing-permission-trashcan-icon'
             >
-              <FontAwesomeIcon
-                icon={['far', 'trash-can']}
-                className='sharing-permission-trashcan-icon'
-              />
               Delete Permissions
-            </button>
+            </ActionButton>
           )}
           {showDeletePermissionsDialog && checkedSites.size > 0 && (
             <DeletePermissionDialog

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -99,7 +99,7 @@ export function SharingPermissionsTableContent({
         <SortableTableHeader<SharingSiteWithSource> sortKey='name' header='Participant Name' />
         <th>Participant Type</th>
         <SortableTableHeader<SharingSiteWithSource> sortKey='addedBy' header='Source' />
-        <th>Actions</th>
+        <th className='action'>Actions</th>
       </tr>
     </thead>
   );

--- a/src/web/components/SharingPermission/SharingPermissionsTable.tsx
+++ b/src/web/components/SharingPermission/SharingPermissionsTable.tsx
@@ -61,7 +61,6 @@ export function SharingPermissionsTableContent({
 
   const handleDeletePermissions = (siteIdsToDelete: number[]) => {
     onDeleteSharingPermission(siteIdsToDelete);
-    // onDeleteSharingPermission(Array.from(checkedSites));
     setCheckedSites(new Set());
   };
   const siteTypeOptions = ClientTypes.map((type) => ({


### PR DESCRIPTION
What Changed:

- Added  in-line delete button for sharing permissions (also added Actions header)
- Extracted DeletePermissionsDialog to its own file 

Test Plans:

- Add and delete participants in the Sharing Permissions table - both individually and in bulk and make sure everything deletes correctly 