### PR TITLE
Always provide participantId in API calls

### DIFF
--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -51,7 +51,7 @@ export class UserController {
 
   @httpPut('/current/acceptTerms')
   public async acceptTerms(@request() req: UserRequest, @response() res: Response): Promise<void> {
-    // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-2822
+    // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-3989
     const currentParticipantId = req.user?.participants?.[0].id;
     const participant = currentParticipantId
       ? await Participant.query().findById(currentParticipantId)

--- a/src/api/middleware/tests/participantsMiddleware.spec.ts
+++ b/src/api/middleware/tests/participantsMiddleware.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../testHelpers/apiTestHelpers';
 import { UserRoleId } from '../../entities/UserRole';
 import { ParticipantRequest } from '../../services/participantsService';
-import { checkParticipantId } from '../participantsMiddleware';
+import { hasParticipantAccess } from '../participantsMiddleware';
 
 const createParticipantRequest = (
   email: string,
@@ -37,112 +37,73 @@ describe('Participant Service Tests', () => {
     next = jest.fn();
     ({ res } = createResponseObject());
   });
-  describe('checkParticipantId middleware', () => {
-    describe('when participantId is specified', () => {
-      it('should call next if participantId is valid and user belongs to participant', async () => {
-        const relatedParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({
-          participantToRoles: [{ participantId: relatedParticipant.id }],
-        });
-        const participantRequest = createParticipantRequest(
-          relatedUser.email,
-          relatedParticipant.id
-        );
-
-        await checkParticipantId(participantRequest, res, next);
-
-        expect(res.status).not.toHaveBeenCalled();
-        expect(next).toHaveBeenCalled();
+  describe('hasParticipantAccess middleware', () => {
+    it('should call next if participantId is valid and user belongs to participant', async () => {
+      const relatedParticipant = await createParticipant(knex, {});
+      const relatedUser = await createUser({
+        participantToRoles: [{ participantId: relatedParticipant.id }],
       });
-      it('should call next if user is UID2 support, even if user does not belong to participant', async () => {
-        const firstParticipant = await createParticipant(knex, {});
-        const secondParticipant = await createParticipant(knex, {});
-        const uid2SupportUser = await createUser({
-          participantToRoles: [
-            { participantId: firstParticipant.id, userRoleId: UserRoleId.UID2Support },
-          ],
-        });
-        const participantRequest = createParticipantRequest(
-          uid2SupportUser.email,
-          secondParticipant.id
-        );
+      const participantRequest = createParticipantRequest(relatedUser.email, relatedParticipant.id);
 
-        await checkParticipantId(participantRequest, res, next);
+      await hasParticipantAccess(participantRequest, res, next);
 
-        expect(res.status).not.toHaveBeenCalled();
-        expect(next).toHaveBeenCalled();
-      });
-
-      it('should return 404 if participant is not found', async () => {
-        const relatedParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({
-          participantToRoles: [{ participantId: relatedParticipant.id }],
-        });
-        const nonExistentParticipantId = 2;
-        const participantRequest = createParticipantRequest(
-          relatedUser.email,
-          nonExistentParticipantId
-        );
-
-        await checkParticipantId(participantRequest, res, next);
-
-        expect(res.status).toHaveBeenCalledWith(404);
-        expect(res.send).toHaveBeenCalledWith([{ message: 'The participant cannot be found.' }]);
-      });
-
-      it('should return 403 if user does not have access to participant', async () => {
-        const firstParticipant = await createParticipant(knex, {});
-        const secondParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({
-          participantToRoles: [
-            {
-              participantId: secondParticipant.id,
-            },
-          ],
-        });
-        const participantRequest = createParticipantRequest(relatedUser.email, firstParticipant.id);
-
-        await checkParticipantId(participantRequest, res, next);
-
-        expect(res.status).toHaveBeenCalledWith(403);
-        expect(res.send).toHaveBeenCalledWith([
-          { message: 'You do not have permission to that participant.' },
-        ]);
-      });
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
     });
-    // TODO: these will change in UID2-2822
-    describe(`when participantId is 'current'`, () => {
-      it('should call next if user has a valid participant', async () => {
-        const relatedParticipant = await createParticipant(knex, {});
-        const relatedUser = await createUser({
-          participantToRoles: [
-            {
-              participantId: relatedParticipant.id,
-            },
-          ],
-        });
-        const participantRequest = createParticipantRequest(relatedUser.email, 'current');
-
-        await checkParticipantId(participantRequest, res, next);
-
-        expect(res.status).not.toHaveBeenCalled();
-        expect(next).toHaveBeenCalled();
+    it('should call next if user is UID2 support, even if user does not belong to participant', async () => {
+      const firstParticipant = await createParticipant(knex, {});
+      const secondParticipant = await createParticipant(knex, {});
+      const uid2SupportUser = await createUser({
+        participantToRoles: [
+          { participantId: firstParticipant.id, userRoleId: UserRoleId.UID2Support },
+        ],
       });
-      it('should return 404 is user is not found', async () => {
-        const participantRequest = createParticipantRequest('doesNotMatter@example.com', 'current');
+      const participantRequest = createParticipantRequest(
+        uid2SupportUser.email,
+        secondParticipant.id
+      );
 
-        await checkParticipantId(participantRequest, res, next);
-        expect(res.status).toHaveBeenCalledWith(404);
-        expect(res.send).toHaveBeenCalledWith([{ message: 'The user cannot be found.' }]);
-      });
-      it('should return 404 is participant is not found', async () => {
-        const relatedUser = await createUser({});
-        const participantRequest = createParticipantRequest(relatedUser.email, 'current');
+      await hasParticipantAccess(participantRequest, res, next);
 
-        await checkParticipantId(participantRequest, res, next);
-        expect(res.status).toHaveBeenCalledWith(404);
-        expect(res.send).toHaveBeenCalledWith([{ message: 'The participant cannot be found.' }]);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return 404 if participant is not found', async () => {
+      const relatedParticipant = await createParticipant(knex, {});
+      const relatedUser = await createUser({
+        participantToRoles: [{ participantId: relatedParticipant.id }],
       });
+      const nonExistentParticipantId = 2;
+      const participantRequest = createParticipantRequest(
+        relatedUser.email,
+        nonExistentParticipantId
+      );
+
+      await hasParticipantAccess(participantRequest, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.send).toHaveBeenCalledWith([{ message: 'The participant cannot be found.' }]);
+    });
+
+    it('should return 403 if user does not have access to participant', async () => {
+      const firstParticipant = await createParticipant(knex, {});
+      const secondParticipant = await createParticipant(knex, {});
+      const relatedUser = await createUser({
+        participantToRoles: [
+          {
+            participantId: secondParticipant.id,
+          },
+        ],
+      });
+      const participantRequest = createParticipantRequest(relatedUser.email, firstParticipant.id);
+
+      await hasParticipantAccess(participantRequest, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.send).toHaveBeenCalledWith([
+        { message: 'You do not have permission to that participant.' },
+      ]);
     });
   });
 });

--- a/src/api/middleware/tests/participantsMiddleware.spec.ts
+++ b/src/api/middleware/tests/participantsMiddleware.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../testHelpers/apiTestHelpers';
 import { UserRoleId } from '../../entities/UserRole';
 import { ParticipantRequest } from '../../services/participantsService';
-import { hasParticipantAccess } from '../participantsMiddleware';
+import { verifyAndEnrichParticipant } from '../participantsMiddleware';
 
 const createParticipantRequest = (
   email: string,
@@ -27,7 +27,7 @@ const createParticipantRequest = (
   } as unknown as ParticipantRequest;
 };
 
-describe('Participant Service Tests', () => {
+describe('Participant Middleware Tests', () => {
   let knex: Knex;
   let next: NextFunction;
   let res: Response;
@@ -37,73 +37,71 @@ describe('Participant Service Tests', () => {
     next = jest.fn();
     ({ res } = createResponseObject());
   });
-  describe('hasParticipantAccess middleware', () => {
-    it('should call next if participantId is valid and user belongs to participant', async () => {
-      const relatedParticipant = await createParticipant(knex, {});
-      const relatedUser = await createUser({
-        participantToRoles: [{ participantId: relatedParticipant.id }],
-      });
-      const participantRequest = createParticipantRequest(relatedUser.email, relatedParticipant.id);
-
-      await hasParticipantAccess(participantRequest, res, next);
-
-      expect(res.status).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
+  it('should call next if participantId is valid and user belongs to participant', async () => {
+    const relatedParticipant = await createParticipant(knex, {});
+    const relatedUser = await createUser({
+      participantToRoles: [{ participantId: relatedParticipant.id }],
     });
-    it('should call next if user is UID2 support, even if user does not belong to participant', async () => {
-      const firstParticipant = await createParticipant(knex, {});
-      const secondParticipant = await createParticipant(knex, {});
-      const uid2SupportUser = await createUser({
-        participantToRoles: [
-          { participantId: firstParticipant.id, userRoleId: UserRoleId.UID2Support },
-        ],
-      });
-      const participantRequest = createParticipantRequest(
-        uid2SupportUser.email,
-        secondParticipant.id
-      );
+    const participantRequest = createParticipantRequest(relatedUser.email, relatedParticipant.id);
 
-      await hasParticipantAccess(participantRequest, res, next);
+    await verifyAndEnrichParticipant(participantRequest, res, next);
 
-      expect(res.status).not.toHaveBeenCalled();
-      expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+  it('should call next if user is UID2 support, even if user does not belong to participant', async () => {
+    const firstParticipant = await createParticipant(knex, {});
+    const secondParticipant = await createParticipant(knex, {});
+    const uid2SupportUser = await createUser({
+      participantToRoles: [
+        { participantId: firstParticipant.id, userRoleId: UserRoleId.UID2Support },
+      ],
     });
+    const participantRequest = createParticipantRequest(
+      uid2SupportUser.email,
+      secondParticipant.id
+    );
 
-    it('should return 404 if participant is not found', async () => {
-      const relatedParticipant = await createParticipant(knex, {});
-      const relatedUser = await createUser({
-        participantToRoles: [{ participantId: relatedParticipant.id }],
-      });
-      const nonExistentParticipantId = 2;
-      const participantRequest = createParticipantRequest(
-        relatedUser.email,
-        nonExistentParticipantId
-      );
+    await verifyAndEnrichParticipant(participantRequest, res, next);
 
-      await hasParticipantAccess(participantRequest, res, next);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
 
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.send).toHaveBeenCalledWith([{ message: 'The participant cannot be found.' }]);
+  it('should return 404 if participant is not found', async () => {
+    const relatedParticipant = await createParticipant(knex, {});
+    const relatedUser = await createUser({
+      participantToRoles: [{ participantId: relatedParticipant.id }],
     });
+    const nonExistentParticipantId = 2;
+    const participantRequest = createParticipantRequest(
+      relatedUser.email,
+      nonExistentParticipantId
+    );
 
-    it('should return 403 if user does not have access to participant', async () => {
-      const firstParticipant = await createParticipant(knex, {});
-      const secondParticipant = await createParticipant(knex, {});
-      const relatedUser = await createUser({
-        participantToRoles: [
-          {
-            participantId: secondParticipant.id,
-          },
-        ],
-      });
-      const participantRequest = createParticipantRequest(relatedUser.email, firstParticipant.id);
+    await verifyAndEnrichParticipant(participantRequest, res, next);
 
-      await hasParticipantAccess(participantRequest, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith([{ message: 'The participant cannot be found.' }]);
+  });
 
-      expect(res.status).toHaveBeenCalledWith(403);
-      expect(res.send).toHaveBeenCalledWith([
-        { message: 'You do not have permission to that participant.' },
-      ]);
+  it('should return 403 if user does not have access to participant', async () => {
+    const firstParticipant = await createParticipant(knex, {});
+    const secondParticipant = await createParticipant(knex, {});
+    const relatedUser = await createUser({
+      participantToRoles: [
+        {
+          participantId: secondParticipant.id,
+        },
+      ],
     });
+    const participantRequest = createParticipantRequest(relatedUser.email, firstParticipant.id);
+
+    await verifyAndEnrichParticipant(participantRequest, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalledWith([
+      { message: 'You do not have permission to that participant.' },
+    ]);
   });
 });

--- a/src/api/middleware/tests/usersMiddleware.spec.ts
+++ b/src/api/middleware/tests/usersMiddleware.spec.ts
@@ -24,7 +24,7 @@ const createUserRequest = (email: string, userId: string | number): UserRequest 
   } as unknown as UserRequest;
 };
 
-describe('User Service Tests', () => {
+describe('User Middleware Tests', () => {
   let knex: Knex;
   let next: NextFunction;
   let res: Response;

--- a/src/api/middleware/usersMiddleware.ts
+++ b/src/api/middleware/usersMiddleware.ts
@@ -72,7 +72,7 @@ export const enrichWithUserFromParams = async (
   const requestingUserEmail = req.auth?.payload?.email as string;
   const isRequestingUserUid2Support = await isUid2Support(requestingUserEmail);
 
-  // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-2822
+  // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-3989
   const firstParticipant = user.participants?.[0] as Participant;
 
   const canRequestingUserAccessParticipant =

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -15,7 +15,7 @@ import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { isApproverCheck } from '../../middleware/approversMiddleware';
-import { checkParticipantId } from '../../middleware/participantsMiddleware';
+import { hasParticipantAccess } from '../../middleware/participantsMiddleware';
 import { enrichCurrentUser } from '../../middleware/usersMiddleware';
 import {
   addKeyPair,
@@ -210,7 +210,13 @@ export function createParticipantsRouter() {
 
   participantsRouter.put('/', createParticipant);
 
-  participantsRouter.use('/:participantId', checkParticipantId);
+  participantsRouter.use('/:participantId', hasParticipantAccess);
+
+  participantsRouter.get('/:participantId', async (req: ParticipantRequest, res: Response) => {
+    const { participant } = req;
+
+    return res.status(200).json(participant);
+  });
 
   const invitationParser = z.object({
     firstName: z.string(),

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -15,7 +15,7 @@ import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { isApproverCheck } from '../../middleware/approversMiddleware';
-import { hasParticipantAccess } from '../../middleware/participantsMiddleware';
+import { verifyAndEnrichParticipant } from '../../middleware/participantsMiddleware';
 import { enrichCurrentUser } from '../../middleware/usersMiddleware';
 import {
   addKeyPair,
@@ -210,7 +210,7 @@ export function createParticipantsRouter() {
 
   participantsRouter.put('/', createParticipant);
 
-  participantsRouter.use('/:participantId', hasParticipantAccess);
+  participantsRouter.use('/:participantId', verifyAndEnrichParticipant);
 
   participantsRouter.get('/:participantId', async (req: ParticipantRequest, res: Response) => {
     const { participant } = req;

--- a/src/api/services/auditTrailService.ts
+++ b/src/api/services/auditTrailService.ts
@@ -9,7 +9,7 @@ export const constructAuditTrailObject = (
   event: AuditTrailEvents,
   eventData: unknown
 ): InsertAuditTrailDTO => {
-  // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-2822
+  // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-3989
   const currentParticipant = user.participants?.[0];
   return {
     userId: user.id,

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -41,7 +41,7 @@ export class UserService {
   }
 
   public async getCurrentParticipant(req: UserRequest) {
-    // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-2822
+    // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-3989
     const currentParticipant = req.user?.participants?.[0];
     const currentSite = !currentParticipant?.siteId
       ? undefined

--- a/src/web/screens/emailContacts.tsx
+++ b/src/web/screens/emailContacts.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useContext } from 'react';
 import { useRevalidator } from 'react-router-dom';
 import { defer, useLoaderData } from 'react-router-typesafe';
 
@@ -6,12 +6,13 @@ import BusinessContactsTable from '../components/BusinessContacts/BusinessContac
 import { Loading } from '../components/Core/Loading/Loading';
 import { SuccessToast } from '../components/Core/Popups/Toast';
 import { ScreenContentContainer } from '../components/Core/ScreenContentContainer/ScreenContentContainer';
+import { ParticipantContext } from '../contexts/ParticipantProvider';
 import {
   AddEmailContact,
   BusinessContactForm,
   GetEmailContacts,
   RemoveEmailContact,
-  UpdateEmailContact
+  UpdateEmailContact,
 } from '../services/participant';
 import { handleErrorToast } from '../utils/apiError';
 import { AwaitTypesafe } from '../utils/AwaitTypesafe';
@@ -28,11 +29,12 @@ const loader = makeParticipantLoader((participantId) => {
 
 export function BusinessContacts() {
   const data = useLoaderData<typeof loader>();
+  const { participant } = useContext(ParticipantContext);
   const reloader = useRevalidator();
 
   const handleRemoveEmailContact = async (contactId: number) => {
     try {
-      const response = await RemoveEmailContact(contactId);
+      const response = await RemoveEmailContact(contactId, participant!.id);
       if (response.status === 200) {
         SuccessToast('Email contact removed.');
       }
@@ -44,7 +46,7 @@ export function BusinessContacts() {
 
   const handleUpdateEmailContact = async (contactId: number, formData: BusinessContactForm) => {
     try {
-      const response = await UpdateEmailContact(contactId, formData);
+      const response = await UpdateEmailContact(contactId, formData, participant!.id);
       if (response.status === 200) {
         SuccessToast('Email contact updated.');
       }
@@ -56,7 +58,7 @@ export function BusinessContacts() {
 
   const handleAddEmailContact = async (formData: BusinessContactForm) => {
     try {
-      const response = await AddEmailContact(formData);
+      const response = await AddEmailContact(formData, participant!.id);
       if (response.status === 201) {
         SuccessToast('Email contact added.');
       }

--- a/src/web/screens/homeRedirector.tsx
+++ b/src/web/screens/homeRedirector.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { GetCurrentUsersParticipant } from '../services/participant';
+import { GetUsersDefaultParticipant } from '../services/participant';
 
 export function HomeRedirector() {
   const navigate = useNavigate();
@@ -9,7 +9,7 @@ export function HomeRedirector() {
 
   useEffect(() => {
     const loadParticipant = async () => {
-      const currentParticipant = await GetCurrentUsersParticipant();
+      const currentParticipant = await GetUsersDefaultParticipant();
       navigate(`/participant/${currentParticipant.id}/home`);
     };
     if (!participantId) {

--- a/src/web/screens/manageParticipants.tsx
+++ b/src/web/screens/manageParticipants.tsx
@@ -16,8 +16,8 @@ import {
   AddParticipantForm,
   ApproveParticipantRequest,
   GetApprovedParticipants,
-  GetCurrentUsersParticipant,
   GetParticipantsAwaitingApproval,
+  GetUsersDefaultParticipant,
   ParticipantApprovalFormDetails,
   UpdateParticipant,
   UpdateParticipantForm,
@@ -66,7 +66,7 @@ function ManageParticipants() {
     await UpdateParticipant(form, updatedParticipant.id);
     // if updating the current user's participant, update the ParticipantContext
     if (updatedParticipant.id === participant?.id) {
-      const p = await GetCurrentUsersParticipant();
+      const p = await GetUsersDefaultParticipant();
       setParticipant(p);
     }
     SuccessToast('Participant updated');

--- a/src/web/services/apiKeyService.ts
+++ b/src/web/services/apiKeyService.ts
@@ -29,11 +29,11 @@ export type EditApiKeyFormDTO = {
 
 export async function CreateApiKey(
   form: CreateApiKeyFormDTO,
-  participantId?: number
+  participantId: number
 ): Promise<ApiKeySecretsDTO> {
   try {
     const result = await axios.post<ApiKeySecretsDTO>(
-      `/participants/${participantId ?? 'current'}/apiKey`,
+      `/participants/${participantId}/apiKey`,
       form
     );
     return result.data;
@@ -42,17 +42,17 @@ export async function CreateApiKey(
   }
 }
 
-export async function EditApiKey(form: EditApiKeyFormDTO, participantId?: number) {
+export async function EditApiKey(form: EditApiKeyFormDTO, participantId: number) {
   try {
-    await axios.put(`/participants/${participantId ?? 'current'}/apiKey`, form);
+    await axios.put(`/participants/${participantId}/apiKey`, form);
   } catch (e: unknown) {
     throw backendError(e, 'Could not edit API Key');
   }
 }
 
-export async function DisableApiKey(apiKey: ApiKeyDTO, participantId?: number) {
+export async function DisableApiKey(apiKey: ApiKeyDTO, participantId: number) {
   try {
-    await axios.delete(`/participants/${participantId ?? 'current'}/apiKey`, {
+    await axios.delete(`/participants/${participantId}/apiKey`, {
       data: { keyId: apiKey.key_id },
     });
   } catch (e: unknown) {

--- a/src/web/services/appIdsService.ts
+++ b/src/web/services/appIdsService.ts
@@ -10,10 +10,10 @@ export type EditAppIdFormProps = {
   appId: string;
 };
 
-export async function GetAppIds(participantId?: number) {
+export async function GetAppIds(participantId: number) {
   try {
     const result = await axios.get<string[]>(
-      `/participants/${participantId ?? 'current'}/appNames`
+      `/participants/${participantId}/appNames`
     );
     return result.data;
   } catch (e: unknown) {
@@ -21,10 +21,10 @@ export async function GetAppIds(participantId?: number) {
   }
 }
 
-export async function UpdateAppIds(appNames: string[], participantId?: number): Promise<string[]> {
+export async function UpdateAppIds(appNames: string[], participantId: number): Promise<string[]> {
   try {
     const result = await axios.post<string[]>(
-      `/participants/${participantId ?? 'current'}/appNames`,
+      `/participants/${participantId}/appNames`,
       {
         appNames,
       }

--- a/src/web/services/domainNamesService.ts
+++ b/src/web/services/domainNamesService.ts
@@ -11,10 +11,10 @@ export type EditDomainFormProps = {
   domainName: string;
 };
 
-export async function GetDomainNames(participantId?: number) {
+export async function GetDomainNames(participantId: number) {
   try {
     const result = await axios.get<string[]>(
-      `/participants/${participantId ?? 'current'}/domainNames`
+      `/participants/${participantId}/domainNames`
     );
     if (result.status === 200) {
       return result.data;
@@ -26,11 +26,11 @@ export async function GetDomainNames(participantId?: number) {
 
 export async function UpdateDomainNames(
   domainNames: string[],
-  participantId?: number
+  participantId: number
 ): Promise<UpdateCstgValuesResponse> {
   try {
     const result = await axios.post<string[]>(
-      `/participants/${participantId ?? 'current'}/domainNames`,
+      `/participants/${participantId}/domainNames`,
       {
         domainNames,
       }

--- a/src/web/services/keyPairService.ts
+++ b/src/web/services/keyPairService.ts
@@ -5,22 +5,18 @@ import { KeyPairModel, mapKeyPairDTOToModel } from '../components/KeyPairs/KeyPa
 import { backendError } from '../utils/apiError';
 
 export type AddKeyPairFormProps = {
-  participantId?: number;
   name?: string;
 };
 
 export type UpdateKeyPairFormProps = {
-  participantId?: number;
   name?: string;
   subscriptionId: string;
   disabled: boolean;
 };
 
-export async function GetKeyPairs(participantId?: number) {
+export async function GetKeyPairs(participantId: number) {
   try {
-    const result = await axios.get<KeyPairDTO[]>(
-      `/participants/${participantId ?? 'current'}/keyPairs`
-    );
+    const result = await axios.get<KeyPairDTO[]>(`/participants/${participantId}/keyPairs`);
 
     return result.data.map(mapKeyPairDTOToModel);
   } catch (e: unknown) {
@@ -28,23 +24,18 @@ export async function GetKeyPairs(participantId?: number) {
   }
 }
 
-export async function AddKeyPair(props: AddKeyPairFormProps) {
-  const { participantId } = props;
-  const result = await axios.post(`/participants/${participantId ?? 'current'}/keyPair/add`, props);
+export async function AddKeyPair(props: AddKeyPairFormProps, participantId: number) {
+  const result = await axios.post(`/participants/${participantId}/keyPair/add`, props);
   return result;
 }
 
-export async function UpdateKeyPair(props: UpdateKeyPairFormProps) {
-  const { participantId } = props;
-  const result = await axios.post(
-    `/participants/${participantId ?? 'current'}/keyPair/update`,
-    props
-  );
+export async function UpdateKeyPair(props: UpdateKeyPairFormProps, participantId: number) {
+  const result = await axios.post(`/participants/${participantId}/keyPair/update`, props);
   return result;
 }
 
-export async function DisableKeyPair(keyPair: KeyPairModel, participantId?: number) {
-  await axios.delete(`/participants/${participantId ?? 'current'}/keyPair`, {
+export async function DisableKeyPair(keyPair: KeyPairModel, participantId: number) {
+  await axios.delete(`/participants/${participantId}/keyPair`, {
     data: { keyPair },
   });
 }

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -73,7 +73,7 @@ export async function CreateParticipant(formData: CreateParticipantForm, user: K
   }
 }
 
-export async function GetCurrentUsersParticipant() {
+export async function GetUsersDefaultParticipant() {
   try {
     const result = await axios.get<ParticipantDTO>(`/users/current/participant`, {
       validateStatus: (status) => status === 200,
@@ -117,35 +117,29 @@ export async function GetSignedParticipants() {
   }
 }
 
-export async function GetParticipantApiKeys(participantId?: number) {
+export async function GetParticipantApiKeys(participantId: number) {
   try {
-    const result = await axios.get<ApiKeyDTO[]>(
-      `/participants/${participantId ?? 'current'}/apiKeys`
-    );
-
+    const result = await axios.get<ApiKeyDTO[]>(`/participants/${participantId}/apiKeys`);
     return result.data;
   } catch (e: unknown) {
     throw backendError(e, 'Could not get participant API Keys');
   }
 }
 
-export async function GetParticipantApiKey(keyId: string, participantId?: number) {
+export async function GetParticipantApiKey(keyId: string, participantId: number) {
   try {
-    const result = await axios.get<ApiKeyDTO>(
-      `/participants/${participantId ?? 'current'}/apiKey`,
-      { params: { keyId } }
-    );
+    const result = await axios.get<ApiKeyDTO>(`/participants/${participantId}/apiKey`, {
+      params: { keyId },
+    });
     return result.data;
   } catch (e: unknown) {
     throw backendError(e, 'Could not get API Key');
   }
 }
 
-export async function GetParticipantApiRoles(participantId?: number) {
+export async function GetParticipantApiRoles(participantId: number) {
   try {
-    const result = await axios.get<ApiRoleDTO[]>(
-      `/participants/${participantId ?? 'current'}/apiRoles`
-    );
+    const result = await axios.get<ApiRoleDTO[]>(`/participants/${participantId}/apiRoles`);
 
     return result.data;
   } catch (e: unknown) {
@@ -155,6 +149,17 @@ export async function GetParticipantApiRoles(participantId?: number) {
 
 export async function InviteTeamMember(formData: InviteTeamMemberForm, participantId: number) {
   return axios.post(`/participants/${participantId}/invite`, formData);
+}
+
+export async function GetSelectedParticipant(participantId: number) {
+  try {
+    const result = await axios.get<ParticipantDTO>(`/participants/${participantId}`, {
+      validateStatus: (status) => status === 200,
+    });
+    return result.data;
+  } catch (e: unknown) {
+    throw backendError(e, 'Could not get participant');
+  }
 }
 
 export type UpdateParticipantForm = {
@@ -187,9 +192,9 @@ export async function AddParticipant(formData: AddParticipantForm) {
   return response;
 }
 
-export async function UpdateParticipant(formData: UpdateParticipantForm, participantId?: number) {
+export async function UpdateParticipant(formData: UpdateParticipantForm, participantId: number) {
   try {
-    await axios.put(`/participants/${participantId ?? 'current'}`, formData);
+    await axios.put(`/participants/${participantId}`, formData);
   } catch (e: unknown) {
     throw backendError(e, 'Could not update participant');
   }
@@ -198,16 +203,16 @@ export async function UpdateParticipant(formData: UpdateParticipantForm, partici
 export async function CompleteRecommendations(participantId: number): Promise<ParticipantDTO> {
   try {
     await axios.put<ParticipantDTO>(`/participants/${participantId}/completeRecommendations`);
-    const result = await GetCurrentUsersParticipant();
+    const result = await GetUsersDefaultParticipant();
     return result;
   } catch (e: unknown) {
     throw backendError(e, 'Could not update participant');
   }
 }
 
-export async function GetSharingList(participantId?: number): Promise<SharingListResponse> {
+export async function GetSharingList(participantId: number): Promise<SharingListResponse> {
   const result = await axios.get<SharingListResponse>(
-    `/participants/${participantId ?? 'current'}/sharingPermission`
+    `/participants/${participantId}/sharingPermission`
   );
   return result.data;
 }
@@ -271,21 +276,18 @@ export type BusinessContactForm = {
   contactType: string;
 };
 
-export async function AddEmailContact(formData: BusinessContactForm, participantId?: number) {
+export async function AddEmailContact(formData: BusinessContactForm, participantId: number) {
   try {
-    return await axios.post(
-      `/participants/${participantId ?? 'current'}/businessContacts`,
-      formData
-    );
+    return await axios.post(`/participants/${participantId}/businessContacts`, formData);
   } catch (e: unknown) {
     throw backendError(e, 'Could not add email contact');
   }
 }
 
-export async function GetEmailContacts(participantId?: number) {
+export async function GetEmailContacts(participantId: number) {
   try {
     const result = await axios.get<BusinessContactResponse[]>(
-      `/participants/${participantId ?? 'current'}/businessContacts`
+      `/participants/${participantId}/businessContacts`
     );
     return result.data;
   } catch (e: unknown) {
@@ -293,11 +295,9 @@ export async function GetEmailContacts(participantId?: number) {
   }
 }
 
-export async function RemoveEmailContact(contactId: number, participantId?: number) {
+export async function RemoveEmailContact(contactId: number, participantId: number) {
   try {
-    return await axios.delete(
-      `/participants/${participantId ?? 'current'}/businessContacts/${contactId}`
-    );
+    return await axios.delete(`/participants/${participantId}/businessContacts/${contactId}`);
   } catch (e: unknown) {
     throw backendError(e, 'Could not delete email contact');
   }
@@ -306,11 +306,11 @@ export async function RemoveEmailContact(contactId: number, participantId?: numb
 export async function UpdateEmailContact(
   contactId: number,
   formData: BusinessContactForm,
-  participantId?: number
+  participantId: number
 ) {
   try {
     return await axios.put(
-      `/participants/${participantId ?? 'current'}/businessContacts/${contactId}`,
+      `/participants/${participantId}/businessContacts/${contactId}`,
       formData
     );
   } catch (e: unknown) {

--- a/src/web/services/userAccount.ts
+++ b/src/web/services/userAccount.ts
@@ -73,10 +73,10 @@ export async function SelfResendInvitation(formData: SelfResendInvitationForm): 
   }
 }
 
-export async function GetAllUsersOfParticipant(participantId?: number) {
+export async function GetAllUsersOfParticipant(participantId: number) {
   try {
     const result = await axios.get<UserResponse[]>(
-      `/participants/${participantId ?? 'current'}/users`,
+      `/participants/${participantId}/users`,
       {
         validateStatus: (status) => [200, 404].includes(status),
       }
@@ -87,6 +87,7 @@ export async function GetAllUsersOfParticipant(participantId?: number) {
   }
 }
 
+// TODO: make this only remove the user from the given participant in UID2-3852
 export async function RemoveUser(id: number) {
   try {
     return await axios.delete(`/users/${id}`);

--- a/src/web/utils/loaderHelpers.ts
+++ b/src/web/utils/loaderHelpers.ts
@@ -16,6 +16,6 @@ export const makeParticipantLoader = <T extends ReturnType<typeof defer>>(
 ) => {
   return makeLoader((args: LoaderFunctionArgs) => {
     const participantId = parseParticipantId(args.params.participantId);
-    return loaderFn(participantId, args);
+    return loaderFn(participantId!, args);
   });
 };

--- a/src/web/utils/urlHelpers.ts
+++ b/src/web/utils/urlHelpers.ts
@@ -1,10 +1,10 @@
 export const parseParticipantId = (participantId: string | undefined) => {
   if (!participantId) {
-    throw new Error('Participant ID is not defined');
+    return undefined;
   }
   const result = parseInt(participantId, 10);
   if (isNaN(result)) {
-    throw new Error('Participant ID is not a valid number');
+    return undefined;
   }
   return result;
 };


### PR DESCRIPTION
## What changed
- General idea: use `useParams()` hook to get `participantId` then populate the ParticipantContext. Then use the ParticipantContext from then on (rather than relying on 'current' or calling `useParams()` from every screen)
- Participant ID is never provided on initial log in, hence why we need to keep the call to `GetUsersDefaultParticipant()`
- Make `participantId` a required parameter where it used to be optional
- Remove support for 'current' in the participant middleware. Refactor to make it more readable. Remove unnecessary tests
- Update some TODOs

## Manual testing
1. Change the participantId in the URL to another participant you have access to (i.e. not the first participant for your user in the `usersToParticipantRoles` table). Access comes for free if you have the UID2 Support role:
    ```
    insert into dbo.userstoParticipantRoles (userId, participantId, userRoleId) values (<your userID>, <your participantId>, 3)
    ```
3. Perform operations in the portal, e.g. creating/editing API keys, modifying client side integration config, adding team members, etc.
4. Note all the API calls are using the participantId you currently have selected (via the URL), rather than just the first participant that your user belongs to.

## Quick demo

https://github.com/user-attachments/assets/a8a39f08-7e5a-4dec-a6ec-657773e10b6d


