### PR TITLE
Remove duplication from users and participants

### DIFF
--- a/src/api/middleware/participantsMiddleware.ts
+++ b/src/api/middleware/participantsMiddleware.ts
@@ -23,8 +23,7 @@ const hasParticipantAccess = async (req: ParticipantRequest, res: Response, next
   const isUserUid2Support = await isUid2Support(userEmail);
 
   const canUserAccessParticipant =
-    isUserUid2Support ||
-    (await isUserBelongsToParticipant(userEmail, participantId, traceId));
+    isUserUid2Support || (await isUserBelongsToParticipant(userEmail, participantId, traceId));
 
   if (!canUserAccessParticipant) {
     return res.status(403).send([{ message: 'You do not have permission to that participant.' }]);


### PR DESCRIPTION
- Remove duplication of user.participants
- Remove duplication of participant.users

# Manual testing
## Users
1. Set up your user (e.g. abby@example.com) to have multiple userRoleIds for your participant.
1. Call `http://localhost:3000/api/participants/current/users` and look at the response:

### Before

```
[
    {
        "id": 3,
        "email": "abby@example.com",
        "phone": null,
        "participantId": 8,
        "firstName": "abby",
        "lastName": "example",
        "jobFunction": "Marketing",
        "acceptedTerms": true,
        "deleted": false,
        "fullName": "abby example"
    },
    {
        "id": 3,
        "email": "abby@example.com",
        "phone": null,
        "participantId": 8,
        "firstName": "abby",
        "lastName": "example",
        "jobFunction": "Marketing",
        "acceptedTerms": true,
        "deleted": false,
        "fullName": "abby example"
    },
    {
        "id": 5059,
        "email": "11077777777777@example.com",
        "phone": null,
        "participantId": null,
        "firstName": "11077777777777 8",
        "lastName": "example",
        "jobFunction": "Data / Analytics",
        "acceptedTerms": true,
        "deleted": false,
        "fullName": "11077777777777 8 example"
    }
    ...
]
```

### After
```
[
    {
        "id": 3,
        "email": "abby@example.com",
        "phone": null,
        "participantId": 8,
        "firstName": "abby",
        "lastName": "example",
        "jobFunction": "Marketing",
        "acceptedTerms": true,
        "deleted": false,
        "fullName": "abby example"
    },
    {
        "id": 5059,
        "email": "11077777777777@example.com",
        "phone": null,
        "participantId": null,
        "firstName": "11077777777777 8",
        "lastName": "example",
        "jobFunction": "Data / Analytics",
        "acceptedTerms": true,
        "deleted": false,
        "fullName": "11077777777777 8 example"
    },
   ...
```

## Participants
2. Call `http://localhost:3000/api/users/current` and look at `user.participants`

### Before
```
"participants": [
    {
        "id": 8,
        "name": "abby",
        "status": "approved",
        "allowSharing": true,
        "siteId": 999,
        "completedRecommendations": true,
        "approverId": null,
        "dateApproved": null,
        "crmAgreementNumber": null,
        "currentUserRoleIds": [
            1,
            3
        ]
    },
    {
        "id": 8,
        "name": "abby",
        "status": "approved",
        "allowSharing": true,
        "siteId": 999,
        "completedRecommendations": true,
        "approverId": null,
        "dateApproved": null,
        "crmAgreementNumber": null,
        "currentUserRoleIds": [
            1,
            3
        ]
    },
    {
        "id": 9,
        "name": "355",
        "status": "approved",
        "allowSharing": true,
        "siteId": null,
        "completedRecommendations": false,
        "approverId": 3,
        "dateApproved": "2024-05-03T05:55:34.716Z",
        "crmAgreementNumber": "99999999",
        "currentUserRoleIds": [
            1
        ]
    }
],
```
### After

```
"participants": [
    {
        "id": 8,
        "name": "abby",
        "status": "approved",
        "allowSharing": true,
        "siteId": 999,
        "completedRecommendations": true,
        "approverId": null,
        "dateApproved": null,
        "crmAgreementNumber": null,
        "currentUserRoleIds": [
            1,
            3
        ]
    },
    {
        "id": 9,
        "name": "355",
        "status": "approved",
        "allowSharing": true,
        "siteId": null,
        "completedRecommendations": false,
        "approverId": 3,
        "dateApproved": "2024-05-03T05:55:34.716Z",
        "crmAgreementNumber": "99999999",
        "currentUserRoleIds": [
            1
        ]
    }
],
```