### PR TITLE
Show banner if user does not have sharing permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "axios": "^1.6.7",
         "babel-plugin-transform-typescript-metadata": "^0.3.2",
         "body-parser": "^1.20.2",
+        "braces": "^3.0.3",
         "clsx": "^1.2.1",
         "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
@@ -11924,11 +11925,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -15980,9 +15981,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "axios": "^1.6.7",
     "babel-plugin-transform-typescript-metadata": "^0.3.2",
     "body-parser": "^1.20.2",
+    "braces": "^3.0.3",
     "clsx": "^1.2.1",
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",

--- a/src/web/components/Home/SharingPermissionCard.scss
+++ b/src/web/components/Home/SharingPermissionCard.scss
@@ -23,6 +23,6 @@
 }
 
 .no-sharing-permissions-banner {
-  margin-top: 12px;
-  margin-bottom: 90px;
+  padding-top: 30px;
+  padding-bottom: 70px;
 }

--- a/src/web/components/Home/SharingPermissionCard.scss
+++ b/src/web/components/Home/SharingPermissionCard.scss
@@ -21,3 +21,8 @@
   border-right: 1px solid var(--theme-divider);
   margin: 0 24px 0 38px;
 }
+
+.no-sharing-permissions-banner {
+  margin-top: 12px;
+  margin-bottom: 90px;
+}

--- a/src/web/components/Home/SharingPermissionCard.tsx
+++ b/src/web/components/Home/SharingPermissionCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 
+import { Banner } from '../Core/Banner';
 import { Card } from '../Core/Card';
 
 import './SharingPermissionCard.scss';
@@ -7,32 +8,44 @@ import './SharingPermissionCard.scss';
 type SharingPermissionCardProps = Readonly<{
   sharingPermissionsCount?: number;
   bulkPermissionsCount?: number;
+  hasKeyset: boolean;
 }>;
 
 function SharingPermissionCard({
   sharingPermissionsCount,
   bulkPermissionsCount,
+  hasKeyset,
 }: SharingPermissionCardProps) {
   return (
     <Card>
       <h2>Your Sharing Permissions</h2>
       <span>Participants you&apos;re sharing with to decrypt your encrypted UID2s. </span>
-      <div className='permissions-count-section'>
-        <div>
-          <div className='permissions-count'>{sharingPermissionsCount}</div>
-          <span>MANUAL PERMISSIONS</span>
+      {hasKeyset ? (
+        <div className='permissions-count-section'>
+          <div>
+            <div className='permissions-count'>{sharingPermissionsCount}</div>
+            <span>MANUAL PERMISSIONS</span>
+          </div>
+          <div className='divider' />
+          <div>
+            <div className='permissions-count'>{bulkPermissionsCount}</div>
+            <span>AUTOMATIC PERMISSIONS</span>
+          </div>
+          <Link to='/dashboard/sharing'>
+            <button className='primary-button small-button' type='button'>
+              View & Add Sharing Permissions
+            </button>
+          </Link>
         </div>
-        <div className='divider' />
-        <div>
-          <div className='permissions-count'>{bulkPermissionsCount}</div>
-          <span>AUTOMATIC PERMISSIONS</span>
+      ) : (
+        <div className='no-sharing-permissions-banner'>
+          <Banner
+            message='You do not have access to this feature. To get access, please contact Support.'
+            type='Info'
+            fitContent
+          />
         </div>
-      </div>
-      <Link to='/dashboard/sharing'>
-        <button className='primary-button small-button' type='button'>
-          View & Add Sharing Permissions
-        </button>
-      </Link>
+      )}
     </Card>
   );
 }

--- a/src/web/screens/home.tsx
+++ b/src/web/screens/home.tsx
@@ -23,6 +23,7 @@ import './home.scss';
 async function getSharingCounts() {
   let manualSites: number[] = [];
   let allowedTypes: ClientType[] = [];
+  let hasKeyset: boolean = true;
   const allSitesPromise = getAllSites();
   try {
     const sharingList = await GetSharingList();
@@ -30,7 +31,7 @@ async function getSharingCounts() {
     allowedTypes = sharingList.allowed_types;
   } catch (e: unknown) {
     if (e instanceof AxiosError && e.response?.data?.missingKeyset) {
-      // having no keyset is an expected state.  Don't error on this
+      hasKeyset = false;
     } else {
       log.error(e);
       throw e;
@@ -47,6 +48,7 @@ async function getSharingCounts() {
     return {
       sharingPermissionsCount: manualSites.length,
       bulkPermissionsCount: bulkSites.length,
+      hasKeyset,
     };
   } catch (e: unknown) {
     log.error(e);
@@ -118,6 +120,7 @@ function Home() {
                   <SharingPermissionCard
                     sharingPermissionsCount={counts.sharingPermissionsCount}
                     bulkPermissionsCount={counts.bulkPermissionsCount}
+                    hasKeyset={counts.hasKeyset}
                   />
                 )}
               </AwaitTypesafe>


### PR DESCRIPTION
What Changed:

- banner to show if user does not have sharing permissions on home page (see UX in Jira ticket)
- updated version number for braces npm package - was getting a high vulnerability that was causing the build to fail

Test Plan:
- test that the card looks correct when you do have sharing permissions
- change your participant's site id to a site id that does not have any keysets associated with it in local admin (I changed mine to site id = 1002) and see banner on home page