### PR TITLE
Populate support user role for approvers

### DIFF
--- a/src/database/migrations/20240808041539_PopulateUID2SupportUsers.ts
+++ b/src/database/migrations/20240808041539_PopulateUID2SupportUsers.ts
@@ -45,6 +45,7 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   const approverUserIds = await getAllApproverUserIds(knex);
+
   await knex('usersToParticipantRoles')
     .whereIn('userId', approverUserIds)
     .where('userRoleId', '=', UID2_SUPPORT_USER_ROLE_ID)

--- a/src/database/migrations/20240808041539_PopulateUID2SupportUsers.ts
+++ b/src/database/migrations/20240808041539_PopulateUID2SupportUsers.ts
@@ -23,6 +23,10 @@ const getAllApproverUserIds = async (knex: Knex) => {
 export async function up(knex: Knex): Promise<void> {
   const approverUserIds = await getAllApproverUserIds(knex);
 
+  if (approverUserIds.length === 0) {
+    return;
+  }
+
   // Find the lowest participantId for each userId
   const usersToParticipants: UserToParticipant[] = await knex('usersToParticipantRoles')
     .select('userId')
@@ -45,6 +49,10 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   const approverUserIds = await getAllApproverUserIds(knex);
+
+  if (approverUserIds.length === 0) {
+    return;
+  }
 
   await knex('usersToParticipantRoles')
     .whereIn('userId', approverUserIds)

--- a/src/database/migrations/20240808041539_PopulateUID2SupportUsers.ts
+++ b/src/database/migrations/20240808041539_PopulateUID2SupportUsers.ts
@@ -1,0 +1,44 @@
+import { Knex } from 'knex';
+
+type UserToParticipantRole = {
+  userId: number;
+  participantId: number;
+  userRoleId: number;
+};
+
+type UserToParticipant = Omit<UserToParticipantRole, 'userRoleId'>;
+
+const UID2_SUPPORT_USER_ROLE_ID = 3;
+
+export async function up(knex: Knex): Promise<void> {
+  // Find all approvers
+  const approvers = await knex('approvers').distinct('email');
+  const approverEmails = approvers.map((approver) => approver.email);
+
+  // Retrieve their user IDs
+  const approverUsers = await knex('users').whereIn('email', approverEmails);
+  const approverUserIds = approverUsers.map((user) => user.id);
+
+  // Find the lowest participantId for each userId
+  const usersToParticipants: UserToParticipant[] = await knex('usersToParticipantRoles')
+    .select('userId')
+    .min('participantId as participantId')
+    .whereIn('userId', approverUserIds)
+    .groupBy('userId');
+
+  // Populate usersToParticipantRoles with a new row for the support user role id
+  await knex('usersToParticipantRoles').insert(
+    usersToParticipants.map((userToParticipant) => {
+      const data: UserToParticipantRole = {
+        userId: userToParticipant.userId,
+        participantId: userToParticipant.participantId,
+        userRoleId: UID2_SUPPORT_USER_ROLE_ID,
+      };
+      return data;
+    })
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex('usersToParticipantRoles').where('userRoleId', '=', UID2_SUPPORT_USER_ROLE_ID).del();
+}


### PR DESCRIPTION
- Use the existing `dbo.approvers` table to populate the `dbo.userToParticipantRoles` table.
- Since `participantId` is not nullable, it just finds the lowest `participantId` against the existing approver user, then inserts a new row with the `userRoleId` that matches "UID2 Support". This `participantId` here doesn't really matter, since the presence of UID2 Support will bypass any participant restrictions.
- No-op if there are no rows in the approvers table