### PR TITLE
Enhance user middleware to cover edge case

### DIFF
--- a/src/api/middleware/usersMiddleware.ts
+++ b/src/api/middleware/usersMiddleware.ts
@@ -44,10 +44,8 @@ const canUserAccessParticipant = async (
   participantId: number,
   traceId: string
 ) => {
-  const isRequestingUserUid2Support = await isUid2Support(requestingUserEmail);
-
   return (
-    isRequestingUserUid2Support ||
+    (await isUid2Support(requestingUserEmail)) ||
     (await isUserBelongsToParticipant(requestingUserEmail, participantId, traceId))
   );
 };

--- a/src/api/middleware/usersMiddleware.ts
+++ b/src/api/middleware/usersMiddleware.ts
@@ -1,11 +1,11 @@
 import { NextFunction, Response } from 'express';
 import { z } from 'zod';
 
-import { Participant } from '../entities/Participant';
 import { User } from '../entities/User';
 import { UserRoleId } from '../entities/UserRole';
 import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { getLoggers, getTraceId } from '../helpers/loggingHelpers';
+import { UserParticipantRequest } from '../services/participantsService';
 import { findUserByEmail, UserRequest } from '../services/usersService';
 
 export const isUid2Support = async (userEmail: string) => {
@@ -39,6 +39,19 @@ export const isUserBelongsToParticipant = async (
   return false;
 };
 
+const canUserAccessParticipant = async (
+  requestingUserEmail: string,
+  participantId: number,
+  traceId: string
+) => {
+  const isRequestingUserUid2Support = await isUid2Support(requestingUserEmail);
+
+  return (
+    isRequestingUserUid2Support ||
+    (await isUserBelongsToParticipant(requestingUserEmail, participantId, traceId))
+  );
+};
+
 export const enrichCurrentUser = async (req: UserRequest, res: Response, next: NextFunction) => {
   const userEmail = req.auth?.payload?.email as string;
   const user = await findUserByEmail(userEmail);
@@ -53,32 +66,44 @@ const userIdParser = z.object({
   userId: z.coerce.number(),
 });
 
-export const verifyAndEnrichUser = async (req: UserRequest, res: Response, next: NextFunction) => {
+export const verifyAndEnrichUser = async (
+  req: UserParticipantRequest,
+  res: Response,
+  next: NextFunction
+) => {
   const { userId } = userIdParser.parse(req.params);
+  const { participant } = req;
   const traceId = getTraceId(req);
-  const user = await User.query().findById(userId).modify('withParticipants');
+  const targetUser = await User.query().findById(userId).modify('withParticipants');
 
-  if (!user) {
+  if (!targetUser) {
     return res.status(404).send([{ message: 'The user cannot be found.' }]);
   }
-  if (user.participants?.length === 0) {
+  if (targetUser.participants?.length === 0) {
     return res.status(404).send([{ message: 'The participant for that user cannot be found.' }]);
   }
 
+  const targetUserBelongsToParticipant = await isUserBelongsToParticipant(
+    targetUser.email,
+    participant!.id,
+    traceId
+  );
+  if (!targetUserBelongsToParticipant) {
+    const { infoLogger } = getLoggers();
+    infoLogger.info('Target user does not belong to participant', traceId);
+    return res.status(404).send([{ message: 'The user cannot be found.' }]);
+  }
+
   const requestingUserEmail = req.auth?.payload?.email as string;
-  const isRequestingUserUid2Support = await isUid2Support(requestingUserEmail);
-
-  // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-3989
-  const firstParticipant = user.participants?.[0] as Participant;
-
-  const canRequestingUserAccessParticipant =
-    isRequestingUserUid2Support ||
-    (await isUserBelongsToParticipant(requestingUserEmail, firstParticipant.id, traceId));
-
+  const canRequestingUserAccessParticipant = await canUserAccessParticipant(
+    requestingUserEmail,
+    participant!.id,
+    traceId
+  );
   if (!canRequestingUserAccessParticipant) {
     return res.status(403).send([{ message: 'You do not have permission to that user account.' }]);
   }
 
-  req.user = user;
+  req.user = targetUser;
   return next();
 };


### PR DESCRIPTION
- Cover the edge case where the user has access to the requestor participant, but the target user does not belong to that participant
- Make the distinction clearer between the requesting user and the target user (the one that is being changed). Do the same in the tests
- Add a test to cover this case.