### PR TITLE
Avoid showing unnecessary tours on each new release.

### DIFF
--- a/src/web/components/SiteTour/UpdatesTour.tsx
+++ b/src/web/components/SiteTour/UpdatesTour.tsx
@@ -1,6 +1,6 @@
 import Joyride, { Actions, CallBackProps } from 'react-joyride';
 
-import { GetTourSteps, markTourAsSeen, ShouldShowTour } from './tourStorage';
+import { GetTourSteps, markTourAsSeen } from './tourStorage';
 
 function callback(data: CallBackProps) {
   const doNotShowAgainActions: Actions[] = ['close', 'skip', 'stop', 'reset'];

--- a/src/web/components/SiteTour/UpdatesTour.tsx
+++ b/src/web/components/SiteTour/UpdatesTour.tsx
@@ -1,6 +1,6 @@
 import Joyride, { Actions, CallBackProps } from 'react-joyride';
 
-import { markTourAsSeen, ShouldShowTour, TourSteps } from './tourStorage';
+import { GetTourSteps, markTourAsSeen, ShouldShowTour } from './tourStorage';
 
 function callback(data: CallBackProps) {
   const doNotShowAgainActions: Actions[] = ['close', 'skip', 'stop', 'reset'];
@@ -8,7 +8,8 @@ function callback(data: CallBackProps) {
 }
 
 export function UpdatesTour() {
-  const showTour = ShouldShowTour();
+  const tourSteps = GetTourSteps();
+  const showTour = tourSteps.length > 0;
   const actionButtonStyle = {
     backgroundColor: '#cdf200', // --theme-button
     color: '#030a40', // --theme-button-text
@@ -21,7 +22,7 @@ export function UpdatesTour() {
     <div>
       {showTour && (
         <Joyride
-          steps={TourSteps}
+          steps={tourSteps}
           callback={callback}
           continuous
           showSkipButton

--- a/src/web/components/SiteTour/tourStorage.ts
+++ b/src/web/components/SiteTour/tourStorage.ts
@@ -4,13 +4,20 @@ import config from '../../../../package.json';
 
 const { version } = config;
 
-export const TourSteps: React.ComponentProps<typeof Joyride>['steps'] = [
+type VersionedTourStep = React.ComponentProps<typeof Joyride>['steps'][number] & {
+  version?: string;
+};
+// Temporary solution: all tour steps without a version are treated as relevant to the current version.
+// Update the version after release to avoid showing it again. We can automate this in the release pipeline.
+const tourSteps: VersionedTourStep[] = [
   {
     target: `.profile-dropdown-button`,
     content: `We've moved some menu items to your profile dropdown.`,
     disableBeacon: true,
+    version: '0.36.0',
   },
 ];
+
 type TourData = {
   seenForVersions: string[];
 };
@@ -35,13 +42,14 @@ function saveTourData(data: TourData) {
   localStorage.setItem(tourStorageKey, JSON.stringify(data));
 }
 
-export function ShouldShowTour() {
-  const tourData = getTourData();
-  return !tourData.seenForVersions.includes(version);
-}
-
 export function markTourAsSeen() {
   const tourData = getTourData();
   if (!tourData.seenForVersions.includes(version)) tourData.seenForVersions.push(version);
   saveTourData(tourData);
+}
+
+export function GetTourSteps(): VersionedTourStep[] {
+  return tourSteps.filter(
+    (step) => !getTourData().seenForVersions.includes(step.version ?? version)
+  );
 }


### PR DESCRIPTION
Temporary solution to the problem - this still needs updates to the pipeline to be complete, but this unblocks release.