### PR TITLE
Refactor some user invite code

### DIFF
--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -36,7 +36,7 @@ import makeMetricsApiMiddleware from './middleware/metrics';
 import { createParticipantsRouter } from './routers/participants/participantsRouter';
 import { createSitesRouter } from './routers/sitesRouter';
 import { createUsersRouter } from './routers/usersRouter';
-import { API_PARTICIPANT_MEMBER } from './services/kcUsersService';
+import { API_PARTICIPANT_MEMBER_ROLE_NAME } from './services/kcUsersService';
 import { LoggerService } from './services/loggerService';
 import { UserService } from './services/userService';
 
@@ -135,7 +135,7 @@ export function configureAndStartApi(useMetrics: boolean = true, portNumber: num
     bypassHandlerForPaths(
       claimCheck((claim: Claim) => {
         const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
-        return roles.includes(API_PARTICIPANT_MEMBER);
+        return roles.includes(API_PARTICIPANT_MEMBER_ROLE_NAME);
       }),
       ...BYPASS_CLAIM_PATHS,
       ...BYPASS_AUTH_PATHS

--- a/src/api/configureApi.ts
+++ b/src/api/configureApi.ts
@@ -36,6 +36,7 @@ import makeMetricsApiMiddleware from './middleware/metrics';
 import { createParticipantsRouter } from './routers/participants/participantsRouter';
 import { createSitesRouter } from './routers/sitesRouter';
 import { createUsersRouter } from './routers/usersRouter';
+import { API_PARTICIPANT_MEMBER } from './services/kcUsersService';
 import { LoggerService } from './services/loggerService';
 import { UserService } from './services/userService';
 
@@ -134,7 +135,7 @@ export function configureAndStartApi(useMetrics: boolean = true, portNumber: num
     bypassHandlerForPaths(
       claimCheck((claim: Claim) => {
         const roles = claim.resource_access?.self_serve_portal_apis?.roles || [];
-        return roles.includes('api-participant-member');
+        return roles.includes(API_PARTICIPANT_MEMBER);
       }),
       ...BYPASS_CLAIM_PATHS,
       ...BYPASS_AUTH_PATHS

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -18,7 +18,7 @@ import { getKcAdminClient } from '../keycloakAdminClient';
 import {
   assignClientRoleToUser,
   queryUsersByEmail,
-  sendInviteEmail,
+  sendInviteEmailToNewUser,
 } from '../services/kcUsersService';
 import { LoggerService } from '../services/loggerService';
 import { SelfResendInvitationParser, UserService } from '../services/userService';
@@ -85,7 +85,7 @@ export class UserController {
       res.sendStatus(200);
     }
     logger.info(`Resending invitation email for ${email}, keycloak ID ${user[0].id}`);
-    await sendInviteEmail(kcAdminClient, user[0]);
+    await sendInviteEmailToNewUser(kcAdminClient, user[0]);
     res.sendStatus(200);
   }
 
@@ -116,7 +116,7 @@ export class UserController {
     }
 
     logger.info(`Resending invitation email for ${req.user?.email}, keycloak ID ${user[0].id}`);
-    await sendInviteEmail(kcAdminClient, user[0]);
+    await sendInviteEmailToNewUser(kcAdminClient, user[0]);
     res.sendStatus(200);
   }
 

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -8,7 +8,7 @@ import {
   httpPost,
   httpPut,
   request,
-  response
+  response,
 } from 'inversify-express-utils';
 
 import { TYPES } from '../constant/types';
@@ -16,8 +16,9 @@ import { ParticipantStatus } from '../entities/Participant';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { getKcAdminClient } from '../keycloakAdminClient';
 import {
-  assignApiParticipantMemberRole, queryUsersByEmail,
-  sendInviteEmailToNewUser
+  assignApiParticipantMemberRole,
+  queryUsersByEmail,
+  sendInviteEmailToNewUser,
 } from '../services/kcUsersService';
 import { LoggerService } from '../services/loggerService';
 import { SelfResendInvitationParser, UserService } from '../services/userService';

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -8,7 +8,7 @@ import {
   httpPost,
   httpPut,
   request,
-  response,
+  response
 } from 'inversify-express-utils';
 
 import { TYPES } from '../constant/types';
@@ -16,9 +16,8 @@ import { ParticipantStatus } from '../entities/Participant';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { getKcAdminClient } from '../keycloakAdminClient';
 import {
-  assignClientRoleToUser,
-  queryUsersByEmail,
-  sendInviteEmailToNewUser,
+  assignApiParticipantMemberRole, queryUsersByEmail,
+  sendInviteEmailToNewUser
 } from '../services/kcUsersService';
 import { LoggerService } from '../services/loggerService';
 import { SelfResendInvitationParser, UserService } from '../services/userService';
@@ -66,7 +65,7 @@ export class UserController {
     const kcAdminClient = await getKcAdminClient();
     const promises = [
       req.user!.$query().patch({ acceptedTerms: true }),
-      assignClientRoleToUser(kcAdminClient, req.user?.email!, 'api-participant-member'),
+      assignApiParticipantMemberRole(kcAdminClient, req.user?.email!),
     ];
     await Promise.all(promises);
     res.sendStatus(200);

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -23,7 +23,7 @@ import {
   performAsyncOperationWithAuditTrail,
 } from '../../services/auditTrailService';
 import {
-  assignClientRoleToUser,
+  assignApiParticipantMemberRole,
   createNewUser,
   sendInviteEmailToNewUser,
 } from '../../services/kcUsersService';
@@ -163,7 +163,7 @@ async function createParticipant(
     );
 
     // assign proper api access
-    assignClientRoleToUser(kcAdminClient, user.email, 'api-participant-member');
+    await assignApiParticipantMemberRole(kcAdminClient, user.email);
 
     // send email
     await sendInviteEmailToNewUser(kcAdminClient, newKcUser);

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -8,7 +8,7 @@ import {
   Participant,
   ParticipantApprovalPartial,
   ParticipantDTO,
-  ParticipantStatus
+  ParticipantStatus,
 } from '../../entities/Participant';
 import { UserDTO } from '../../entities/User';
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
@@ -26,25 +26,23 @@ import {
   renameApiKey,
   setSiteClientTypes,
   updateApiKeyRoles,
-  updateKeyPair
+  updateKeyPair,
 } from '../../services/adminServiceClient';
 import {
   mapAdminApiKeysToApiKeyDTOs,
-  ParticipantApprovalResponse
+  ParticipantApprovalResponse,
 } from '../../services/adminServiceHelpers';
 import {
   createdApiKeyToApiKeySecrets,
   getApiKey,
   getApiRoles,
-  validateApiRoles
+  validateApiRoles,
 } from '../../services/apiKeyService';
 import {
   constructAuditTrailObject,
-  performAsyncOperationWithAuditTrail
+  performAsyncOperationWithAuditTrail,
 } from '../../services/auditTrailService';
-import {
-  assignApiParticipantMemberRole
-} from '../../services/kcUsersService';
+import { assignApiParticipantMemberRole } from '../../services/kcUsersService';
 import {
   addSharingParticipants,
   deleteSharingParticipants,
@@ -55,7 +53,7 @@ import {
   updateParticipant,
   updateParticipantAndTypesAndApiRoles,
   UpdateSharingTypes,
-  UserParticipantRequest
+  UserParticipantRequest,
 } from '../../services/participantsService';
 import { getSignedParticipants } from '../../services/signedParticipantsService';
 import { getAllUserFromParticipant } from '../../services/usersService';

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -42,7 +42,9 @@ import {
   constructAuditTrailObject,
   performAsyncOperationWithAuditTrail
 } from '../../services/auditTrailService';
-import { assignClientRoleToUser } from '../../services/kcUsersService';
+import {
+  assignApiParticipantMemberRole
+} from '../../services/kcUsersService';
 import {
   addSharingParticipants,
   deleteSharingParticipants,
@@ -167,7 +169,7 @@ export function createParticipantsRouter() {
           await setSiteClientTypes(data);
           await Promise.all(
             usersFromParticipant.map((currentUser) =>
-              assignClientRoleToUser(kcAdminClient, currentUser.email, 'api-participant-member')
+              assignApiParticipantMemberRole(kcAdminClient, currentUser.email)
             )
           );
 

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -8,9 +8,9 @@ import {
   Participant,
   ParticipantApprovalPartial,
   ParticipantDTO,
-  ParticipantStatus,
+  ParticipantStatus
 } from '../../entities/Participant';
-import { UserDTO, UserJobFunction } from '../../entities/User';
+import { UserDTO } from '../../entities/User';
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
@@ -26,27 +26,23 @@ import {
   renameApiKey,
   setSiteClientTypes,
   updateApiKeyRoles,
-  updateKeyPair,
+  updateKeyPair
 } from '../../services/adminServiceClient';
 import {
   mapAdminApiKeysToApiKeyDTOs,
-  ParticipantApprovalResponse,
+  ParticipantApprovalResponse
 } from '../../services/adminServiceHelpers';
 import {
   createdApiKeyToApiKeySecrets,
   getApiKey,
   getApiRoles,
-  validateApiRoles,
+  validateApiRoles
 } from '../../services/apiKeyService';
 import {
   constructAuditTrailObject,
-  performAsyncOperationWithAuditTrail,
+  performAsyncOperationWithAuditTrail
 } from '../../services/auditTrailService';
-import {
-  assignClientRoleToUser,
-  createNewUser,
-  sendInviteEmailToNewUser,
-} from '../../services/kcUsersService';
+import { assignClientRoleToUser } from '../../services/kcUsersService';
 import {
   addSharingParticipants,
   deleteSharingParticipants,
@@ -57,14 +53,10 @@ import {
   updateParticipant,
   updateParticipantAndTypesAndApiRoles,
   UpdateSharingTypes,
-  UserParticipantRequest,
+  UserParticipantRequest
 } from '../../services/participantsService';
 import { getSignedParticipants } from '../../services/signedParticipantsService';
-import {
-  createUserInPortal,
-  findUserByEmail,
-  getAllUserFromParticipant,
-} from '../../services/usersService';
+import { getAllUserFromParticipant } from '../../services/usersService';
 import { createBusinessContactsRouter } from '../businessContactsRouter';
 import { createParticipantUsersRouter } from '../participantUsersRouter';
 import { getParticipantAppNames, setParticipantAppNames } from './participantsAppIds';

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -45,7 +45,7 @@ import {
 import {
   assignClientRoleToUser,
   createNewUser,
-  sendInviteEmail,
+  sendInviteEmailToNewUser,
 } from '../../services/kcUsersService';
 import {
   addSharingParticipants,
@@ -68,10 +68,10 @@ import {
 import { createBusinessContactsRouter } from '../businessContactsRouter';
 import { createParticipantUsersRouter } from '../participantUsersRouter';
 import { getParticipantAppNames, setParticipantAppNames } from './participantsAppIds';
-import { createParticipant, createParticipantFromRequest } from './participantsCreation';
+import { createParticipantFromRequest, handleCreateParticipant } from './participantsCreation';
 import { getParticipantDomainNames, setParticipantDomainNames } from './participantsDomainNames';
 import { getParticipantKeyPairs } from './participantsKeyPairs';
-import { getParticipantUsers } from './participantsUsers';
+import { getParticipantUsers, handleInviteUserToParticipant } from './participantsUsers';
 
 export type AvailableParticipantDTO = Required<Pick<ParticipantDTO, 'name' | 'siteId' | 'types'>>;
 
@@ -210,7 +210,7 @@ export function createParticipantsRouter() {
     }
   );
 
-  participantsRouter.put('/', createParticipant);
+  participantsRouter.put('/', handleCreateParticipant);
 
   participantsRouter.use('/:participantId', verifyAndEnrichParticipant);
 
@@ -220,62 +220,7 @@ export function createParticipantsRouter() {
     return res.status(200).json(participant);
   });
 
-  const invitationParser = z.object({
-    firstName: z.string(),
-    lastName: z.string(),
-    email: z.string(),
-    jobFunction: z.nativeEnum(UserJobFunction),
-  });
-
-  participantsRouter.post(
-    '/:participantId/invite',
-    async (req: UserParticipantRequest, res: Response) => {
-      try {
-        const { participant, user } = req;
-        const { firstName, lastName, email, jobFunction } = invitationParser.parse(req.body);
-        const traceId = getTraceId(req);
-        // TODO: UID2-3878 - support user belonging to multiple participants by not 400ing here if the user already exists.
-        const existingUser = await findUserByEmail(email);
-        if (existingUser) {
-          return res.status(400).send('Error inviting user');
-        }
-        const kcAdminClient = await getKcAdminClient();
-        const auditTrailInsertObject = constructAuditTrailObject(
-          user!,
-          AuditTrailEvents.ManageTeamMembers,
-          {
-            action: AuditAction.Add,
-            firstName,
-            lastName,
-            email,
-            jobFunction,
-          },
-          participant!.id
-        );
-
-        await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
-          const newUser = await createNewUser(kcAdminClient, firstName, lastName, email);
-          await createUserInPortal(
-            {
-              email,
-              jobFunction,
-              firstName,
-              lastName,
-            },
-            participant!.id
-          );
-          await sendInviteEmail(kcAdminClient, newUser);
-        });
-
-        return res.sendStatus(201);
-      } catch (err) {
-        if (err instanceof z.ZodError) {
-          return res.status(400).send(err.issues);
-        }
-        throw err;
-      }
-    }
-  );
+  participantsRouter.post('/:participantId/invite', handleInviteUserToParticipant);
 
   participantsRouter.get(
     '/:participantId/sharingPermission',

--- a/src/api/routers/participants/participantsUsers.ts
+++ b/src/api/routers/participants/participantsUsers.ts
@@ -1,10 +1,78 @@
 import { Response } from 'express';
+import { z } from 'zod';
 
-import { ParticipantRequest } from '../../services/participantsService';
-import { getAllUserFromParticipant } from '../../services/usersService';
+import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
+import { UserJobFunction } from '../../entities/User';
+import { getTraceId } from '../../helpers/loggingHelpers';
+import { getKcAdminClient } from '../../keycloakAdminClient';
+import {
+  constructAuditTrailObject,
+  performAsyncOperationWithAuditTrail,
+} from '../../services/auditTrailService';
+import { createNewUser, sendInviteEmailToNewUser } from '../../services/kcUsersService';
+import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
+import {
+  createUserInPortal,
+  findUserByEmail,
+  getAllUserFromParticipant,
+} from '../../services/usersService';
 
 export async function getParticipantUsers(req: ParticipantRequest, res: Response) {
   const { participant } = req;
   const users = await getAllUserFromParticipant(participant!);
   return res.status(200).json(users);
+}
+
+const invitationParser = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string(),
+  jobFunction: z.nativeEnum(UserJobFunction),
+});
+
+export async function handleInviteUserToParticipant(req: UserParticipantRequest, res: Response) {
+  try {
+    const { participant, user } = req;
+    const { firstName, lastName, email, jobFunction } = invitationParser.parse(req.body);
+    const traceId = getTraceId(req);
+    // TODO: UID2-3878 - support user belonging to multiple participants by not 400ing here if the user already exists.
+    const existingUser = await findUserByEmail(email);
+    if (existingUser) {
+      return res.status(400).send('Error inviting user');
+    }
+    const kcAdminClient = await getKcAdminClient();
+    const auditTrailInsertObject = constructAuditTrailObject(
+      user!,
+      AuditTrailEvents.ManageTeamMembers,
+      {
+        action: AuditAction.Add,
+        firstName,
+        lastName,
+        email,
+        jobFunction,
+      },
+      participant!.id
+    );
+
+    await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
+      const newUser = await createNewUser(kcAdminClient, firstName, lastName, email);
+      await createUserInPortal(
+        {
+          email,
+          jobFunction,
+          firstName,
+          lastName,
+        },
+        participant!.id
+      );
+      await sendInviteEmailToNewUser(kcAdminClient, newUser);
+    });
+
+    return res.sendStatus(201);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).send(err.issues);
+    }
+    throw err;
+  }
 }

--- a/src/api/services/kcUsersService.ts
+++ b/src/api/services/kcUsersService.ts
@@ -11,6 +11,14 @@ export const queryUsersByEmail = async (kcAdminClient: KeycloakAdminClient, emai
   });
 };
 
+export const doesUserExistInKeycloak = async (
+  kcAdminClient: KeycloakAdminClient,
+  email: string
+) => {
+  const existingKcUser = await queryUsersByEmail(kcAdminClient, email);
+  return existingKcUser.length > 0;
+};
+
 export const createNewUser = async (
   kcAdminClient: KeycloakAdminClient,
   firstName: string,
@@ -76,7 +84,7 @@ export const deleteUserByEmail = async (kcAdminClient: KeycloakAdminClient, user
   });
 };
 
-export const assignClientRoleToUser = async (
+const assignClientRoleToUser = async (
   kcAdminClient: KeycloakAdminClient,
   userEmail: string,
   roleName: string
@@ -100,4 +108,13 @@ export const assignClientRoleToUser = async (
       },
     ],
   });
+};
+
+export const API_PARTICIPANT_MEMBER = 'api-participant-member';
+
+export const assignApiParticipantMemberRole = async (
+  kcAdminClient: KeycloakAdminClient,
+  userEmail: string
+) => {
+  await assignClientRoleToUser(kcAdminClient, userEmail, API_PARTICIPANT_MEMBER);
 };

--- a/src/api/services/kcUsersService.ts
+++ b/src/api/services/kcUsersService.ts
@@ -118,4 +118,3 @@ export const assignApiParticipantMemberRole = async (
 ) => {
   await assignClientRoleToUser(kcAdminClient, userEmail, API_PARTICIPANT_MEMBER_ROLE_NAME);
 };
-};

--- a/src/api/services/kcUsersService.ts
+++ b/src/api/services/kcUsersService.ts
@@ -30,7 +30,7 @@ export const createNewUser = async (
 };
 
 const logoutUrl = new URL('logout', SSP_WEB_BASE_URL).href;
-export const sendInviteEmail = async (
+export const sendInviteEmailToNewUser = async (
   kcAdminClient: KeycloakAdminClient,
   user: UserRepresentation
 ) => {

--- a/src/api/services/kcUsersService.ts
+++ b/src/api/services/kcUsersService.ts
@@ -4,6 +4,8 @@ import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRep
 
 import { SSP_KK_API_CLIENT_ID, SSP_KK_SSL_RESOURCE, SSP_WEB_BASE_URL } from '../envars';
 
+export const API_PARTICIPANT_MEMBER_ROLE_NAME = 'api-participant-member';
+
 export const queryUsersByEmail = async (kcAdminClient: KeycloakAdminClient, email: string) => {
   return kcAdminClient.users.find({
     email,
@@ -110,11 +112,10 @@ const assignClientRoleToUser = async (
   });
 };
 
-export const API_PARTICIPANT_MEMBER = 'api-participant-member';
-
 export const assignApiParticipantMemberRole = async (
   kcAdminClient: KeycloakAdminClient,
   userEmail: string
 ) => {
-  await assignClientRoleToUser(kcAdminClient, userEmail, API_PARTICIPANT_MEMBER);
+  await assignClientRoleToUser(kcAdminClient, userEmail, API_PARTICIPANT_MEMBER_ROLE_NAME);
+};
 };

--- a/src/web/stores/userStore.ts
+++ b/src/web/stores/userStore.ts
@@ -1,3 +1,0 @@
-export const userStore = {
-  username: 'lionellpack@gmail.com',
-};


### PR DESCRIPTION
## Why?
https://github.com/IABTechLab/uid2-self-serve-portal/pull/516 will be changing the functionality to allow user invitations to still work when the user already belongs to another participant. I'm doing this refactoring to make it easier for me to add that functionality as well as make it easier to be reviewed. 

## What?
- There are no functional changes.
- Rename a function to avoid confusion with an upcoming function to send an invite to an existing user
- Split out the handler for inviting a new participant/user to `participantsUsers.ts`
- Extract a method out of the handler for creating a new participant. This started as more of an exercise but figured it was still worth merging.
- Wrapper method to assign keycloak user role. It's the only role we use today anyway.
- Remove an unused file