### PR TITLE
Fix create key dialog for consistency

### DIFF
--- a/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
@@ -148,7 +148,7 @@ function KeyCreationDialog({
 
   return (
     <div className='key-creation-dialog'>
-      <Dialog onOpenChange={onOpenChange} hideCloseButtons>
+      <Dialog onOpenChange={onOpenChange}>
         {!keySecrets ? (
           <CreateApiKeyForm
             onFormSubmit={onFormSubmit}

--- a/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
@@ -39,7 +39,7 @@ function CreateApiKeyForm({ onFormSubmit, availableRoles, closeDialog }: CreateA
   const { handleSubmit } = formMethods;
   return (
     <>
-      <h1>Add API Key</h1>
+      <h1 className='dialog-title'>Add API Key</h1>
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onFormSubmit)}>
           <TextInput


### PR DESCRIPTION
- Removed `hideCloseButtons` prop from the create key dialog - this prop is not used anywhere in the code now 
- Added the css for a dialog title for the title of the Create API Key form