### PR TITLE
Move some user routers to participant/user routes

### DIFF
--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -90,11 +90,6 @@ export class UserController {
     res.sendStatus(200);
   }
 
-  @httpGet('/:userId')
-  public async getUserById(@request() req: UserRequest, @response() res: Response): Promise<void> {
-    res.status(200).json(req.user);
-  }
-
   @httpPost('/:userId/resendInvitation')
   public async resendInvitation(
     @request() req: UserRequest,

--- a/src/api/routers/participantUsersRouter.ts
+++ b/src/api/routers/participantUsersRouter.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+
+import { UserController } from '../controllers/userController';
+import { enrichWithUserFromParams } from '../middleware/usersMiddleware';
+import { LoggerService } from '../services/loggerService';
+import { UserService } from '../services/userService';
+
+const createParticipantUsersRouter = () => {
+  const participantUsersRouter = express.Router({ mergeParams: true });
+  const userController = new UserController(new UserService(), new LoggerService());
+
+  participantUsersRouter.use('/:userId', enrichWithUserFromParams);
+  participantUsersRouter.post(
+    '/:userId/resendInvitation',
+    userController.resendInvitation.bind(userController)
+  );
+  participantUsersRouter.delete('/:userId', userController.deleteUser.bind(userController));
+  participantUsersRouter.patch('/:userId', userController.updateUser.bind(userController));
+
+  return participantUsersRouter;
+};
+
+export { createParticipantUsersRouter };

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -66,6 +66,7 @@ import {
   getAllUserFromParticipant,
 } from '../../services/usersService';
 import { createBusinessContactsRouter } from '../businessContactsRouter';
+import { createParticipantUsersRouter } from '../participantUsersRouter';
 import { getParticipantAppNames, setParticipantAppNames } from './participantsAppIds';
 import { createParticipant, createParticipantFromRequest } from './participantsCreation';
 import { getParticipantDomainNames, setParticipantDomainNames } from './participantsDomainNames';
@@ -724,6 +725,9 @@ export function createParticipantsRouter() {
   );
 
   participantsRouter.get('/:participantId/users', getParticipantUsers);
+
+  const participantUsersRouter = createParticipantUsersRouter();
+  participantsRouter.use('/:participantId/users', participantUsersRouter);
 
   const businessContactsRouter = createBusinessContactsRouter();
   participantsRouter.use('/:participantId/businessContacts', businessContactsRouter);

--- a/src/api/routers/usersRouter.ts
+++ b/src/api/routers/usersRouter.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 
 import { UserController } from '../controllers/userController';
-import { enrichCurrentUser, enrichWithUserFromParams } from '../middleware/usersMiddleware';
+import { enrichCurrentUser } from '../middleware/usersMiddleware';
 import { LoggerService } from '../services/loggerService';
 import { UserService } from '../services/userService';
 
@@ -20,14 +20,6 @@ const createUsersRouter = () => {
     '/selfResendInvitation',
     userController.selfResendInvitation.bind(userController)
   );
-  usersRouter.use('/:userId', enrichWithUserFromParams);
-  usersRouter.get('/:userId', userController.getUserById.bind(userController));
-  usersRouter.post(
-    '/:userId/resendInvitation',
-    userController.resendInvitation.bind(userController)
-  );
-  usersRouter.delete('/:userId', userController.deleteUser.bind(userController));
-  usersRouter.patch('/:userId', userController.updateUser.bind(userController));
 
   return usersRouter;
 };

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
 import log from 'loglevel';
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { UserDTO } from '../../../api/entities/User';
+import { ParticipantContext } from '../../contexts/ParticipantProvider';
 import { UpdateTeamMemberForm, UserResponse } from '../../services/userAccount';
 import { handleErrorToast } from '../../utils/apiError';
 import ActionButton from '../Core/Buttons/ActionButton';
@@ -14,7 +15,7 @@ import TeamMemberDialog from './TeamMemberDialog';
 type TeamMemberProps = Readonly<{
   existingTeamMembers: UserDTO[];
   person: UserResponse;
-  resendInvite: (id: number) => Promise<void>;
+  resendInvite: (id: number, participantId: number) => Promise<void>;
   onRemoveTeamMember: (id: number) => Promise<void>;
   onUpdateTeamMember: (id: number, form: UpdateTeamMemberForm) => Promise<void>;
 }>;
@@ -36,7 +37,7 @@ function TeamMember({
   const [errorMessage, setErrorMessage] = useState<string>();
   const [showTeamMemberDialog, setShowTeamMemberDialog] = useState<boolean>();
   const [showDeleteTeamMemberDialog, setShowDeleteTeamMemberDialog] = useState<boolean>();
-
+  const { participant } = useContext(ParticipantContext);
   const setErrorInfo = (e: Error) => {
     setErrorMessage(e.message);
   };
@@ -57,7 +58,7 @@ function TeamMember({
 
     setInviteState(InviteState.inProgress);
     try {
-      await resendInvite(person.id);
+      await resendInvite(person.id, participant!.id);
       SuccessToast('Invitation sent');
       setInviteState(InviteState.sent);
     } catch (e) {
@@ -65,7 +66,7 @@ function TeamMember({
       setInviteState(InviteState.error);
       handleErrorToast(e);
     }
-  }, [person.id, reinviteState, resendInvite]);
+  }, [participant, person.id, reinviteState, resendInvite]);
 
   const handleRemoveUser = async () => {
     try {

--- a/src/web/components/TeamMember/TeamMembersTable.tsx
+++ b/src/web/components/TeamMember/TeamMembersTable.tsx
@@ -18,7 +18,7 @@ type TeamMembersTableProps = Readonly<{
   onAddTeamMember: (form: InviteTeamMemberForm) => Promise<void>;
   onRemoveTeamMember: (id: number) => Promise<void>;
   onUpdateTeamMember: (id: number, form: UpdateTeamMemberForm) => Promise<void>;
-  resendInvite: (id: number) => Promise<void>;
+  resendInvite: (id: number, participantId: number) => Promise<void>;
 }>;
 
 function TeamMembersTableContent({

--- a/src/web/screens/teamMembers.tsx
+++ b/src/web/screens/teamMembers.tsx
@@ -15,7 +15,7 @@ import {
   RemoveUser,
   ResendInvite,
   UpdateTeamMemberForm,
-  UpdateUser
+  UpdateUser,
 } from '../services/userAccount';
 import { handleErrorToast } from '../utils/apiError';
 import { AwaitTypesafe } from '../utils/AwaitTypesafe';
@@ -48,7 +48,7 @@ function TeamMembers() {
 
   const handleRemoveTeamMember = async (userId: number) => {
     try {
-      const response = await RemoveUser(userId);
+      const response = await RemoveUser(userId, participant!.id);
       if (response.status === 200) {
         SuccessToast('Team member removed.');
       }
@@ -60,7 +60,7 @@ function TeamMembers() {
 
   const handleUpdateTeamMember = async (userId: number, formData: UpdateTeamMemberForm) => {
     try {
-      const response = await UpdateUser(userId, formData);
+      const response = await UpdateUser(userId, formData, participant!.id);
       if (response.status === 200) {
         SuccessToast('Team member updated.');
       }


### PR DESCRIPTION
- Change a few user routes to be participantUser routes (of the form `/participants/:participantId/users/:userId`). Move these from usersRouter to participantUsersRouter - add this as a subrouter to the participantsRouter. Actual functionality of the endpoints is unchanged
- Pass participantId from front-end using `ParticipantContext`
- Remove an unused function & endpoint

## Manual testing
Perform resend invitation or delete/update user and notice the request URL is now of the form `http://localhost:3000/api/participants/8/users/7181` rather than `http://localhost:3000/api/users/7181`