### PR TITLE
Align property names in `AddParticipantForm`

### DIFF
--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -174,9 +174,6 @@ export type UpdateParticipantForm = {
 };
 
 export type AddParticipantForm = {
-  contactFirstName: string;
-  contactLastName: string;
-  contactEmail: string;
   participantName: string;
   apiRoles: number[];
   participantTypes: number[];
@@ -185,6 +182,9 @@ export type AddParticipantForm = {
   siteName?: string;
   jobFunction: string;
   crmAgreementNumber: string;
+  firstName: string;
+  lastName: string;
+  email: string;
 };
 
 export async function AddParticipant(formData: AddParticipantForm) {


### PR DESCRIPTION
Match property names in `AddParticipantForm` to the input names in `AddParticipantDialog`. This mismatch prevented defaults to be set on the contact inputs, which was slowing down developer iteration.

## Manual testing
**Still working like normal**

https://github.com/user-attachments/assets/6d6e57e6-86df-40fe-bc63-91719811024f


**With a default value set**
```
const formMethods = useForm<AddParticipantForm>({
  defaultValues: { siteIdType: 0, firstName: 'hello reviewer' },
});
```
https://github.com/user-attachments/assets/7c86ef32-2a6f-40e6-98a2-cbc2114f2c43





