### PR TITLE
fixed keypair endpoint to return empty array instead of error

### DIFF
--- a/src/api/routers/participants/participantsKeyPairs.ts
+++ b/src/api/routers/participants/participantsKeyPairs.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
+import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKeyPairsList } from '../../services/adminServiceClient';
 import { ParticipantRequest } from '../../services/participantsService';
 
@@ -10,6 +11,7 @@ export async function getParticipantKeyPairs(req: ParticipantRequest, res: Respo
     return siteIdNotSetError(req, res);
   }
   const siteId = participant?.siteId;
-  const allKeyPairs = await getKeyPairsList(siteId!);
+  const traceId = getTraceId(req);
+  const allKeyPairs = await getKeyPairsList(siteId!, traceId);
   return res.status(200).json(allKeyPairs);
 }

--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -196,13 +196,11 @@ export const getKeyPairsList = async (
     }
     return allKeyPairs;
   } catch (e: unknown) {
-    if (
-      e instanceof AxiosError &&
-      e?.response?.status === 404 &&
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      e?.response?.data.message.includes('No keypairs available for site ID')
-    ) {
-      return [];
+    if (e instanceof AxiosError && e?.response?.status === 404) {
+      const message: unknown = e?.response?.data.message;
+      if (typeof message === 'string' && message.includes('No keypairs available for site ID')) {
+        return [];
+      }
     }
     const { errorLogger } = getLoggers();
     errorLogger.error(`${e}`, traceId);


### PR DESCRIPTION
What Changed:

- When participant's site has no keypairs, don't error, but just return empty array instead

Test Plan:

- Test that it works normally when there are keypairs
- Delete all keypairs or change site to site id that has all its keypairs disabled and make sure no error pops up
- Change site id to a site id that has no keypairs (enabled or disabled) and make sure there is no keypair error that pops up

*If interested in replicating the error on main, change siteid to a site that has no keypairs (enabled or disabled), then go to Client-Side Integration page*  