### PR TITLE
Copy changes for root-level domains and mobile app IDs

### DIFF
--- a/src/web/components/ClientSideTokenGeneration/CstgAddDialog.spec.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDialog.spec.tsx
@@ -28,7 +28,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.Domain}
-        addInstructions='Add one or more domains.'
+        addInstructions=''
       />
     );
 
@@ -58,7 +58,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.Domain}
-        addInstructions='Add one or more domains.'
+        addInstructions=''
       />
     );
 
@@ -92,7 +92,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.Domain}
-        addInstructions='Add one or more domains.'
+        addInstructions=''
       />
     );
 
@@ -118,7 +118,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.Domain}
-        addInstructions='Add one or more domains.'
+        addInstructions=''
       />
     );
 
@@ -142,7 +142,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.Domain}
-        addInstructions='Add one or more domains.'
+        addInstructions=''
       />
     );
     await submitDialogDomains();
@@ -163,7 +163,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.MobileAppId}
-        addInstructions='Please register the Android App ID, iOS/tvOS Bundle ID and iOS App Store ID.'
+        addInstructions=''
       />
     );
 
@@ -193,7 +193,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.MobileAppId}
-        addInstructions='Please register the Android App ID, iOS/tvOS Bundle ID and iOS App Store ID.'
+        addInstructions=''
       />
     );
 
@@ -227,7 +227,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.MobileAppId}
-        addInstructions='Please register the Android App ID, iOS/tvOS Bundle ID and iOS App Store ID.'
+        addInstructions=''
       />
     );
 
@@ -253,7 +253,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.MobileAppId}
-        addInstructions='Please register the Android App ID, iOS/tvOS Bundle ID and iOS App Store ID.'
+        addInstructions=''
       />
     );
 
@@ -277,7 +277,7 @@ describe('CstgAddDialog', () => {
         onOpenChange={() => {}}
         existingCstgValues={[]}
         cstgValueType={CstgValueType.MobileAppId}
-        addInstructions='Please register the Android App ID, iOS/tvOS Bundle ID and iOS App Store ID.'
+        addInstructions=''
       />
     );
     await submitDialogMobileAppIds();

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDialog.tsx
@@ -38,6 +38,7 @@ function CstgAddDialog({
 }: CstgAddDialogProps) {
   const [deleteExistingList, setDeleteExistingList] = useState<boolean>(false);
   const formMethods = useForm<AddCstgValuesFormProps>();
+  const formattedCstgValueType = formatCstgValueType(cstgValueType);
   const {
     handleSubmit,
     setError,
@@ -58,7 +59,7 @@ function CstgAddDialog({
       deleteExistingList
     );
     if (newCstgValues.length === 0) {
-      handleError(`The ${formatCstgValueType(cstgValueType)}s entered already exist.`);
+      handleError(`The ${formattedCstgValueType}s entered already exist.`);
     } else if (cstgValueType === CstgValueType.Domain) {
       newCstgValues.forEach((newDomain, index) => {
         newCstgValues[index] = extractTopLevelDomain(newDomain);
@@ -110,12 +111,12 @@ function CstgAddDialog({
                 onClick={onClickCheckbox}
                 checked={deleteExistingList}
               />
-              <div className='checkbox-text'>{`Replace all existing ${formatCstgValueType(cstgValueType)}s with the new ones.`}</div>
+              <div className='checkbox-text'>{`Replace all existing ${formattedCstgValueType}s with the new ones.`}</div>
             </div>
             <MultilineTextInput
               inputName='cstgValues'
               label={`${cstgValueType}s`}
-              rules={{ required: `Please specify ${formatCstgValueType(cstgValueType)}s.` }}
+              rules={{ required: `Please specify ${formattedCstgValueType}s.` }}
               className='cstg-add-input'
             />
             <div className='form-footer'>

--- a/src/web/components/ClientSideTokenGeneration/CstgDeleteDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgDeleteDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '../Core/Dialog/Dialog';
-import { CstgValueType } from './CstgHelper';
+import { CstgValueType, formatCstgValueType } from './CstgHelper';
 
 import './CstgDeleteDialog.scss';
 
@@ -19,13 +19,14 @@ function DeleteConfirmationDialog({
   const handleRemove = () => {
     onRemoveCstgValues();
   };
+  const formattedCstgValueType = formatCstgValueType(cstgValueType);
 
   return (
     <Dialog
       title={`Are you sure you want to delete ${
         cstgValues.length > 1
-          ? `these ${cstgValueType.toLowerCase()}s`
-          : `this ${cstgValueType.toLowerCase()}`
+          ? `these ${formattedCstgValueType}s`
+          : `this ${formattedCstgValueType}`
       }?`}
       onOpenChange={onOpenChange}
       closeButtonText='Cancel'

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
@@ -43,7 +43,7 @@ function CstgEditDialog({
   const showInvalidError = () => {
     setError('root.serverError', {
       type: '400',
-      message: `Edited value is an invalid ${formattedCstgValueType}.`,
+      message: `The ${formattedCstgValueType} is invalid.`,
     });
   };
 

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
@@ -7,6 +7,7 @@ import {
   CstgValueType,
   EditCstgValuesFormProps,
   extractTopLevelDomain,
+  formatCstgValueType,
   validateAppId,
 } from './CstgHelper';
 
@@ -37,10 +38,12 @@ function CstgEditDialog({
     formState: { errors },
   } = formMethods;
 
+  const formattedCstgValueType = formatCstgValueType(cstgValueType);
+
   const showInvalidError = () => {
     setError('root.serverError', {
       type: '400',
-      message: `Edited value is an invalid ${cstgValueType.toLowerCase()}.`,
+      message: `Edited value is an invalid ${formattedCstgValueType}.`,
     });
   };
 
@@ -57,7 +60,7 @@ function CstgEditDialog({
     } else if (existingCstgValues.includes(updatedCstgValue)) {
       setError('root.serverError', {
         type: '400',
-        message: `${cstgValueType} already exists.`,
+        message: `The ${formattedCstgValueType} already exists.`,
       });
     }
     if (cstgValueType === CstgValueType.MobileAppId) {
@@ -85,7 +88,7 @@ function CstgEditDialog({
             inputName='cstgValue'
             label={`${cstgValueType}`}
             rules={{
-              required: `Please specify ${cstgValueType}.`,
+              required: `Please specify a ${formattedCstgValueType}.`,
             }}
           />
           <div className='form-footer'>

--- a/src/web/components/ClientSideTokenGeneration/CstgTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgTable.tsx
@@ -195,6 +195,8 @@ export function CstgTable({
     ? `Delete All ${cstgValueType}s`
     : deletingMultipleItemsMessage;
 
+  const formattedCstgValueType = formatCstgValueType(cstgValueType);
+
   return (
     <div className='cstg-values-management'>
       <div className='cstg-values-table-header'>
@@ -234,7 +236,7 @@ export function CstgTable({
               type='text'
               className='cstg-values-search-bar'
               onChange={handleSearchCstgValue}
-              placeholder={`Search ${formatCstgValueType(cstgValueType)}s`}
+              placeholder={`Search ${formattedCstgValueType}s`}
               value={searchText}
             />
             <FontAwesomeIcon icon='search' className='cstg-values-search-bar-icon' />
@@ -280,7 +282,7 @@ export function CstgTable({
       </table>
       {cstgValues.length !== 0 && searchText && !searchedCstgValues.length && (
         <TableNoDataPlaceholder title={`No ${cstgValueType}s`}>
-          <span>{`There are no ${formatCstgValueType(cstgValueType)}s that match this search.`}</span>
+          <span>{`There are no ${formattedCstgValueType}s that match this search.`}</span>
         </TableNoDataPlaceholder>
       )}
       {!!searchedCstgValues.length && (
@@ -294,7 +296,7 @@ export function CstgTable({
 
       {!cstgValues.length && (
         <TableNoDataPlaceholder title={`No ${cstgValueType}s`}>
-          <span>{`There are no ${formatCstgValueType(cstgValueType)}s.`}</span>
+          <span>{`There are no ${formattedCstgValueType}s.`}</span>
         </TableNoDataPlaceholder>
       )}
     </div>

--- a/src/web/components/ClientSideTokenGeneration/CstgTable.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgTable.tsx
@@ -20,10 +20,7 @@ import './CstgTable.scss';
 
 type CstgTableProps = Readonly<{
   cstgValues: string[];
-  onUpdateCstgValues: (
-    cstgValues: string[],
-    action: string
-  ) => Promise<UpdateCstgValuesResponse | undefined>;
+  onUpdateCstgValues: (cstgValues: string[]) => Promise<UpdateCstgValuesResponse | undefined>;
   onAddCstgValues: (
     newCstgValuesFormatted: string[],
     deleteExistingList: boolean,
@@ -85,8 +82,7 @@ export function CstgTable({
 
   const handleBulkDeleteCstgValues = async (deleteCstgValues: string[]) => {
     const newCstgValuesResponse = await onUpdateCstgValues(
-      cstgValues.filter((cstgValue) => !deleteCstgValues.includes(cstgValue)),
-      'deleted'
+      cstgValues.filter((cstgValue) => !deleteCstgValues.includes(cstgValue))
     );
     const newCstgValues = newCstgValuesResponse?.cstgValues;
     setShowDeleteDialog(false);
@@ -126,13 +122,10 @@ export function CstgTable({
     originalCstgValue: string
   ): Promise<boolean> => {
     // removes original domain name from list and adds new domain name
-    const editedCstgValueResponse = await onUpdateCstgValues(
-      [
-        ...cstgValues.filter((cstgValue) => ![originalCstgValue].includes(cstgValue)),
-        ...[updatedCstgValue],
-      ],
-      'edited'
-    );
+    const editedCstgValueResponse = await onUpdateCstgValues([
+      ...cstgValues.filter((cstgValue) => ![originalCstgValue].includes(cstgValue)),
+      ...[updatedCstgValue],
+    ]);
     const editedCstgValues = editedCstgValueResponse?.cstgValues;
     const isValid = editedCstgValueResponse?.isValidCstgValues;
     if (editedCstgValues && isValid) {

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -93,8 +93,7 @@ function ClientSideIntegration() {
   };
 
   const handleUpdateDomainNames = async (
-    updatedDomainNames: string[],
-    action: string
+    updatedDomainNames: string[]
   ): Promise<UpdateCstgValuesResponse | undefined> => {
     try {
       const response = await UpdateDomainNames(updatedDomainNames, participant!.id);
@@ -105,7 +104,7 @@ function ClientSideIntegration() {
         domains = invalidDomains;
       } else {
         reloader.revalidate();
-        SuccessToast(`Root-level domains ${action}.`);
+        SuccessToast(`Root-level domains saved.`);
       }
       const updatedDomainNamesResponse: UpdateCstgValuesResponse = {
         cstgValues: sortStringsAlphabetically(domains),
@@ -116,11 +115,11 @@ function ClientSideIntegration() {
       handleErrorToast(e);
     }
   };
-  const handleUpdateAppIds = async (updatedAppIds: string[], action: string) => {
+  const handleUpdateAppIds = async (updatedAppIds: string[]) => {
     try {
       const appIds = await UpdateAppIds(updatedAppIds, participant!.id);
       reloader.revalidate();
-      SuccessToast(`Mobile app IDs ${action}.`);
+      SuccessToast(`Mobile app IDs saved.`);
 
       const updatedAppIdsResponse: UpdateCstgValuesResponse = {
         cstgValues: sortStringsAlphabetically(appIds),
@@ -143,10 +142,10 @@ function ClientSideIntegration() {
       updatedCstgValues = [...newCstgValues, ...existingCstgValues];
     }
     if (cstgType === CstgValueType.MobileAppId) {
-      return handleUpdateAppIds(updatedCstgValues, 'added');
+      return handleUpdateAppIds(updatedCstgValues);
     }
     if (cstgType === CstgValueType.Domain) {
-      return handleUpdateDomainNames(updatedCstgValues, 'added');
+      return handleUpdateDomainNames(updatedCstgValues);
     }
   };
 


### PR DESCRIPTION
- Changed the success toast for CSTG to always use the term "saved", because there's not currently an easy way to tell how many are being added or deleted.
- Removed some unnecessary/inaccurate strings from the tests
- Fixed some more casing issues
- Improved some error messages

## Non-exhaustive demo
https://github.com/user-attachments/assets/bf6bf569-963e-4f74-9c6b-780135298181

https://github.com/user-attachments/assets/6ea439cf-7bab-4b46-af5f-09073ffe6e1a

