### PR TITLE
Check for UID2 Support role in middleware

### DIFF
--- a/src/api/entities/UserRole.ts
+++ b/src/api/entities/UserRole.ts
@@ -1,5 +1,11 @@
 import { BaseModel } from './BaseModel';
 
+export enum UserRoleId {
+  Admin = 1,
+  Operations = 2,
+  UID2Support = 3,
+}
+
 export class UserRole extends BaseModel {
   static get tableName() {
     return 'userRoles';
@@ -7,5 +13,3 @@ export class UserRole extends BaseModel {
   declare id: number;
   declare roleName: string;
 }
-
-export const ADMIN_USER_ROLE_ID = 1;

--- a/src/api/middleware/usersMiddleware.ts
+++ b/src/api/middleware/usersMiddleware.ts
@@ -3,20 +3,31 @@ import { z } from 'zod';
 
 import { Participant } from '../entities/Participant';
 import { User } from '../entities/User';
+import { UserRoleId } from '../entities/UserRole';
+import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { getLoggers, getTraceId } from '../helpers/loggingHelpers';
 import { findUserByEmail, UserRequest } from '../services/usersService';
+
+export const userHasUid2SupportRole = async (userEmail: string) => {
+  const user = await findUserByEmail(userEmail);
+  const hasUid2SupportRole = await UserToParticipantRole.query()
+    .where('userId', '=', user!.id)
+    .andWhere('userRoleId', '=', UserRoleId.UID2Support)
+    .first();
+  return !!hasUid2SupportRole;
+};
 
 export const isUserBelongsToParticipant = async (
   email: string,
   participantId: number,
   traceId: string
 ) => {
-  const { errorLogger } = getLoggers();
   const userWithParticipants = await User.query()
     .findOne({ email, deleted: 0 })
     .modify('withParticipants');
 
   if (!userWithParticipants) {
+    const { errorLogger } = getLoggers();
     errorLogger.error(`User with email ${email} not found`, traceId);
     return false;
   }
@@ -25,7 +36,6 @@ export const isUserBelongsToParticipant = async (
       return true;
     }
   }
-  errorLogger.error(`Denied access to participant ID ${participantId} by user ${email}`, traceId);
   return false;
 };
 
@@ -59,15 +69,17 @@ export const enrichWithUserFromParams = async (
     return res.status(404).send([{ message: 'The participant for that user cannot be found.' }]);
   }
 
+  const requestingUserEmail = req.auth?.payload?.email as string;
+  const requestingUserIsUid2Support = await userHasUid2SupportRole(requestingUserEmail);
+
   // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-2822
   const firstParticipant = user.participants?.[0] as Participant;
-  if (
-    !(await isUserBelongsToParticipant(
-      req.auth?.payload?.email as string,
-      firstParticipant.id,
-      traceId
-    ))
-  ) {
+
+  const requestingUserHasAccessToParticipant =
+    requestingUserIsUid2Support ||
+    (await isUserBelongsToParticipant(requestingUserEmail, firstParticipant.id, traceId));
+
+  if (!requestingUserHasAccessToParticipant) {
     return res.status(403).send([{ message: 'You do not have permission to that user account.' }]);
   }
 

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -6,36 +6,36 @@ import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import {
   Participant,
   ParticipantCreationPartial,
-  ParticipantStatus,
+  ParticipantStatus
 } from '../../entities/Participant';
 import { User, UserCreationPartial } from '../../entities/User';
-import { ADMIN_USER_ROLE_ID } from '../../entities/UserRole';
+import { UserRoleId } from '../../entities/UserRole';
 import { UserToParticipantRole } from '../../entities/UserToParticipantRole';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { addSite, getSiteList, setSiteClientTypes } from '../../services/adminServiceClient';
 import {
   mapClientTypesToAdminEnums,
-  SiteCreationRequest,
+  SiteCreationRequest
 } from '../../services/adminServiceHelpers';
 import {
   constructAuditTrailObject,
-  performAsyncOperationWithAuditTrail,
+  performAsyncOperationWithAuditTrail
 } from '../../services/auditTrailService';
 import {
   assignClientRoleToUser,
   createNewUser,
-  sendInviteEmail,
+  sendInviteEmail
 } from '../../services/kcUsersService';
 import {
   getParticipantTypesByIds,
   ParticipantRequest,
-  sendNewParticipantEmail,
+  sendNewParticipantEmail
 } from '../../services/participantsService';
 import { findUserByEmail } from '../../services/usersService';
 import {
   ParticipantCreationAndApprovalPartial,
-  ParticipantCreationRequest,
+  ParticipantCreationRequest
 } from './participantClasses';
 
 export async function validateParticipantCreationRequest(
@@ -90,7 +90,7 @@ const createUserAndAssociatedParticipant = async (
     await UserToParticipantRole.query(trx).insert({
       userId: newPortalUser.id,
       participantId: newParticipant?.id!,
-      userRoleId: ADMIN_USER_ROLE_ID,
+      userRoleId: UserRoleId.Admin,
     });
   });
 };
@@ -210,7 +210,7 @@ export const createParticipantFromRequest = async (req: ParticipantRequest, res:
       await UserToParticipantRole.query(trx).insert({
         userId: newPortalUser.id,
         participantId: newParticipant?.id!,
-        userRoleId: ADMIN_USER_ROLE_ID,
+        userRoleId: UserRoleId.Admin,
       });
       return newParticipant;
     });

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 
 import { Participant } from '../entities/Participant';
 import { User, UserDTO } from '../entities/User';
-import { ADMIN_USER_ROLE_ID } from '../entities/UserRole';
+import { UserRoleId } from '../entities/UserRole';
 import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { isUserAnApprover } from './approversService';
 
@@ -65,7 +65,7 @@ export const createUserInPortal = async (
     await UserToParticipantRole.query(trx).insert({
       userId: newUser?.id,
       participantId,
-      userRoleId: ADMIN_USER_ROLE_ID,
+      userRoleId: UserRoleId.Admin,
     });
   });
 };

--- a/src/database/seeds/Users.ts
+++ b/src/database/seeds/Users.ts
@@ -4,7 +4,7 @@ import { Optional } from 'utility-types';
 
 import { ParticipantStatus } from '../../api/entities/Participant';
 import { User, UserJobFunction } from '../../api/entities/User';
-import { ADMIN_USER_ROLE_ID } from '../../api/entities/UserRole';
+import { UserRoleId } from '../../api/entities/UserRole';
 import { CreateParticipant } from './Participants';
 
 type UserType = ModelObject<User>;
@@ -81,7 +81,7 @@ export async function seed(knex: Knex): Promise<void> {
     newUsers.map((user: UserType) => ({
       userId: user.id,
       participantId,
-      userRoleId: ADMIN_USER_ROLE_ID,
+      userRoleId: UserRoleId.Admin,
     }))
   );
 }

--- a/src/testHelpers/apiTestHelpers.ts
+++ b/src/testHelpers/apiTestHelpers.ts
@@ -5,7 +5,7 @@ import { Knex } from 'knex';
 import { ModelObjectOpt } from '../api/entities/ModelObjectOpt';
 import { Participant, ParticipantStatus } from '../api/entities/Participant';
 import { User, UserJobFunction } from '../api/entities/User';
-import { ADMIN_USER_ROLE_ID } from '../api/entities/UserRole';
+import { UserRoleId } from '../api/entities/UserRole';
 import { UserToParticipantRole } from '../api/entities/UserToParticipantRole';
 import { CreateParticipant } from '../database/seeds/Participants';
 
@@ -84,7 +84,7 @@ export async function createUser({
   const userToParticipantRolesData = participantToRoles?.map((item) => ({
     ...item,
     userId: user.id,
-    userRoleId: item.userRoleId ?? ADMIN_USER_ROLE_ID,
+    userRoleId: item.userRoleId ?? UserRoleId.Admin,
   }));
   if (userToParticipantRolesData) {
     await UserToParticipantRole.query().insert(userToParticipantRolesData);


### PR DESCRIPTION
- Add checks in the users and participants middleware to check for the existence of the UID2 Support role
- Add a test case to cover the new functionality
- Change from exporting a single user role ID to an enum of all three.