### PR TITLE
User/Participant/Role relationship backend

### DIFF
--- a/src/api/entities/Participant.ts
+++ b/src/api/entities/Participant.ts
@@ -6,7 +6,6 @@ import { BaseModel } from './BaseModel';
 import { ModelObjectOpt } from './ModelObjectOpt';
 import { ParticipantType, ParticipantTypeDTO, ParticipantTypeSchema } from './ParticipantType';
 import { type User, UserCreationPartial, UserDTO, UserSchema } from './User';
-import { UserToParticipantRole } from './UserToParticipantRole';
 
 export enum ParticipantStatus {
   AwaitingSigning = 'awaitingSigning',
@@ -109,17 +108,11 @@ export const ParticipantSchema = z.object({
   crmAgreementNumber: z.string().nullable(),
 });
 
-export const ParticipantCreationFromRequestPartial = ParticipantSchema.pick({
-  name: true,
-}).extend({
-  types: z.array(ParticipantTypeSchema.pick({ id: true })),
-  users: z.array(UserCreationPartial).optional(),
-});
-
 export const ParticipantCreationPartial = ParticipantSchema.pick({
   name: true,
 }).extend({
   types: z.array(ParticipantTypeSchema.pick({ id: true })),
+  users: z.array(UserCreationPartial).optional(),
 });
 
 export const ParticipantApprovalPartial = ParticipantSchema.pick({

--- a/src/api/entities/Participant.ts
+++ b/src/api/entities/Participant.ts
@@ -6,7 +6,6 @@ import { BaseModel } from './BaseModel';
 import { ModelObjectOpt } from './ModelObjectOpt';
 import { ParticipantType, ParticipantTypeDTO, ParticipantTypeSchema } from './ParticipantType';
 import { type User, UserCreationPartial, UserDTO, UserSchema } from './User';
-import { UserRole } from './UserRole';
 import { UserToParticipantRole } from './UserToParticipantRole';
 
 export enum ParticipantStatus {

--- a/src/api/entities/Participant.ts
+++ b/src/api/entities/Participant.ts
@@ -71,16 +71,6 @@ export class Participant extends BaseModel {
         to: 'users.id',
       },
     },
-    // TODO remove unused comments
-    // Add something to do with UserToParticipantRole so that we can populate the mapping easily
-    // participantToUserRoles: {
-    //   relation: Model.HasManyRelation,
-    //   modelClass: 'UserToParticipantRole',
-    //   join: {
-    //     from: 'participants.id',
-    //     to: 'usersToParticipantRoles.participantId',
-    //   },
-    // },
   };
   declare id: number;
   declare name: string;
@@ -95,7 +85,6 @@ export class Participant extends BaseModel {
   declare approver?: UserDTO;
   declare dateApproved?: Date;
   declare crmAgreementNumber: string | null;
-  // declare participantToUserRoles?: UserToParticipantRole[];
 }
 
 // TODO: Can ModelObjectOpt do relationships automatically?
@@ -120,15 +109,14 @@ export const ParticipantSchema = z.object({
   crmAgreementNumber: z.string().nullable(),
 });
 
-export const ParticipantCreationPartial = ParticipantSchema.pick({
+export const ParticipantCreationFromRequestPartial = ParticipantSchema.pick({
   name: true,
 }).extend({
   types: z.array(ParticipantTypeSchema.pick({ id: true })),
   users: z.array(UserCreationPartial).optional(),
 });
 
-// TODO rename this
-export const ParticipantCreationPartial2 = ParticipantSchema.pick({
+export const ParticipantCreationPartial = ParticipantSchema.pick({
   name: true,
 }).extend({
   types: z.array(ParticipantTypeSchema.pick({ id: true })),

--- a/src/api/entities/Participant.ts
+++ b/src/api/entities/Participant.ts
@@ -6,6 +6,7 @@ import { BaseModel } from './BaseModel';
 import { ModelObjectOpt } from './ModelObjectOpt';
 import { ParticipantType, ParticipantTypeDTO, ParticipantTypeSchema } from './ParticipantType';
 import { type User, UserCreationPartial, UserDTO, UserSchema } from './User';
+import { UserToParticipantRole } from './UserToParticipantRole';
 
 export enum ParticipantStatus {
   AwaitingSigning = 'awaitingSigning',
@@ -70,6 +71,16 @@ export class Participant extends BaseModel {
         to: 'users.id',
       },
     },
+    // TODO remove unused comments
+    // Add something to do with UserToParticipantRole so that we can populate the mapping easily
+    // participantToUserRoles: {
+    //   relation: Model.HasManyRelation,
+    //   modelClass: 'UserToParticipantRole',
+    //   join: {
+    //     from: 'participants.id',
+    //     to: 'usersToParticipantRoles.participantId',
+    //   },
+    // },
   };
   declare id: number;
   declare name: string;
@@ -84,6 +95,7 @@ export class Participant extends BaseModel {
   declare approver?: UserDTO;
   declare dateApproved?: Date;
   declare crmAgreementNumber: string | null;
+  // declare participantToUserRoles?: UserToParticipantRole[];
 }
 
 // TODO: Can ModelObjectOpt do relationships automatically?
@@ -113,6 +125,13 @@ export const ParticipantCreationPartial = ParticipantSchema.pick({
 }).extend({
   types: z.array(ParticipantTypeSchema.pick({ id: true })),
   users: z.array(UserCreationPartial).optional(),
+});
+
+// TODO rename this
+export const ParticipantCreationPartial2 = ParticipantSchema.pick({
+  name: true,
+}).extend({
+  types: z.array(ParticipantTypeSchema.pick({ id: true })),
 });
 
 export const ParticipantApprovalPartial = ParticipantSchema.pick({

--- a/src/api/entities/Participant.ts
+++ b/src/api/entities/Participant.ts
@@ -6,6 +6,8 @@ import { BaseModel } from './BaseModel';
 import { ModelObjectOpt } from './ModelObjectOpt';
 import { ParticipantType, ParticipantTypeDTO, ParticipantTypeSchema } from './ParticipantType';
 import { type User, UserCreationPartial, UserDTO, UserSchema } from './User';
+import { UserRole } from './UserRole';
+import { UserToParticipantRole } from './UserToParticipantRole';
 
 export enum ParticipantStatus {
   AwaitingSigning = 'awaitingSigning',
@@ -70,6 +72,14 @@ export class Participant extends BaseModel {
         to: 'users.id',
       },
     },
+    participantToUserRoles: {
+      relation: Model.HasManyRelation,
+      modelClass: 'UserToParticipantRole',
+      join: {
+        from: 'participants.id',
+        to: 'usersToParticipantRoles.participantId',
+      },
+    },
   };
   declare id: number;
   declare name: string;
@@ -84,6 +94,8 @@ export class Participant extends BaseModel {
   declare approver?: UserDTO;
   declare dateApproved?: Date;
   declare crmAgreementNumber: string | null;
+  declare currentUserRoleIds?: number[];
+  declare participantToUserRoles?: UserToParticipantRole[];
 }
 
 // TODO: Can ModelObjectOpt do relationships automatically?

--- a/src/api/entities/User.ts
+++ b/src/api/entities/User.ts
@@ -67,10 +67,9 @@ export class User extends BaseModel {
 
   static readonly modifiers = {
     withParticipants<TResult>(query: Objection.QueryBuilder<User, TResult>) {
-      const myQuery = query.withGraphFetched('participants') as Objection.QueryBuilder<
-        User,
-        TResult & { participants: Participant[] }
-      >;
+      const myQuery = query.withGraphFetched(
+        '[participants.participantToUserRoles]'
+      ) as Objection.QueryBuilder<User, TResult & { participants: Participant[] }>;
       return myQuery;
     },
   };

--- a/src/api/entities/User.ts
+++ b/src/api/entities/User.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { BaseModel } from './BaseModel';
 import { ModelObjectOpt } from './ModelObjectOpt';
 import type { Participant } from './Participant';
+import { UserToParticipantRole } from './UserToParticipantRole';
 
 export interface IUser {}
 export enum UserJobFunction {
@@ -44,6 +45,14 @@ export class User extends BaseModel {
         to: 'participants.id',
       },
     },
+    userToParticipantRoles: {
+      relation: Model.HasManyRelation,
+      modelClass: 'UserToParticipantRole',
+      join: {
+        from: 'users.id',
+        to: 'usersToParticipantRoles.userId',
+      },
+    },
   };
 
   declare id: number;
@@ -54,6 +63,7 @@ export class User extends BaseModel {
   declare jobFunction: UserJobFunction;
   declare participants?: Participant[];
   declare acceptedTerms: boolean;
+  declare userToParticipantRoles?: UserToParticipantRole[];
 
   static readonly modifiers = {
     withParticipants<TResult>(query: Objection.QueryBuilder<User, TResult>) {
@@ -86,3 +96,5 @@ export const UserCreationPartial = UserSchema.pick({
   jobFunction: true,
   acceptedTerms: true,
 });
+
+export type UserCreationDTO = Omit<ModelObjectOpt<UserDTO>, 'id'>;

--- a/src/api/entities/UserRole.ts
+++ b/src/api/entities/UserRole.ts
@@ -1,0 +1,26 @@
+import { BaseModel } from './BaseModel';
+
+export class UserRole extends BaseModel {
+  static get tableName() {
+    return 'userRoles';
+  }
+  // TODO Consider if I need this relationMapping
+  // static readonly relationMappings = {
+  //   user: {
+  //     relation: Model.ManyToManyRelation,
+  //     modelClass: 'User',
+  //     join: {
+  //       from: 'userRoles.id',
+  //       through: {
+  //         from: 'usersToParticipantRoles.userRoleId',
+  //         to: 'usersToParticipantRoles.userId',
+  //       },
+  //       to: 'users.id',
+  //     },
+  //   },
+  // };
+  declare id: number;
+  declare roleName: string;
+}
+
+export const ADMIN_USER_ROLE_ID = 1;

--- a/src/api/entities/UserRole.ts
+++ b/src/api/entities/UserRole.ts
@@ -4,21 +4,6 @@ export class UserRole extends BaseModel {
   static get tableName() {
     return 'userRoles';
   }
-  // TODO Consider if I need this relationMapping
-  // static readonly relationMappings = {
-  //   user: {
-  //     relation: Model.ManyToManyRelation,
-  //     modelClass: 'User',
-  //     join: {
-  //       from: 'userRoles.id',
-  //       through: {
-  //         from: 'usersToParticipantRoles.userRoleId',
-  //         to: 'usersToParticipantRoles.userId',
-  //       },
-  //       to: 'users.id',
-  //     },
-  //   },
-  // };
   declare id: number;
   declare roleName: string;
 }

--- a/src/api/entities/UserToParticipantRole.ts
+++ b/src/api/entities/UserToParticipantRole.ts
@@ -61,9 +61,3 @@ export type UserToParticipantRoleDTO = ModelObjectOpt<UserToParticipantRole>;
 export type TestUserToParticipantRoleDTO = Partial<
   Pick<ModelObjectOpt<UserToParticipantRole>, 'participantId' | 'userRoleId'>
 >;
-
-// TODO remove unused comment
-// export type UserToParticipantRoleCreationDTO = Omit<
-//   ModelObjectOpt<UserToParticipantRole>,
-//   'userId'
-// >;

--- a/src/api/entities/UserToParticipantRole.ts
+++ b/src/api/entities/UserToParticipantRole.ts
@@ -1,7 +1,4 @@
 import { Model } from 'objection';
-import { z } from 'zod';
-
-import { ModelObjectOpt } from './ModelObjectOpt';
 
 export class UserToParticipantRole extends Model {
   static get tableName() {
@@ -40,24 +37,3 @@ export class UserToParticipantRole extends Model {
   declare participantId: number;
   declare userRoleId: number;
 }
-
-export const UserToParticipantRoleSchema = z.object({
-  userId: z.number(),
-  participantId: z.number(),
-  userRoleId: z.number(),
-});
-
-export const UserToParticipantRoleCreationPartial = UserToParticipantRoleSchema.pick({
-  userRoleId: true,
-});
-
-export const UserToParticipantRoleCreationPartialTest = UserToParticipantRoleSchema.pick({
-  userRoleId: true,
-  participantId: true,
-});
-
-export type UserToParticipantRoleDTO = ModelObjectOpt<UserToParticipantRole>;
-
-export type TestUserToParticipantRoleDTO = Partial<
-  Pick<ModelObjectOpt<UserToParticipantRole>, 'participantId' | 'userRoleId'>
->;

--- a/src/api/entities/UserToParticipantRole.ts
+++ b/src/api/entities/UserToParticipantRole.ts
@@ -1,0 +1,69 @@
+import { Model } from 'objection';
+import { z } from 'zod';
+
+import { ModelObjectOpt } from './ModelObjectOpt';
+
+export class UserToParticipantRole extends Model {
+  static get tableName() {
+    return 'usersToParticipantRoles';
+  }
+  static get idColumn() {
+    return ['userId', 'participantId', 'userRoleId'];
+  }
+  static readonly relationMappings = {
+    user: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: 'User',
+      join: {
+        from: 'usersToParticipantRoles.userId',
+        to: 'users.id',
+      },
+    },
+    participant: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: 'Participant',
+      join: {
+        from: 'usersToParticipantRoles.participantId',
+        to: 'participants.id',
+      },
+    },
+    role: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: 'UserRole',
+      join: {
+        from: 'usersToParticipantRoles.userRoleId',
+        to: 'userRoles.id',
+      },
+    },
+  };
+  declare userId: number;
+  declare participantId: number;
+  declare userRoleId: number;
+}
+
+export const UserToParticipantRoleSchema = z.object({
+  userId: z.number(),
+  participantId: z.number(),
+  userRoleId: z.number(),
+});
+
+export const UserToParticipantRoleCreationPartial = UserToParticipantRoleSchema.pick({
+  userRoleId: true,
+});
+
+export const UserToParticipantRoleCreationPartialTest = UserToParticipantRoleSchema.pick({
+  userRoleId: true,
+  participantId: true,
+});
+
+export type UserToParticipantRoleDTO = ModelObjectOpt<UserToParticipantRole>;
+
+export type TestUserToParticipantRoleDTO = Partial<
+  Pick<ModelObjectOpt<UserToParticipantRole>, 'participantId' | 'userRoleId'>
+>;
+
+// TODO remove unused comment
+// export type UserToParticipantRoleCreationDTO = Omit<
+//   ModelObjectOpt<UserToParticipantRole>,
+//   'userId'
+// >;

--- a/src/api/routers/participants/participantClasses.ts
+++ b/src/api/routers/participants/participantClasses.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 
 import { ParticipantSchema } from '../../entities/Participant';
 import { ParticipantTypeSchema } from '../../entities/ParticipantType';
-import { UserCreationPartial } from '../../entities/User';
-import { UserToParticipantRoleCreationPartial, UserToParticipantRoleSchema } from '../../entities/UserToParticipantRole';
 
 export const ParticipantCreationRequest = z.object({
   participantName: z.string(),
@@ -18,23 +16,14 @@ export const ParticipantCreationRequest = z.object({
   crmAgreementNumber: z.string(),
 });
 
-// TODO remove unused comments
 export const ParticipantCreationAndApprovalPartial = ParticipantSchema.pick({
   siteId: true,
   name: true,
   types: true,
   apiRoles: true,
   crmAgreementNumber: true,
-  // status: true,
-  // approverId: true,
-  // dateApproved: true,
 }).extend({
   siteId: z.number().optional(),
   types: z.array(ParticipantTypeSchema.pick({ id: true })),
   apiRoles: z.array(ParticipantTypeSchema.pick({ id: true })),
-  // users: z.array(UserCreationPartial),
-  // userRoleId: z.array(z.number()),
-  // participantToUserRoles: z.array(z.number()),
-  // participantToUserRoles: z.array(UserToParticipantRoleCreationPartial),
-  // crmAgreementNumber: z.string(),
 });

--- a/src/api/routers/participants/participantClasses.ts
+++ b/src/api/routers/participants/participantClasses.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ParticipantSchema } from '../../entities/Participant';
 import { ParticipantTypeSchema } from '../../entities/ParticipantType';
 import { UserCreationPartial } from '../../entities/User';
+import { UserToParticipantRoleCreationPartial, UserToParticipantRoleSchema } from '../../entities/UserToParticipantRole';
 
 export const ParticipantCreationRequest = z.object({
   participantName: z.string(),
@@ -17,18 +18,23 @@ export const ParticipantCreationRequest = z.object({
   crmAgreementNumber: z.string(),
 });
 
+// TODO remove unused comments
 export const ParticipantCreationAndApprovalPartial = ParticipantSchema.pick({
   siteId: true,
   name: true,
   types: true,
   apiRoles: true,
-  status: true,
-  approverId: true,
-  dateApproved: true,
+  crmAgreementNumber: true,
+  // status: true,
+  // approverId: true,
+  // dateApproved: true,
 }).extend({
   siteId: z.number().optional(),
   types: z.array(ParticipantTypeSchema.pick({ id: true })),
   apiRoles: z.array(ParticipantTypeSchema.pick({ id: true })),
-  users: z.array(UserCreationPartial),
-  crmAgreementNumber: z.string(),
+  // users: z.array(UserCreationPartial),
+  // userRoleId: z.array(z.number()),
+  // participantToUserRoles: z.array(z.number()),
+  // participantToUserRoles: z.array(UserToParticipantRoleCreationPartial),
+  // crmAgreementNumber: z.string(),
 });

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -5,8 +5,7 @@ import { ApiRole } from '../../entities/ApiRole';
 import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import {
   Participant,
-  ParticipantCreationPartial,
-  ParticipantCreationPartial2,
+  ParticipantCreationFromRequestPartial,
   ParticipantStatus,
 } from '../../entities/Participant';
 import { User, UserCreationPartial } from '../../entities/User';
@@ -185,7 +184,7 @@ export async function createParticipant(req: ParticipantRequest, res: Response) 
 export const createParticipantFromRequest = async (req: ParticipantRequest, res: Response) => {
   try {
     const traceId = getTraceId(req);
-    const parsedRequest = ParticipantCreationPartial.parse(req.body);
+    const parsedRequest = ParticipantCreationFromRequestPartial.parse(req.body);
     const { users, ...rest } = parsedRequest;
     const participantData = {
       ...rest,

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -5,7 +5,7 @@ import { ApiRole } from '../../entities/ApiRole';
 import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import {
   Participant,
-  ParticipantCreationFromRequestPartial,
+  ParticipantCreationPartial,
   ParticipantStatus,
 } from '../../entities/Participant';
 import { User, UserCreationPartial } from '../../entities/User';
@@ -184,7 +184,7 @@ export async function createParticipant(req: ParticipantRequest, res: Response) 
 export const createParticipantFromRequest = async (req: ParticipantRequest, res: Response) => {
   try {
     const traceId = getTraceId(req);
-    const parsedRequest = ParticipantCreationFromRequestPartial.parse(req.body);
+    const parsedRequest = ParticipantCreationPartial.parse(req.body);
     const { users, ...rest } = parsedRequest;
     const participantData = {
       ...rest,

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -7,12 +7,10 @@ import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import {
   Participant,
   ParticipantApprovalPartial,
-  ParticipantCreationPartial,
-  ParticipantCreationPartial2,
   ParticipantDTO,
   ParticipantStatus,
 } from '../../entities/Participant';
-import { User, UserCreationPartial, UserDTO, UserJobFunction } from '../../entities/User';
+import { UserDTO, UserJobFunction } from '../../entities/User';
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
@@ -54,7 +52,6 @@ import {
   getParticipantsApproved,
   getParticipantsAwaitingApproval,
   ParticipantRequest,
-  sendNewParticipantEmail,
   sendParticipantApprovedEmail,
   updateParticipant,
   updateParticipantAndTypesAndApiRoles,
@@ -67,7 +64,6 @@ import {
   enrichCurrentUser,
   findUserByEmail,
   getAllUserFromParticipant,
-  insertUserParticipantRoleMapping,
 } from '../../services/usersService';
 import { createBusinessContactsRouter } from '../businessContactsRouter';
 import { getParticipantAppNames, setParticipantAppNames } from './participantsAppIds';

--- a/src/api/routers/participants/participantsUsers.spec.ts
+++ b/src/api/routers/participants/participantsUsers.spec.ts
@@ -31,10 +31,14 @@ describe('#getParticipantUsers', () => {
     const { res, json } = createResponseObject();
 
     const relatedParticipant = await createParticipant(knex, {});
-    const relatedUser = await createUser({ participantId: relatedParticipant.id });
+    const relatedUser = await createUser({
+      participantToRoles: [{ participantId: relatedParticipant.id }],
+    });
 
     const unrelatedParticipant = await createParticipant(knex, {});
-    const unrelatedUser = await createUser({ participantId: unrelatedParticipant.id });
+    const unrelatedUser = await createUser({
+      participantToRoles: [{ participantId: unrelatedParticipant.id }],
+    });
 
     const participantRequest = {
       participant: relatedParticipant,
@@ -56,12 +60,12 @@ describe('#getParticipantUsers', () => {
 
     const relatedParticipant = await createParticipant(knex, {});
     const relatedUsers = [
-      await createUser({ participantId: relatedParticipant.id }),
-      await createUser({ participantId: relatedParticipant.id }),
+      await createUser({ participantToRoles: [{ participantId: relatedParticipant.id }] }),
+      await createUser({ participantToRoles: [{ participantId: relatedParticipant.id }] }),
     ];
 
     const unrelatedParticipant = await createParticipant(knex, {});
-    await createUser({ participantId: unrelatedParticipant.id });
+    await createUser({ participantToRoles: [{ participantId: unrelatedParticipant.id }] });
 
     const participantRequest = {
       participant: relatedParticipant,

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -7,7 +7,7 @@ import { AuditAction, AuditTrailEvents } from '../entities/AuditTrail';
 import {
   Participant,
   ParticipantApprovalPartial,
-  ParticipantCreationPartial,
+  ParticipantCreationFromRequestPartial,
   ParticipantDTO,
   ParticipantStatus,
 } from '../entities/Participant';
@@ -41,7 +41,7 @@ export const getParticipantTypesByIds = async (
 };
 
 export const sendNewParticipantEmail = async (
-  newParticipant: z.infer<typeof ParticipantCreationPartial>,
+  newParticipant: z.infer<typeof ParticipantCreationFromRequestPartial>,
   typeIds: number[],
   traceId: string
 ) => {

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -164,7 +164,7 @@ export const updateParticipantApiRolesWithTransaction = async (
   }
 };
 
-export const updateParticipantAndTypesAndRoles = async (
+export const updateParticipantAndTypesAndApiRoles = async (
   participant: Participant,
   participantApprovalPartial: z.infer<typeof ParticipantApprovalPartial> & {
     status: ParticipantStatus;

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -7,7 +7,7 @@ import { AuditAction, AuditTrailEvents } from '../entities/AuditTrail';
 import {
   Participant,
   ParticipantApprovalPartial,
-  ParticipantCreationFromRequestPartial,
+  ParticipantCreationPartial,
   ParticipantDTO,
   ParticipantStatus,
 } from '../entities/Participant';
@@ -41,7 +41,7 @@ export const getParticipantTypesByIds = async (
 };
 
 export const sendNewParticipantEmail = async (
-  newParticipant: z.infer<typeof ParticipantCreationFromRequestPartial>,
+  newParticipant: z.infer<typeof ParticipantCreationPartial>,
   typeIds: number[],
   traceId: string
 ) => {

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { Participant } from '../entities/Participant';
 import { User, UserDTO } from '../entities/User';
 import { ADMIN_USER_ROLE_ID } from '../entities/UserRole';
-import { UserToParticipantRole, UserToParticipantRoleDTO } from '../entities/UserToParticipantRole';
+import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { getLoggers, getTraceId } from '../helpers/loggingHelpers';
 import { isUserAnApprover } from './approversService';
 
@@ -18,24 +18,12 @@ export const findUserByEmail = async (email: string) => {
     .withGraphFetched('userToParticipantRoles');
 };
 
-// TODO remove unused comments
-
-// export const findUserByEmail = async (email: string) => {
-//   return User.query().findOne('email', email).where('deleted', 0).modify('withParticipants');
-// };
-
 export const enrichUserWithIsApprover = async (user: User) => {
   const userIsApprover = await isUserAnApprover(user.email);
   return {
     ...user,
     isApprover: userIsApprover,
   };
-};
-
-export const insertUserParticipantRoleMapping = (
-  userToParticipantRole: UserToParticipantRoleDTO
-) => {
-  return UserToParticipantRole.query().insert(userToParticipantRole);
 };
 
 // TODO: Update this method so that if an existing user is invited, it will still add the new participant + mapping.
@@ -100,10 +88,6 @@ const userIdParser = z.object({
 export const enrichCurrentUser = async (req: UserRequest, res: Response, next: NextFunction) => {
   const userEmail = req.auth?.payload?.email as string;
   const user = await findUserByEmail(userEmail);
-  // const user = await findUserByEmail(userEmail);
-  console.log('');
-  console.log(user);
-  // console.log(user?.userRolesToParticipant?.[0].userRoleId);
   if (!user) {
     return res.status(404).send([{ message: 'The user cannot be found.' }]);
   }

--- a/src/api/tests/participantsService.spec.ts
+++ b/src/api/tests/participantsService.spec.ts
@@ -40,7 +40,9 @@ describe('Participant Service Tests', () => {
     describe('when participantId is specified', () => {
       it('should call next if participantId is valid and user has access', async () => {
         const relatedParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({ participantId: relatedParticipant.id });
+        const relatedUser = await createUser({
+          participantToRoles: [{ participantId: relatedParticipant.id }],
+        });
         const participantRequest = createParticipantRequest(
           relatedUser.email,
           relatedParticipant.id
@@ -54,7 +56,9 @@ describe('Participant Service Tests', () => {
 
       it('should return 404 if participant is not found', async () => {
         const relatedParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({ participantId: relatedParticipant.id });
+        const relatedUser = await createUser({
+          participantToRoles: [{ participantId: relatedParticipant.id }],
+        });
         const nonExistentParticipantId = 2;
         const participantRequest = createParticipantRequest(
           relatedUser.email,
@@ -70,7 +74,13 @@ describe('Participant Service Tests', () => {
       it('should return 403 if user does not have access to participant', async () => {
         const firstParticipant = await createParticipant(knex, {});
         const secondParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({ participantId: secondParticipant.id });
+        const relatedUser = await createUser({
+          participantToRoles: [
+            {
+              participantId: secondParticipant.id,
+            },
+          ],
+        });
         const participantRequest = createParticipantRequest(relatedUser.email, firstParticipant.id);
 
         await checkParticipantId(participantRequest, res, next);
@@ -85,7 +95,13 @@ describe('Participant Service Tests', () => {
     describe(`when participantId is 'current'`, () => {
       it('should call next if user has a valid participant', async () => {
         const relatedParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({ participantId: relatedParticipant.id });
+        const relatedUser = await createUser({
+          participantToRoles: [
+            {
+              participantId: relatedParticipant.id,
+            },
+          ],
+        });
         const participantRequest = createParticipantRequest(relatedUser.email, 'current');
 
         await checkParticipantId(participantRequest, res, next);

--- a/src/api/tests/usersService.spec.ts
+++ b/src/api/tests/usersService.spec.ts
@@ -37,7 +37,9 @@ describe('User Service Tests', () => {
   describe('enrichWithUserFromParams middleware', () => {
     it('should call next if user request is valid', async () => {
       const relatedParticipant = await createParticipant(knex, {});
-      const relatedUser = await createUser({ participantId: relatedParticipant.id });
+      const relatedUser = await createUser({
+        participantToRoles: [{ participantId: relatedParticipant.id }],
+      });
       const userRequest = createUserRequest(relatedUser.email, relatedUser.id);
 
       await enrichWithUserFromParams(userRequest, res, next);
@@ -48,7 +50,9 @@ describe('User Service Tests', () => {
 
     it('should return 404 if user is not found', async () => {
       const relatedParticipant = await createParticipant(knex, {});
-      const relatedUser = await createUser({ participantId: relatedParticipant.id });
+      const relatedUser = await createUser({
+        participantToRoles: [{ participantId: relatedParticipant.id }],
+      });
       const nonExistentUserId = 2;
       const userRequest = createUserRequest(relatedUser.email, nonExistentUserId);
 
@@ -71,8 +75,12 @@ describe('User Service Tests', () => {
     it('should return 403 if user does not have access to participant', async () => {
       const firstParticipant = await createParticipant(knex, {});
       const secondParticipant = await createParticipant(knex, {});
-      const firstUser = await createUser({ participantId: firstParticipant.id });
-      const secondUser = await createUser({ participantId: secondParticipant.id });
+      const firstUser = await createUser({
+        participantToRoles: [{ participantId: firstParticipant.id }],
+      });
+      const secondUser = await createUser({
+        participantToRoles: [{ participantId: secondParticipant.id }],
+      });
       const userRequest = createUserRequest(secondUser.email, firstUser.id);
 
       await enrichWithUserFromParams(userRequest, res, next);

--- a/src/database/migrations/20240729070741_CreateUserRolesTable.ts
+++ b/src/database/migrations/20240729070741_CreateUserRolesTable.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('userRoles', (table) => {
+    table.increments('id').primary();
+    table.string('roleName', 100).notNullable();
+  });
+
+  const userRoleNames = ['Admin', 'Operations', 'UID2 Support'];
+
+  await knex('userRoles').insert(
+    userRoleNames.map((role) => {
+      return { roleName: role };
+    })
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('userRoles');
+}

--- a/src/database/migrations/20240730010143_AddUserRoleIdColumnToUsersToParticipantRoles.ts
+++ b/src/database/migrations/20240730010143_AddUserRoleIdColumnToUsersToParticipantRoles.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Add the new column, initially nullable
+  await knex.schema.alterTable('usersToParticipantRoles', (table) => {
+    table.integer('userRoleId');
+    table.foreign('userRoleId').references('userRoles.id');
+  });
+
+  // Populate new column
+  const adminUserRoleId = 1;
+  await knex('usersToParticipantRoles').update({ userRoleId: adminUserRoleId });
+
+  // Make it not nullable and add to PK
+  await knex.schema.alterTable('usersToParticipantRoles', (table) => {
+    table.integer('userRoleId').notNullable().alter();
+    table.dropPrimary();
+    table.primary(['userId', 'participantId', 'userRoleId']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('usersToParticipantRoles', (table) => {
+    table.dropForeign('userRoleId');
+    table.dropPrimary();
+    table.dropColumn('userRoleId');
+    table.primary(['userId', 'participantId']);
+  });
+}

--- a/src/database/seeds/Users.ts
+++ b/src/database/seeds/Users.ts
@@ -4,6 +4,7 @@ import { Optional } from 'utility-types';
 
 import { ParticipantStatus } from '../../api/entities/Participant';
 import { User, UserJobFunction } from '../../api/entities/User';
+import { ADMIN_USER_ROLE_ID } from '../../api/entities/UserRole';
 import { CreateParticipant } from './Participants';
 
 type UserType = ModelObject<User>;
@@ -48,6 +49,12 @@ export async function seed(knex: Knex): Promise<void> {
       existingParticipants.map((participant) => participant.id)
     )
     .del();
+  await knex('auditTrails')
+    .whereIn(
+      'participantId',
+      existingParticipants.map((participant) => participant.id)
+    )
+    .update('participantId', null);
   await knex('users')
     .whereIn(
       'id',
@@ -71,6 +78,10 @@ export async function seed(knex: Knex): Promise<void> {
     sampleData.map((d) => d.email)
   );
   await knex('usersToParticipantRoles').insert(
-    newUsers.map((user: UserType) => ({ userId: user.id, participantId }))
+    newUsers.map((user: UserType) => ({
+      userId: user.id,
+      participantId,
+      userRoleId: ADMIN_USER_ROLE_ID,
+    }))
   );
 }

--- a/src/testHelpers/apiTestHelpers.ts
+++ b/src/testHelpers/apiTestHelpers.ts
@@ -2,14 +2,16 @@ import { faker } from '@faker-js/faker';
 import { Response } from 'express';
 import { Knex } from 'knex';
 
+import { ModelObjectOpt } from '../api/entities/ModelObjectOpt';
 import { Participant, ParticipantStatus } from '../api/entities/Participant';
 import { User, UserJobFunction } from '../api/entities/User';
 import { ADMIN_USER_ROLE_ID } from '../api/entities/UserRole';
-import {
-  TestUserToParticipantRoleDTO,
-  UserToParticipantRole,
-} from '../api/entities/UserToParticipantRole';
+import { UserToParticipantRole } from '../api/entities/UserToParticipantRole';
 import { CreateParticipant } from '../database/seeds/Participants';
+
+type ParticipantToUserRoleDTO = Partial<
+  Pick<ModelObjectOpt<UserToParticipantRole>, 'participantId' | 'userRoleId'>
+>;
 
 export function createResponseObject() {
   const res = {} as unknown as Response;
@@ -68,7 +70,7 @@ export async function createUser({
   lastName?: string;
   jobFunction?: UserJobFunction;
   acceptedTerms?: boolean;
-  participantToRoles?: TestUserToParticipantRoleDTO[];
+  participantToRoles?: ParticipantToUserRoleDTO[];
 }) {
   const data = {
     email,

--- a/src/testHelpers/apiTestHelpers.ts
+++ b/src/testHelpers/apiTestHelpers.ts
@@ -4,6 +4,11 @@ import { Knex } from 'knex';
 
 import { Participant, ParticipantStatus } from '../api/entities/Participant';
 import { User, UserJobFunction } from '../api/entities/User';
+import { ADMIN_USER_ROLE_ID } from '../api/entities/UserRole';
+import {
+  TestUserToParticipantRoleDTO,
+  UserToParticipantRole,
+} from '../api/entities/UserToParticipantRole';
 import { CreateParticipant } from '../database/seeds/Participants';
 
 export function createResponseObject() {
@@ -56,14 +61,14 @@ export async function createUser({
   lastName = faker.person.lastName(),
   jobFunction = UserJobFunction.DA,
   acceptedTerms = true,
-  participantId,
+  participantToRoles,
 }: {
   email?: string;
   firstName?: string;
   lastName?: string;
   jobFunction?: UserJobFunction;
   acceptedTerms?: boolean;
-  participantId?: number;
+  participantToRoles?: TestUserToParticipantRoleDTO[];
 }) {
   const data = {
     email,
@@ -74,8 +79,13 @@ export async function createUser({
   };
 
   const user = await User.query().insert(data);
-  if (participantId) {
-    await user.$relatedQuery('participants').relate(participantId);
+  const userToParticipantRolesData = participantToRoles?.map((item) => ({
+    ...item,
+    userId: user.id,
+    userRoleId: item.userRoleId ?? ADMIN_USER_ROLE_ID,
+  }));
+  if (userToParticipantRolesData) {
+    await UserToParticipantRole.query().insert(userToParticipantRolesData);
   }
 
   return user;

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 
 import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { BusinessContactSchema } from '../../api/entities/BusinessContact';
-import { ParticipantCreationPartial, ParticipantDTO } from '../../api/entities/Participant';
+import {
+  ParticipantCreationFromRequestPartial,
+  ParticipantDTO,
+} from '../../api/entities/Participant';
 import { SignedParticipantDTO } from '../../api/entities/SignedParticipant';
 import { ParticipantRequestDTO } from '../../api/routers/participants/participantsRouter';
 import {
@@ -16,7 +19,7 @@ import {
 import { backendError } from '../utils/apiError';
 import { InviteTeamMemberForm, UserPayload } from './userAccount';
 
-export type ParticipantCreationPayload = z.infer<typeof ParticipantCreationPartial>;
+export type ParticipantCreationPayload = z.infer<typeof ParticipantCreationFromRequestPartial>;
 export type CreateParticipantForm = {
   companyName: string;
   companyType: number[];

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -4,10 +4,7 @@ import { z } from 'zod';
 
 import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { BusinessContactSchema } from '../../api/entities/BusinessContact';
-import {
-  ParticipantCreationFromRequestPartial,
-  ParticipantDTO,
-} from '../../api/entities/Participant';
+import { ParticipantCreationPartial, ParticipantDTO } from '../../api/entities/Participant';
 import { SignedParticipantDTO } from '../../api/entities/SignedParticipant';
 import { ParticipantRequestDTO } from '../../api/routers/participants/participantsRouter';
 import {
@@ -19,7 +16,7 @@ import {
 import { backendError } from '../utils/apiError';
 import { InviteTeamMemberForm, UserPayload } from './userAccount';
 
-export type ParticipantCreationPayload = z.infer<typeof ParticipantCreationFromRequestPartial>;
+export type ParticipantCreationPayload = z.infer<typeof ParticipantCreationPartial>;
 export type CreateParticipantForm = {
   companyName: string;
   companyType: number[];


### PR DESCRIPTION
- Migration to create `userRoles` table
- Migration to add column to `usersToParticipantRoles` table, using default value of 1 (Admin)
- New `UserRole` and `UserToParticipantRole` entities
- Relate the `UserToParticipantRole` entity to `UserRole`, `User` and `Participant`.
- Alter participant/user creation methods so that the three-way mapping is also updated. Objection doesn't seem to handle this three-way mapping very well, so we've opted to manually insert into the mapping table rather than using graph inserts.
- Simplify some parsers to only parse the actual request from the front-end, rather than the request + properties we add in the back-end.
- Some minor refactoring out of router file
- Some minor renaming for clarity
- Modify `createUser` test method to accept a participant/role mapping, rather than just a `participantId`.

## Manual testing
1. Run the migrations to get the latest schema. 
2. Observe that all rows in `usersToParticipantRoles` have a `userRoleId` of 1.
3. Add yourself to another participant manually into the db, optionally with a different `userRoleId`. For me, this was done via:
    ```
    insert into dbo.userstoParticipantRoles (userId, participantId, userRoleId) values (3, 9, 3)
    ```
4. Log into the UI and check the response from `http://localhost:3000/api/users/current`. It should include the `currentUserRoleIds` array (as well as a separate `Participants` array), e.g.:
    ```
    "id": 3,
    "email": "abby@example.com",
    ...
    "participantId": 8, // will be changed/removed in future
    "participants": [
        {
            "id": 8,
            "name": "Participant A",
            ...
            "currentUserRoleIds": [
                1
            ]
        },
        {
            "id": 9,
            "name": "Participant B",
            ...
            "currentUserRoleIds": [
                3
            ]
        }
    ],
    ...
    ```
