### PR TITLE
Make local API more reliable during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "api": "run-p check-env-file api-watch",
     "check-env-file": "npx ts-node src/checkEnvFile.ts",
     "api-watch": "nodemon -e \".ts\" --exec npm run babel-node-api",
-    "babel-node-api": "babel-node -r dotenv/config -x \".ts\" ./src/api/api.ts",
+    "babel-node-api": "npx kill-port 6540 && babel-node -r dotenv/config -x \".ts\" ./src/api/api.ts",
     "build-api": "npx tsc --build ./tsconfig-api.json",
     "test-api": "npx jest --testTimeout=5000 --forceExit --runInBand --config=./src/api/jest.config.ts",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
While working on API changes, the watcher occasionally crashes with:
```
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1899:8)
    at processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'EADDRINUSE',
  errno: -4091,
  syscall: 'listen',
  address: '::',
  port: 6540
}

Node.js v20.11.0
[nodemon] app crashed - waiting for file changes before starting...
```
And gets stuck - saving a file just results in the same error. It needs to be manually killed along with the port, then the command needs to be run again to get the local API to work. This commit means that the API-watcher is slightly slower each time but much more reliable.