### PR TITLE
Rename "role" to "jobFunction" in User table

### DIFF
--- a/src/api/entities/AuditTrail.ts
+++ b/src/api/entities/AuditTrail.ts
@@ -61,7 +61,7 @@ export type AddParticipantEventData = {
   lastName: string;
   participantName: string;
   participantTypes: number[];
-  role: string;
+  jobFunction: string;
   siteId?: number;
   crmAgreementNumber: string;
 };

--- a/src/api/entities/User.ts
+++ b/src/api/entities/User.ts
@@ -6,7 +6,7 @@ import { ModelObjectOpt } from './ModelObjectOpt';
 import type { Participant } from './Participant';
 
 export interface IUser {}
-export enum JobFunction {
+export enum UserJobFunction {
   BusinessDevelopment = 'Business Development',
   DA = 'Data / Analytics',
   Marketing = 'Marketing',
@@ -51,7 +51,7 @@ export class User extends BaseModel {
   declare firstName: string;
   declare lastName: string;
   declare phone?: string;
-  declare jobFunction: JobFunction;
+  declare jobFunction: UserJobFunction;
   declare participants?: Participant[];
   declare acceptedTerms: boolean;
 
@@ -74,7 +74,7 @@ export const UserSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   phone: z.string().optional(),
-  jobFunction: z.nativeEnum(JobFunction).optional(),
+  jobFunction: z.nativeEnum(UserJobFunction).optional(),
   acceptedTerms: z.boolean(),
 });
 

--- a/src/api/entities/User.ts
+++ b/src/api/entities/User.ts
@@ -6,7 +6,7 @@ import { ModelObjectOpt } from './ModelObjectOpt';
 import type { Participant } from './Participant';
 
 export interface IUser {}
-export enum UserRole {
+export enum JobFunction {
   BusinessDevelopment = 'Business Development',
   DA = 'Data / Analytics',
   Marketing = 'Marketing',
@@ -51,7 +51,7 @@ export class User extends BaseModel {
   declare firstName: string;
   declare lastName: string;
   declare phone?: string;
-  declare role: UserRole;
+  declare jobFunction: JobFunction;
   declare participants?: Participant[];
   declare acceptedTerms: boolean;
 
@@ -74,7 +74,7 @@ export const UserSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   phone: z.string().optional(),
-  role: z.nativeEnum(UserRole).optional(),
+  jobFunction: z.nativeEnum(JobFunction).optional(),
   acceptedTerms: z.boolean(),
 });
 
@@ -83,6 +83,6 @@ export const UserCreationPartial = UserSchema.pick({
   firstName: true,
   lastName: true,
   phone: true,
-  role: true,
+  jobFunction: true,
   acceptedTerms: true,
 });

--- a/src/api/routers/participants/participantClasses.ts
+++ b/src/api/routers/participants/participantClasses.ts
@@ -13,7 +13,7 @@ export const ParticipantCreationRequest = z.object({
   firstName: z.string(),
   lastName: z.string(),
   email: z.string(),
-  role: z.string().optional(),
+  jobFunction: z.string().optional(),
   crmAgreementNumber: z.string(),
 });
 

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -118,7 +118,7 @@ export async function createParticipant(req: ParticipantRequest, res: Response) 
       firstName: participantData.users[0].firstName,
       lastName: participantData.users[0].lastName,
       participantTypes: participantData.types.map((type) => type.id),
-      jobFunction: participantData.users[0].jobFunction!,
+      jobFunction: participantData.users[0].jobFunction,
       crmAgreementNumber: participantData.crmAgreementNumber,
     }
   );

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -252,7 +252,7 @@ export function createParticipantsRouter() {
         const { participant, user } = req;
         const { firstName, lastName, email, jobFunction } = invitationParser.parse(req.body);
         const traceId = getTraceId(req);
-        // TODO: support user belonging to multiple participants by not 400ing here if the user already exists.
+        // TODO: UID2-3878 - support user belonging to multiple participants by not 400ing here if the user already exists.
         const existingUser = await findUserByEmail(email);
         if (existingUser) {
           return res.status(400).send('Error inviting user');

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -11,7 +11,7 @@ import {
   ParticipantDTO,
   ParticipantStatus,
 } from '../../entities/Participant';
-import { UserDTO, UserRole } from '../../entities/User';
+import { JobFunction, UserDTO } from '../../entities/User';
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
@@ -84,7 +84,7 @@ export type ParticipantRequestDTO = Pick<
   ParticipantDTO,
   'id' | 'name' | 'siteId' | 'types' | 'status' | 'apiRoles'
 > & {
-  requestingUser: Pick<UserDTO, 'email'> & Partial<Pick<UserDTO, 'role'>> & { fullName: string };
+  requestingUser: Pick<UserDTO, 'email'> & Partial<Pick<UserDTO, 'jobFunction'>> & { fullName: string };
 };
 
 export const ClientTypeEnum = z.enum(['DSP', 'ADVERTISER', 'DATA_PROVIDER', 'PUBLISHER']);
@@ -101,7 +101,7 @@ function mapParticipantToApprovalRequest(participant: Participant): ParticipantR
     status: participant.status,
     requestingUser: {
       email: firstUser ? firstUser.email : '',
-      role: firstUser?.role,
+      jobFunction: firstUser?.jobFunction,
       fullName: firstUser
         ? firstUser?.fullName()
         : 'There is no user attached to this participant.',
@@ -226,7 +226,7 @@ export function createParticipantsRouter() {
     firstName: z.string(),
     lastName: z.string(),
     email: z.string(),
-    role: z.nativeEnum(UserRole),
+    jobFunction: z.nativeEnum(JobFunction),
   });
 
   participantsRouter.post(
@@ -234,7 +234,7 @@ export function createParticipantsRouter() {
     async (req: ParticipantRequest, res: Response) => {
       try {
         const { participant } = req;
-        const { firstName, lastName, email, role } = invitationParser.parse(req.body);
+        const { firstName, lastName, email, jobFunction } = invitationParser.parse(req.body);
         const existingUser = await findUserByEmail(email);
         if (existingUser) {
           return res.status(400).send('Error inviting user');
@@ -244,7 +244,7 @@ export function createParticipantsRouter() {
         await createUserInPortal(
           {
             email,
-            role,
+            jobFunction,
             firstName,
             lastName,
           },

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -11,7 +11,7 @@ import {
   ParticipantDTO,
   ParticipantStatus,
 } from '../../entities/Participant';
-import { JobFunction, UserDTO } from '../../entities/User';
+import { UserDTO, UserJobFunction } from '../../entities/User';
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
@@ -84,7 +84,8 @@ export type ParticipantRequestDTO = Pick<
   ParticipantDTO,
   'id' | 'name' | 'siteId' | 'types' | 'status' | 'apiRoles'
 > & {
-  requestingUser: Pick<UserDTO, 'email'> & Partial<Pick<UserDTO, 'jobFunction'>> & { fullName: string };
+  requestingUser: Pick<UserDTO, 'email'> &
+    Partial<Pick<UserDTO, 'jobFunction'>> & { fullName: string };
 };
 
 export const ClientTypeEnum = z.enum(['DSP', 'ADVERTISER', 'DATA_PROVIDER', 'PUBLISHER']);
@@ -226,7 +227,7 @@ export function createParticipantsRouter() {
     firstName: z.string(),
     lastName: z.string(),
     email: z.string(),
-    jobFunction: z.nativeEnum(JobFunction),
+    jobFunction: z.nativeEnum(UserJobFunction),
   });
 
   participantsRouter.post(

--- a/src/api/services/auditTrailService.ts
+++ b/src/api/services/auditTrailService.ts
@@ -261,7 +261,7 @@ export const insertAddParticipantAuditTrail = async (
     firstName: data.users[0].firstName,
     lastName: data.users[0].lastName,
     participantTypes: data.types.map((type) => type.id),
-    role: data.users[0].role!,
+    jobFunction: data.users[0].jobFunction!,
     crmAgreementNumber: data.crmAgreementNumber,
   };
 

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -48,7 +48,7 @@ export const sendNewParticipantEmail = async (
     participantType: participantTypes.map((pt) => pt.typeName).join(', '),
     requestor: `${requestor.firstName} ${requestor.lastName}`,
     requestorEmail: requestor.email,
-    jobFunction: requestor.role,
+    jobFunction: requestor.jobFunction,
   };
 
   const approvers = await findApproversByType(typeIds);

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -2,7 +2,7 @@ import { injectable } from 'inversify';
 import { z } from 'zod';
 
 import { ParticipantType } from '../entities/ParticipantType';
-import { JobFunction } from '../entities/User';
+import { UserJobFunction } from '../entities/User';
 import { mapClientTypeToParticipantType } from '../helpers/siteConvertingHelpers';
 import { getSite } from './adminServiceClient';
 import { getApiRoles } from './apiKeyService';
@@ -17,7 +17,7 @@ export type DeletedUser = {
 export const UpdateUserParser = z.object({
   firstName: z.string(),
   lastName: z.string(),
-  jobFunction: z.nativeEnum(JobFunction),
+  jobFunction: z.nativeEnum(UserJobFunction),
 });
 
 export const SelfResendInvitationParser = z.object({ email: z.string() });

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -101,7 +101,7 @@ export class UserService {
       AuditTrailEvents.ManageTeamMembers,
       {
         action: AuditAction.Update,
-        email: user!.email, // So we can which user is being updated
+        email: user!.email, // So we know which user is being updated, in case their name changes
         firstName: data.firstName,
         lastName: data.lastName,
         jobFunction: data.jobFunction,

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -2,7 +2,7 @@ import { injectable } from 'inversify';
 import { z } from 'zod';
 
 import { ParticipantType } from '../entities/ParticipantType';
-import { UserRole } from '../entities/User';
+import { JobFunction } from '../entities/User';
 import { mapClientTypeToParticipantType } from '../helpers/siteConvertingHelpers';
 import { getSite } from './adminServiceClient';
 import { getApiRoles } from './apiKeyService';
@@ -17,7 +17,7 @@ export type DeletedUser = {
 export const UpdateUserParser = z.object({
   firstName: z.string(),
   lastName: z.string(),
-  role: z.nativeEnum(UserRole),
+  jobFunction: z.nativeEnum(JobFunction),
 });
 
 export const SelfResendInvitationParser = z.object({ email: z.string() });

--- a/src/database/migrations/20240729055559_RenameRoleColumnInUserTable.ts
+++ b/src/database/migrations/20240729055559_RenameRoleColumnInUserTable.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.renameColumn('role', 'jobFunction');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.renameColumn('jobFunction', 'role');
+  });
+}

--- a/src/database/seeds/Users.ts
+++ b/src/database/seeds/Users.ts
@@ -3,7 +3,7 @@ import { ModelObject } from 'objection';
 import { Optional } from 'utility-types';
 
 import { ParticipantStatus } from '../../api/entities/Participant';
-import { JobFunction, User } from '../../api/entities/User';
+import { User, UserJobFunction } from '../../api/entities/User';
 import { CreateParticipant } from './Participants';
 
 type UserType = ModelObject<User>;
@@ -21,7 +21,7 @@ const sampleData: Optional<UserType, 'id'>[] = [
     firstName: 'Test',
     lastName: 'User',
     phone: '+61298765432',
-    jobFunction: JobFunction.DA,
+    jobFunction: UserJobFunction.DA,
     acceptedTerms: false,
   },
 ];

--- a/src/database/seeds/Users.ts
+++ b/src/database/seeds/Users.ts
@@ -3,7 +3,7 @@ import { ModelObject } from 'objection';
 import { Optional } from 'utility-types';
 
 import { ParticipantStatus } from '../../api/entities/Participant';
-import { User, JobFunction } from '../../api/entities/User';
+import { JobFunction, User } from '../../api/entities/User';
 import { CreateParticipant } from './Participants';
 
 type UserType = ModelObject<User>;

--- a/src/database/seeds/Users.ts
+++ b/src/database/seeds/Users.ts
@@ -3,7 +3,7 @@ import { ModelObject } from 'objection';
 import { Optional } from 'utility-types';
 
 import { ParticipantStatus } from '../../api/entities/Participant';
-import { User, UserRole } from '../../api/entities/User';
+import { User, JobFunction } from '../../api/entities/User';
 import { CreateParticipant } from './Participants';
 
 type UserType = ModelObject<User>;
@@ -21,7 +21,7 @@ const sampleData: Optional<UserType, 'id'>[] = [
     firstName: 'Test',
     lastName: 'User',
     phone: '+61298765432',
-    role: UserRole.DA,
+    jobFunction: JobFunction.DA,
     acceptedTerms: false,
   },
 ];

--- a/src/testHelpers/apiTestHelpers.ts
+++ b/src/testHelpers/apiTestHelpers.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { Knex } from 'knex';
 
 import { Participant, ParticipantStatus } from '../api/entities/Participant';
-import { User, UserRole } from '../api/entities/User';
+import { JobFunction, User } from '../api/entities/User';
 import { CreateParticipant } from '../database/seeds/Participants';
 
 export function createResponseObject() {
@@ -54,14 +54,14 @@ export async function createUser({
   email = faker.internet.email(),
   firstName = faker.person.firstName(),
   lastName = faker.person.lastName(),
-  role = UserRole.DA,
+  jobFunction = JobFunction.DA,
   acceptedTerms = true,
   participantId,
 }: {
   email?: string;
   firstName?: string;
   lastName?: string;
-  role?: UserRole;
+  jobFunction?: JobFunction;
   acceptedTerms?: boolean;
   participantId?: number;
 }) {
@@ -69,7 +69,7 @@ export async function createUser({
     email,
     firstName,
     lastName,
-    role,
+    jobFunction,
     acceptedTerms,
   };
 

--- a/src/testHelpers/apiTestHelpers.ts
+++ b/src/testHelpers/apiTestHelpers.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { Knex } from 'knex';
 
 import { Participant, ParticipantStatus } from '../api/entities/Participant';
-import { JobFunction, User } from '../api/entities/User';
+import { User, UserJobFunction } from '../api/entities/User';
 import { CreateParticipant } from '../database/seeds/Participants';
 
 export function createResponseObject() {
@@ -54,14 +54,14 @@ export async function createUser({
   email = faker.internet.email(),
   firstName = faker.person.firstName(),
   lastName = faker.person.lastName(),
-  jobFunction = JobFunction.DA,
+  jobFunction = UserJobFunction.DA,
   acceptedTerms = true,
   participantId,
 }: {
   email?: string;
   firstName?: string;
   lastName?: string;
-  jobFunction?: JobFunction;
+  jobFunction?: UserJobFunction;
   acceptedTerms?: boolean;
   participantId?: number;
 }) {

--- a/src/web/components/Account/CreateAccountForm.tsx
+++ b/src/web/components/Account/CreateAccountForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import { CreateParticipantForm } from '../../services/participant';
 import { Dialog } from '../Core/Dialog/Dialog';
 import { FormError, RootFormErrors, setGlobalErrors } from '../Input/FormError';
@@ -71,10 +71,12 @@ export function CreateAccountForm({ resolvedParticipantTypes, onSubmit }: Create
           inputName='jobFunction'
           label='Job Function'
           rules={{ required: 'Please specify your job function.' }}
-          options={(Object.keys(JobFunction) as Array<keyof typeof JobFunction>).map((key) => ({
-            optionLabel: JobFunction[key],
-            value: JobFunction[key],
-          }))}
+          options={(Object.keys(UserJobFunction) as Array<keyof typeof UserJobFunction>).map(
+            (key) => ({
+              optionLabel: UserJobFunction[key],
+              value: UserJobFunction[key],
+            })
+          )}
         />
         <div className='terms-section'>
           <FormStyledCheckbox

--- a/src/web/components/Account/CreateAccountForm.tsx
+++ b/src/web/components/Account/CreateAccountForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import { CreateParticipantForm } from '../../services/participant';
 import { Dialog } from '../Core/Dialog/Dialog';
 import { FormError, RootFormErrors, setGlobalErrors } from '../Input/FormError';
@@ -12,8 +12,8 @@ import { FormStyledCheckbox } from '../Input/StyledCheckbox';
 import { TextInput } from '../Input/TextInput';
 import { TermsAndConditionsForm } from '../TermsAndConditions/TermsAndConditions';
 
-import './createAccountForm.scss';
 import '../../styles/forms.scss';
+import './createAccountForm.scss';
 
 export type CreateAccountFormProps = Readonly<{
   resolvedParticipantTypes: ParticipantTypeDTO[];
@@ -68,12 +68,12 @@ export function CreateAccountForm({ resolvedParticipantTypes, onSubmit }: Create
           rules={{ required: 'Please specify Participant type.' }}
         />
         <SelectInput
-          inputName='role'
+          inputName='jobFunction'
           label='Job Function'
           rules={{ required: 'Please specify your job function.' }}
-          options={(Object.keys(UserRole) as Array<keyof typeof UserRole>).map((key) => ({
-            optionLabel: UserRole[key],
-            value: UserRole[key],
+          options={(Object.keys(JobFunction) as Array<keyof typeof JobFunction>).map((key) => ({
+            optionLabel: JobFunction[key],
+            value: JobFunction[key],
           }))}
         />
         <div className='terms-section'>

--- a/src/web/components/ParticipantManagement/AddParticipantDialog.scss
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.scss
@@ -17,7 +17,7 @@
   }
 
   .text-input,
-  .user-roles,
+  .user-job-function,
   .site-type {
     width: 400px;
   }

--- a/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import { SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { AddParticipantForm } from '../../services/participant';
 import { useSiteList } from '../../services/site';
@@ -272,12 +272,12 @@ function AddParticipantDialog({
                   <SelectInput
                     inputName='jobFunction'
                     label='Job Function'
-                    options={(Object.keys(JobFunction) as Array<keyof typeof JobFunction>).map(
-                      (key) => ({
-                        optionLabel: JobFunction[key],
-                        value: JobFunction[key],
-                      })
-                    )}
+                    options={(
+                      Object.keys(UserJobFunction) as Array<keyof typeof UserJobFunction>
+                    ).map((key) => ({
+                      optionLabel: UserJobFunction[key],
+                      value: UserJobFunction[key],
+                    }))}
                   />
                 </div>
               </div>

--- a/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
+++ b/src/web/components/ParticipantManagement/AddParticipantDialog.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import { SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { AddParticipantForm } from '../../services/participant';
 import { useSiteList } from '../../services/site';
@@ -268,14 +268,16 @@ function AddParticipantDialog({
                     }}
                   />
                 </div>
-                <div className='user-roles right-column'>
+                <div className='user-job-function right-column'>
                   <SelectInput
-                    inputName='role'
+                    inputName='jobFunction'
                     label='Job Function'
-                    options={(Object.keys(UserRole) as Array<keyof typeof UserRole>).map((key) => ({
-                      optionLabel: UserRole[key],
-                      value: UserRole[key],
-                    }))}
+                    options={(Object.keys(JobFunction) as Array<keyof typeof JobFunction>).map(
+                      (key) => ({
+                        optionLabel: JobFunction[key],
+                        value: JobFunction[key],
+                      })
+                    )}
                   />
                 </div>
               </div>

--- a/src/web/components/ParticipantManagement/ApprovedParticipantsTable.stories.tsx
+++ b/src/web/components/ParticipantManagement/ApprovedParticipantsTable.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import ApprovedParticipantsTable from './ApprovedParticipantsTable';
 
 const meta: Meta<typeof ApprovedParticipantsTable> = {
@@ -28,7 +28,7 @@ export const AllParticipants: Story = {
           email: 'tes2@example.com',
           firstName: 'Approver 2 First Name +',
           lastName: 'Approver 2 Last Name',
-          role: UserRole.Marketing,
+          jobFunction: JobFunction.Marketing,
           acceptedTerms: false,
         },
         dateApproved: new Date(),
@@ -39,7 +39,7 @@ export const AllParticipants: Story = {
             email: 'tes2@example.com',
             firstName: 'First Test User 2',
             lastName: 'Last Test User 2',
-            role: UserRole.Marketing,
+            jobFunction: JobFunction.Marketing,
             acceptedTerms: false,
           },
         ],
@@ -60,7 +60,7 @@ export const AllParticipants: Story = {
           email: 'tes3@example.com',
           firstName: 'Approver 3 First Name +',
           lastName: 'Approver 3 Last Name',
-          role: UserRole.Marketing,
+          jobFunction: JobFunction.Marketing,
           acceptedTerms: false,
         },
         dateApproved: new Date(),
@@ -71,7 +71,7 @@ export const AllParticipants: Story = {
             email: 'test3@example.com',
             firstName: 'First Test User 3',
             lastName: 'Last Test User 3',
-            role: UserRole.Marketing,
+            jobFunction: JobFunction.Marketing,
             acceptedTerms: false,
           },
         ],
@@ -96,7 +96,7 @@ export const AllParticipants: Story = {
           email: 'tes4@example.com',
           firstName: 'Approver 4 First Name +',
           lastName: 'Approver 4 Last Name',
-          role: UserRole.Marketing,
+          jobFunction: JobFunction.Marketing,
           acceptedTerms: false,
         },
         dateApproved: new Date(),
@@ -107,7 +107,7 @@ export const AllParticipants: Story = {
             email: 'test4@example.com',
             firstName: 'First Test User 4',
             lastName: 'Last Test User 4',
-            role: UserRole.Marketing,
+            jobFunction: JobFunction.Marketing,
             acceptedTerms: false,
           },
         ],
@@ -136,7 +136,7 @@ export const AllParticipants: Story = {
             email: 'test5@example.com',
             firstName: 'First Test User 5',
             lastName: 'Last Test User 5',
-            role: UserRole.Marketing,
+            jobFunction: JobFunction.Marketing,
             acceptedTerms: false,
           },
         ],

--- a/src/web/components/ParticipantManagement/ApprovedParticipantsTable.stories.tsx
+++ b/src/web/components/ParticipantManagement/ApprovedParticipantsTable.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import ApprovedParticipantsTable from './ApprovedParticipantsTable';
 
 const meta: Meta<typeof ApprovedParticipantsTable> = {
@@ -28,7 +28,7 @@ export const AllParticipants: Story = {
           email: 'tes2@example.com',
           firstName: 'Approver 2 First Name +',
           lastName: 'Approver 2 Last Name',
-          jobFunction: JobFunction.Marketing,
+          jobFunction: UserJobFunction.Marketing,
           acceptedTerms: false,
         },
         dateApproved: new Date(),
@@ -39,7 +39,7 @@ export const AllParticipants: Story = {
             email: 'tes2@example.com',
             firstName: 'First Test User 2',
             lastName: 'Last Test User 2',
-            jobFunction: JobFunction.Marketing,
+            jobFunction: UserJobFunction.Marketing,
             acceptedTerms: false,
           },
         ],
@@ -60,7 +60,7 @@ export const AllParticipants: Story = {
           email: 'tes3@example.com',
           firstName: 'Approver 3 First Name +',
           lastName: 'Approver 3 Last Name',
-          jobFunction: JobFunction.Marketing,
+          jobFunction: UserJobFunction.Marketing,
           acceptedTerms: false,
         },
         dateApproved: new Date(),
@@ -71,7 +71,7 @@ export const AllParticipants: Story = {
             email: 'test3@example.com',
             firstName: 'First Test User 3',
             lastName: 'Last Test User 3',
-            jobFunction: JobFunction.Marketing,
+            jobFunction: UserJobFunction.Marketing,
             acceptedTerms: false,
           },
         ],
@@ -96,7 +96,7 @@ export const AllParticipants: Story = {
           email: 'tes4@example.com',
           firstName: 'Approver 4 First Name +',
           lastName: 'Approver 4 Last Name',
-          jobFunction: JobFunction.Marketing,
+          jobFunction: UserJobFunction.Marketing,
           acceptedTerms: false,
         },
         dateApproved: new Date(),
@@ -107,7 +107,7 @@ export const AllParticipants: Story = {
             email: 'test4@example.com',
             firstName: 'First Test User 4',
             lastName: 'Last Test User 4',
-            jobFunction: JobFunction.Marketing,
+            jobFunction: UserJobFunction.Marketing,
             acceptedTerms: false,
           },
         ],
@@ -136,7 +136,7 @@ export const AllParticipants: Story = {
             email: 'test5@example.com',
             firstName: 'First Test User 5',
             lastName: 'Last Test User 5',
-            jobFunction: JobFunction.Marketing,
+            jobFunction: UserJobFunction.Marketing,
             acceptedTerms: false,
           },
         ],

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from '@storybook/react';
 import { useState } from 'react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import EditParticipantDialog from './EditParticipantDialog';
 
 const meta: Meta<typeof EditParticipantDialog> = {
@@ -45,7 +45,7 @@ const participant = {
       email: 'test5@example.com',
       firstName: 'First Test User 5',
       lastName: 'Last Test User 5',
-      role: UserRole.Marketing,
+      jobFunction: JobFunction.Marketing,
       acceptedTerms: false,
     },
   ],

--- a/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
+++ b/src/web/components/ParticipantManagement/EditParticipantDialog.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from '@storybook/react';
 import { useState } from 'react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import EditParticipantDialog from './EditParticipantDialog';
 
 const meta: Meta<typeof EditParticipantDialog> = {
@@ -45,7 +45,7 @@ const participant = {
       email: 'test5@example.com',
       firstName: 'First Test User 5',
       lastName: 'Last Test User 5',
-      jobFunction: JobFunction.Marketing,
+      jobFunction: UserJobFunction.Marketing,
       acceptedTerms: false,
     },
   ],

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -191,7 +191,11 @@ function ParticipantApprovalForm({
               />
             </Input>
             <Input inputName='readonly-requestor-job' label='Job Function'>
-              <input className='input-container' disabled value={participant.requestingUser.role} />
+              <input
+                className='input-container'
+                disabled
+                value={participant.requestingUser.jobFunction}
+              />
             </Input>
             <FormSubmitButton>Approve Participant</FormSubmitButton>
           </form>

--- a/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
@@ -2,7 +2,7 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import { SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { TestSiteListProvider } from '../../services/site';
 import ParticipantApprovalForm from './ParticipantApprovalForm';
@@ -66,7 +66,7 @@ export const ParticipantApprovalMatchingSite: Story = {
       requestingUser: {
         email: 'test@example.com',
         fullName: 'Test User',
-        jobFunction: JobFunction.MediaBuyer,
+        jobFunction: UserJobFunction.MediaBuyer,
       },
     },
     participantTypes: [
@@ -101,7 +101,7 @@ export const ParticipantApprovalSiteSearch: Story = {
       requestingUser: {
         email: 'test@example.com',
         fullName: 'Test User',
-        jobFunction: JobFunction.MediaBuyer,
+        jobFunction: UserJobFunction.MediaBuyer,
       },
     },
     participantTypes: [

--- a/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestForm.stories.tsx
@@ -2,7 +2,7 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import { SiteDTO } from '../../../api/services/adminServiceHelpers';
 import { TestSiteListProvider } from '../../services/site';
 import ParticipantApprovalForm from './ParticipantApprovalForm';
@@ -66,7 +66,7 @@ export const ParticipantApprovalMatchingSite: Story = {
       requestingUser: {
         email: 'test@example.com',
         fullName: 'Test User',
-        role: UserRole.MediaBuyer,
+        jobFunction: JobFunction.MediaBuyer,
       },
     },
     participantTypes: [
@@ -101,7 +101,7 @@ export const ParticipantApprovalSiteSearch: Story = {
       requestingUser: {
         email: 'test@example.com',
         fullName: 'Test User',
-        role: UserRole.MediaBuyer,
+        jobFunction: JobFunction.MediaBuyer,
       },
     },
     participantTypes: [

--- a/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
@@ -64,7 +64,9 @@ export function ParticipantRequestItem({
         <div className='participant-item-email'>{participant.requestingUser.email}</div>
       </td>
       <td>
-        <div className='participant-item-job-function'>{participant.requestingUser.role}</div>
+        <div className='participant-item-job-function'>
+          {participant.requestingUser.jobFunction}
+        </div>
       </td>
       <td className='action'>
         <div className='action-cell'>

--- a/src/web/components/ParticipantManagement/ParticipantRequestsTable.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestsTable.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import { ParticipantRequestsTable } from './ParticipantRequestsTable';
 
 const meta: Meta<typeof ParticipantRequestsTable> = {
@@ -24,7 +24,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test1@example.com',
           fullName: 'Test User  1',
-          jobFunction: JobFunction.Engineering,
+          jobFunction: UserJobFunction.Engineering,
         },
       },
       {
@@ -38,7 +38,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test2@example.com',
           fullName: 'Test User 2',
-          jobFunction: JobFunction.BusinessDevelopment,
+          jobFunction: UserJobFunction.BusinessDevelopment,
         },
       },
       {
@@ -53,7 +53,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test3@example.com',
           fullName: 'Test User 3',
-          jobFunction: JobFunction.Marketing,
+          jobFunction: UserJobFunction.Marketing,
         },
       },
       {
@@ -69,7 +69,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test4@example.com',
           fullName: 'Test User 4',
-          jobFunction: JobFunction.MediaBuyer,
+          jobFunction: UserJobFunction.MediaBuyer,
         },
       },
     ],

--- a/src/web/components/ParticipantManagement/ParticipantRequestsTable.stories.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestsTable.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ParticipantStatus } from '../../../api/entities/Participant';
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import { ParticipantRequestsTable } from './ParticipantRequestsTable';
 
 const meta: Meta<typeof ParticipantRequestsTable> = {
@@ -24,7 +24,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test1@example.com',
           fullName: 'Test User  1',
-          role: UserRole.Engineering,
+          jobFunction: JobFunction.Engineering,
         },
       },
       {
@@ -38,7 +38,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test2@example.com',
           fullName: 'Test User 2',
-          role: UserRole.BusinessDevelopment,
+          jobFunction: JobFunction.BusinessDevelopment,
         },
       },
       {
@@ -53,7 +53,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test3@example.com',
           fullName: 'Test User 3',
-          role: UserRole.Marketing,
+          jobFunction: JobFunction.Marketing,
         },
       },
       {
@@ -69,7 +69,7 @@ export const ParticipantRequests: Story = {
         requestingUser: {
           email: 'test4@example.com',
           fullName: 'Test User 4',
-          role: UserRole.MediaBuyer,
+          jobFunction: JobFunction.MediaBuyer,
         },
       },
     ],

--- a/src/web/components/TeamMember/TeamMember.stories.tsx
+++ b/src/web/components/TeamMember/TeamMember.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import TeamMember from './TeamMember';
 
 const meta: Meta<typeof TeamMember> = {
@@ -29,7 +29,7 @@ export const WithAcceptedTerm: Story = {
       email: 'test@user.com',
       firstName: 'test',
       lastName: 'test',
-      role: UserRole.DA,
+      jobFunction: JobFunction.DA,
       acceptedTerms: true,
     },
     resendInvite: (id) => Promise.resolve(console.log(`Resend invite to userId: ${id}`)),
@@ -46,7 +46,7 @@ export const PendingMember: Story = {
       email: 'test@user.com',
       firstName: 'test',
       lastName: 'user 2',
-      role: UserRole.Engineering,
+      jobFunction: JobFunction.Engineering,
       acceptedTerms: false,
     },
     resendInvite: (id) => Promise.resolve(console.log(`Resend invite to userId: ${id}`)),

--- a/src/web/components/TeamMember/TeamMember.stories.tsx
+++ b/src/web/components/TeamMember/TeamMember.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import TeamMember from './TeamMember';
 
 const meta: Meta<typeof TeamMember> = {
@@ -29,7 +29,7 @@ export const WithAcceptedTerm: Story = {
       email: 'test@user.com',
       firstName: 'test',
       lastName: 'test',
-      jobFunction: JobFunction.DA,
+      jobFunction: UserJobFunction.DA,
       acceptedTerms: true,
     },
     resendInvite: (id) => Promise.resolve(console.log(`Resend invite to userId: ${id}`)),
@@ -46,7 +46,7 @@ export const PendingMember: Story = {
       email: 'test@user.com',
       firstName: 'test',
       lastName: 'user 2',
-      jobFunction: JobFunction.Engineering,
+      jobFunction: UserJobFunction.Engineering,
       acceptedTerms: false,
     },
     resendInvite: (id) => Promise.resolve(console.log(`Resend invite to userId: ${id}`)),

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -92,7 +92,7 @@ function TeamMember({
         </div>
       </td>
       <td>{person.email}</td>
-      <td>{person.role}</td>
+      <td>{person.jobFunction}</td>
       <td className='action'>
         <div className='action-cell'>
           {!!errorMessage && <InlineMessage message={errorMessage} type='Error' />}

--- a/src/web/components/TeamMember/TeamMemberDialog.stories.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import { useState } from 'react';
 
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import TeamMemberDialog from './TeamMemberDialog';
 
 const meta: Meta<typeof TeamMemberDialog> = {
@@ -51,7 +51,7 @@ export const WithTeamMember = () => {
             email: 'test@user.com',
             firstName: 'test',
             lastName: 'test',
-            jobFunction: JobFunction.DA,
+            jobFunction: UserJobFunction.DA,
             acceptedTerms: true,
           }}
           teamMembers={[]}

--- a/src/web/components/TeamMember/TeamMemberDialog.stories.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import { useState } from 'react';
 
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import TeamMemberDialog from './TeamMemberDialog';
 
 const meta: Meta<typeof TeamMemberDialog> = {
@@ -51,7 +51,7 @@ export const WithTeamMember = () => {
             email: 'test@user.com',
             firstName: 'test',
             lastName: 'test',
-            role: UserRole.DA,
+            jobFunction: JobFunction.DA,
             acceptedTerms: true,
           }}
           teamMembers={[]}

--- a/src/web/components/TeamMember/TeamMemberDialog.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.tsx
@@ -1,6 +1,6 @@
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { UserDTO, UserRole } from '../../../api/entities/User';
+import { JobFunction, UserDTO } from '../../../api/entities/User';
 import {
   InviteTeamMemberForm,
   UpdateTeamMemberForm,
@@ -39,8 +39,8 @@ function TeamMemberDialog(props: TeamMemberDialogProps) {
 
   const onSubmit = async (formData: InviteTeamMemberForm) => {
     if (isUpdateTeamMemberDialogProps(props)) {
-      const { firstName, lastName, role } = formData;
-      await props.onUpdateTeamMember({ firstName, lastName, role });
+      const { firstName, lastName, jobFunction } = formData;
+      await props.onUpdateTeamMember({ firstName, lastName, jobFunction });
     } else {
       await props.onAddTeamMember(formData);
     }
@@ -79,12 +79,12 @@ function TeamMemberDialog(props: TeamMemberDialogProps) {
             }}
           />
           <SelectInput
-            inputName='role'
+            inputName='jobFunction'
             label='Job Function'
             rules={{ required: 'Please specify your job function.' }}
-            options={(Object.keys(UserRole) as Array<keyof typeof UserRole>).map((key) => ({
-              optionLabel: UserRole[key],
-              value: UserRole[key],
+            options={(Object.keys(JobFunction) as Array<keyof typeof JobFunction>).map((key) => ({
+              optionLabel: JobFunction[key],
+              value: JobFunction[key],
             }))}
           />
           <FormSubmitButton>Save Team Member</FormSubmitButton>

--- a/src/web/components/TeamMember/TeamMemberDialog.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.tsx
@@ -1,6 +1,6 @@
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { JobFunction, UserDTO } from '../../../api/entities/User';
+import { UserDTO, UserJobFunction } from '../../../api/entities/User';
 import {
   InviteTeamMemberForm,
   UpdateTeamMemberForm,
@@ -82,10 +82,12 @@ function TeamMemberDialog(props: TeamMemberDialogProps) {
             inputName='jobFunction'
             label='Job Function'
             rules={{ required: 'Please specify your job function.' }}
-            options={(Object.keys(JobFunction) as Array<keyof typeof JobFunction>).map((key) => ({
-              optionLabel: JobFunction[key],
-              value: JobFunction[key],
-            }))}
+            options={(Object.keys(UserJobFunction) as Array<keyof typeof UserJobFunction>).map(
+              (key) => ({
+                optionLabel: UserJobFunction[key],
+                value: UserJobFunction[key],
+              })
+            )}
           />
           <FormSubmitButton>Save Team Member</FormSubmitButton>
         </form>

--- a/src/web/components/TeamMember/TeamMembersTable.stories.tsx
+++ b/src/web/components/TeamMember/TeamMembersTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { UserRole } from '../../../api/entities/User';
+import { JobFunction } from '../../../api/entities/User';
 import TeamMembersTable from './TeamMembersTable';
 
 const meta: Meta<typeof TeamMembersTable> = {
@@ -31,7 +31,7 @@ export const WithTeamMembers: Story = {
         email: 'test@user.com',
         firstName: 'test',
         lastName: 'test',
-        role: UserRole.DA,
+        jobFunction: JobFunction.DA,
         acceptedTerms: true,
       },
       {
@@ -39,7 +39,7 @@ export const WithTeamMembers: Story = {
         email: 'test@user.com',
         firstName: 'test',
         lastName: 'user 2',
-        role: UserRole.Engineering,
+        jobFunction: JobFunction.Engineering,
         acceptedTerms: false,
       },
     ],

--- a/src/web/components/TeamMember/TeamMembersTable.stories.tsx
+++ b/src/web/components/TeamMember/TeamMembersTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { JobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
 import TeamMembersTable from './TeamMembersTable';
 
 const meta: Meta<typeof TeamMembersTable> = {
@@ -31,7 +31,7 @@ export const WithTeamMembers: Story = {
         email: 'test@user.com',
         firstName: 'test',
         lastName: 'test',
-        jobFunction: JobFunction.DA,
+        jobFunction: UserJobFunction.DA,
         acceptedTerms: true,
       },
       {
@@ -39,7 +39,7 @@ export const WithTeamMembers: Story = {
         email: 'test@user.com',
         firstName: 'test',
         lastName: 'user 2',
-        jobFunction: JobFunction.Engineering,
+        jobFunction: UserJobFunction.Engineering,
         acceptedTerms: false,
       },
     ],

--- a/src/web/components/TeamMember/TeamMembersTable.tsx
+++ b/src/web/components/TeamMember/TeamMembersTable.tsx
@@ -44,7 +44,7 @@ function TeamMembersTableContent({
           <tr>
             <SortableTableHeader<UserResponse> sortKey='firstName' header='Name' />
             <SortableTableHeader<UserResponse> sortKey='email' header='Email' />
-            <SortableTableHeader<UserResponse> sortKey='role' header='Job Function' />
+            <SortableTableHeader<UserResponse> sortKey='jobFunction' header='Job Function' />
             <th className='action'>Actions</th>
           </tr>
         </thead>

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -20,7 +20,7 @@ export type ParticipantCreationPayload = z.infer<typeof ParticipantCreationParti
 export type CreateParticipantForm = {
   companyName: string;
   companyType: number[];
-  role: string;
+  jobFunction: string;
   canSign: boolean;
   signeeEmail: string;
   agreeToTerms: boolean;
@@ -43,7 +43,7 @@ export async function CreateParticipant(formData: CreateParticipantForm, user: K
   const users = [
     {
       email: user.email!,
-      role: formData.role,
+      jobFunction: formData.jobFunction,
       firstName: user.firstName,
       lastName: user.lastName,
       acceptedTerms: formData.agreeToTerms,
@@ -178,7 +178,7 @@ export type AddParticipantForm = {
   siteId?: number;
   siteIdType: number;
   siteName?: string;
-  role: string;
+  jobFunction: string;
   crmAgreementNumber: string;
 };
 

--- a/src/web/services/userAccount.ts
+++ b/src/web/services/userAccount.ts
@@ -16,7 +16,7 @@ export type InviteTeamMemberForm = {
   firstName: string;
   lastName: string;
   email: string;
-  role: string;
+  jobFunction: string;
 };
 
 export type UpdateTeamMemberForm = Omit<InviteTeamMemberForm, 'email'>;


### PR DESCRIPTION
- Rename "role" on the Users table to avoid confusion with RBAC. Update usages of entity across services, front end, seed, stories, etc.
- Use the same term we already use in the UI: **jobFunction**
- No functional changes for end user

![image](https://github.com/user-attachments/assets/76b91d9b-2606-4bc5-bd5b-959015375459)

![image](https://github.com/user-attachments/assets/c262127b-4f39-4b48-a8bd-ae78d8433825)
