### PR TITLE
Ensure client-side completion banner renders appropriately

### DIFF
--- a/src/web/components/ClientSideCompletion/ClientSideCompletion.stories.tsx
+++ b/src/web/components/ClientSideCompletion/ClientSideCompletion.stories.tsx
@@ -38,6 +38,24 @@ export const KeyPairAndAppIds: Story = {
   name: 'Key Pair and App IDs (renders empty - nothing to say!)',
 };
 
+export const KeyPairAndAppIdsWithEmptyDomainNames: Story = {
+  args: {
+    keyPairData: [createKeypairFake(false)],
+    appIds: ['123456789'],
+    domainNames: [],
+  },
+  name: 'Key Pair and App IDs with empty Domain Names (renders empty - nothing to say!)',
+};
+
+export const KeyPairAndDomainNamesWithEmptyAppIds: Story = {
+  args: {
+    keyPairData: [createKeypairFake(false)],
+    appIds: [],
+    domainNames: ['example.com'],
+  },
+  name: 'Key Pair and Domain Names with empty App IDs (renders empty - nothing to say!)',
+};
+
 export const KeyPairOnly: Story = {
   args: {
     keyPairData: [createKeypairFake(false)],

--- a/src/web/components/ClientSideCompletion/ClientSideCompletion.tsx
+++ b/src/web/components/ClientSideCompletion/ClientSideCompletion.tsx
@@ -16,8 +16,7 @@ export function ClientSideCompletion({
   appIds,
 }: ClientSideCompletionProps) {
   const hasKeyPairData = !!keyPairData?.filter((kp) => !kp.disabled).length;
-  const hasDomainNamesOrAppIds =
-    (domainNames && domainNames.length > 0) || (appIds && appIds.length > 0);
+  const hasDomainNamesOrAppIds = (domainNames?.length ?? 0) > 0 || (appIds?.length ?? 0) > 0;
 
   if (hasKeyPairData && hasDomainNamesOrAppIds) return null;
 

--- a/src/web/components/ClientSideCompletion/ClientSideCompletion.tsx
+++ b/src/web/components/ClientSideCompletion/ClientSideCompletion.tsx
@@ -16,7 +16,8 @@ export function ClientSideCompletion({
   appIds,
 }: ClientSideCompletionProps) {
   const hasKeyPairData = !!keyPairData?.filter((kp) => !kp.disabled).length;
-  const hasDomainNamesOrAppIds = domainNames?.length ?? appIds?.length;
+  const hasDomainNamesOrAppIds =
+    (domainNames && domainNames.length > 0) || (appIds && appIds.length > 0);
 
   if (hasKeyPairData && hasDomainNamesOrAppIds) return null;
 


### PR DESCRIPTION
- Address edge case where either domainNames or appIds are all deleted and set to an empty array.
- Add stories to cover edge case.

Before
![image](https://github.com/user-attachments/assets/68d0534d-d769-4502-8ef1-037ea01574af)


After

![image](https://github.com/user-attachments/assets/67fe98eb-83d6-415e-9c32-0ee04f0e63ca)

