### PR TITLE
Stop defaulting to first participant for auditing and `acceptTerms()`

### DIFF
--- a/src/api/entities/AuditTrail.ts
+++ b/src/api/entities/AuditTrail.ts
@@ -46,7 +46,7 @@ export class AuditTrail extends BaseModel {
   declare succeeded: boolean;
   declare event: AuditTrailEvents;
   declare eventData: unknown;
-  declare participantId?: number;
+  declare participantId?: number | null;
 }
 
 export type AuditTrailDTO = ModelObjectOpt<AuditTrail>;

--- a/src/api/routers/participants/participantsAppIds.ts
+++ b/src/api/routers/participants/participantsAppIds.ts
@@ -30,11 +30,16 @@ export async function setParticipantAppNames(req: UserParticipantRequest, res: R
   if (!participant?.siteId) {
     return siteIdNotSetError(req, res);
   }
-  const auditTrailInsertObject = constructAuditTrailObject(user!, AuditTrailEvents.UpdateAppNames, {
-    action: AuditAction.Update,
-    siteId: participant.siteId,
-    appNames,
-  });
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.UpdateAppNames,
+    {
+      action: AuditAction.Update,
+      siteId: participant.siteId,
+      appNames,
+    },
+    participant.id
+  );
 
   const updatedSite = await performAsyncOperationWithAuditTrail(
     auditTrailInsertObject,

--- a/src/api/routers/participants/participantsDomainNames.ts
+++ b/src/api/routers/participants/participantsDomainNames.ts
@@ -6,7 +6,8 @@ import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getSite, setSiteDomainNames } from '../../services/adminServiceClient';
 import {
-  constructAuditTrailObject, performAsyncOperationWithAuditTrail
+  constructAuditTrailObject,
+  performAsyncOperationWithAuditTrail,
 } from '../../services/auditTrailService';
 import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
 
@@ -30,11 +31,16 @@ export async function setParticipantDomainNames(req: UserParticipantRequest, res
     return siteIdNotSetError(req, res);
   }
 
-  const auditTrailInsertObject = constructAuditTrailObject(user!, AuditTrailEvents.UpdateDomainNames, {
-    action: AuditAction.Update,
-    siteId: participant.siteId,
-    domainNames,
-  });
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.UpdateDomainNames,
+    {
+      action: AuditAction.Update,
+      siteId: participant.siteId,
+      domainNames,
+    },
+    participant.id
+  );
 
   const updatedSite = await performAsyncOperationWithAuditTrail(
     auditTrailInsertObject,

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -160,7 +160,8 @@ export function createParticipantsRouter() {
           oldTypeIds: participant?.types!.map((type) => type.id),
           newTypeIds: data.types.map((type) => type.id),
           apiRoles: data.apiRoles.map((role) => role.id),
-        }
+        },
+        participant!.id
       );
 
       const users = await performAsyncOperationWithAuditTrail(
@@ -248,7 +249,8 @@ export function createParticipantsRouter() {
             lastName,
             email,
             jobFunction,
-          }
+          },
+          participant!.id
         );
 
         await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
@@ -370,7 +372,8 @@ export function createParticipantsRouter() {
           newKeyName: newName,
           apiRoles: editedKey.roles.map((role) => role.roleName),
           newApiRoles,
-        }
+        },
+        participant!.id
       );
 
       await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
@@ -429,7 +432,8 @@ export function createParticipantsRouter() {
           keyName: apiKey.name,
           apiRoles: apiKey.roles.map((role) => role.roleName),
           keyId: apiKey.key_id,
-        }
+        },
+        participant!.id
       );
 
       await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () =>
@@ -475,7 +479,8 @@ export function createParticipantsRouter() {
           siteId: participant.siteId,
           keyName,
           apiRoles,
-        }
+        },
+        participant!.id
       );
 
       const key = await performAsyncOperationWithAuditTrail(
@@ -511,7 +516,8 @@ export function createParticipantsRouter() {
           action: AuditAction.Add,
           sharingPermissions: newParticipantSites,
           siteId: participant.siteId,
-        }
+        },
+        participant!.id
       );
 
       const sharingParticipants = await performAsyncOperationWithAuditTrail(
@@ -554,7 +560,8 @@ export function createParticipantsRouter() {
           siteId: participant.siteId,
           name,
           disabled,
-        }
+        },
+        participant!.id
       );
 
       const keyPairs = await performAsyncOperationWithAuditTrail(
@@ -586,7 +593,8 @@ export function createParticipantsRouter() {
           siteId: participant.siteId,
           name,
           disabled,
-        }
+        },
+        participant!.id
       );
 
       const updatedKeyPair = await performAsyncOperationWithAuditTrail(
@@ -622,7 +630,8 @@ export function createParticipantsRouter() {
           siteId: participant.siteId,
           name,
           disabled,
-        }
+        },
+        participant!.id
       );
 
       await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () =>
@@ -665,7 +674,8 @@ export function createParticipantsRouter() {
           action: AuditAction.Delete,
           sharingPermissions: sharingSitesToRemove,
           siteId: participant.siteId,
-        }
+        },
+        participant!.id
       );
 
       const sharingParticipants = await performAsyncOperationWithAuditTrail(
@@ -698,7 +708,8 @@ export function createParticipantsRouter() {
         {
           siteId: participant.siteId,
           allowedTypes: types,
-        }
+        },
+        participant!.id
       );
 
       const sharingParticipants = await performAsyncOperationWithAuditTrail(

--- a/src/api/services/auditTrailService.ts
+++ b/src/api/services/auditTrailService.ts
@@ -7,14 +7,13 @@ export type InsertAuditTrailDTO = Omit<AuditTrailDTO, 'id' | 'succeeded'>;
 export const constructAuditTrailObject = (
   user: User,
   event: AuditTrailEvents,
-  eventData: unknown
+  eventData: unknown,
+  participantId: number | null = null
 ): InsertAuditTrailDTO => {
-  // TODO: This just gets the user's first participant, but it will need to get the currently selected participant as part of UID2-3989
-  const currentParticipant = user.participants?.[0];
   return {
     userId: user.id,
     userEmail: user.email,
-    participantId: currentParticipant?.id,
+    participantId,
     event,
     eventData,
   };

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -15,6 +15,7 @@ import {
   performAsyncOperationWithAuditTrail,
 } from './auditTrailService';
 import { deleteUserByEmail, updateUserProfile } from './kcUsersService';
+import { UserParticipantRequest } from './participantsService';
 import { enrichUserWithIsApprover, findUserByEmail, UserRequest } from './usersService';
 
 export type DeletedUser = {
@@ -57,8 +58,8 @@ export class UserService {
   }
 
   // TODO: Allow for a participant to be specified, so they aren't removed from all of their participants in UID2-3852
-  public async deleteUser(req: UserRequest) {
-    const { user } = req;
+  public async deleteUser(req: UserParticipantRequest) {
+    const { user, participant } = req;
     const requestingUser = await findUserByEmail(req.auth?.payload.email as string);
     const traceId = getTraceId(req);
 
@@ -78,7 +79,8 @@ export class UserService {
         firstName: user?.firstName,
         lastName: user?.lastName,
         jobFunction: user?.jobFunction,
-      }
+      },
+      participant!.id
     );
 
     await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
@@ -90,8 +92,8 @@ export class UserService {
     });
   }
 
-  public async updateUser(req: UserRequest) {
-    const { user } = req;
+  public async updateUser(req: UserParticipantRequest) {
+    const { user, participant } = req;
     const requestingUser = await findUserByEmail(req.auth?.payload.email as string);
     const data = UpdateUserParser.parse(req.body);
     const traceId = getTraceId(req);
@@ -105,7 +107,8 @@ export class UserService {
         firstName: data.firstName,
         lastName: data.lastName,
         jobFunction: data.jobFunction,
-      }
+      },
+      participant!.id
     );
 
     await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {


### PR DESCRIPTION
- Support the case where the user is using the portal as a participant that is not their default participant for audit trails and `acceptTerms()`
- For auditing, use the actual `participantId` that is specified, rather than just defaulting to the first one for the user.
- For `acceptTerms()`, check if the user belongs to any approved participant, rather than just checking if their first participant has been approved.