### PR TITLE
Improve UX for user who has not accepted terms

### DIFF
--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -42,9 +42,13 @@ export function App() {
     <StrictMode>
       <PortalErrorBoundary>
         <ParticipantProvider>
-          <HomeRedirector />
           <div className='app' ref={rootRef}>
-            {LoggedInUser?.user && <UpdatesTour />}
+            {LoggedInUser?.user?.acceptedTerms && (
+              <>
+                <HomeRedirector />
+                <UpdatesTour />
+              </>
+            )}
             <PortalHeader
               email={LoggedInUser?.profile?.email}
               fullName={fullName}

--- a/src/web/components/PortalHeader/PortalHeader.tsx
+++ b/src/web/components/PortalHeader/PortalHeader.tsx
@@ -68,7 +68,7 @@ export function PortalHeader({
         </DropdownMenuTrigger>
         <DropdownMenuContent className='profile-dropdown-content' align='end'>
           <DropdownMenuArrow className='profile-dropdown-arrow' />
-          {LoggedInUser?.user && (
+          {LoggedInUser?.user?.acceptedTerms && (
             <>
               {routes.map((route) => {
                 return (


### PR DESCRIPTION
Use the existing `acceptedTerms` boolean on the User to determine:
- If we direct from successful login to the home page (this was causing an infinite redirect loop on `main`)
- If we show the UI tour
- If we show the participant routes (Participant Information, Team Members & Email Contacts)

## Before

https://github.com/user-attachments/assets/3e170985-0538-408c-b422-4934f95993bb

![image](https://github.com/user-attachments/assets/76020e4e-be43-44cd-8766-af40382af30b)

## After

https://github.com/user-attachments/assets/04753103-5a3b-4911-9d9b-867bc729161e

