### PR TITLE
Consistent naming for zod object variables

### DIFF
--- a/CodingStandards.md
+++ b/CodingStandards.md
@@ -5,7 +5,7 @@
 - Whenever a database entity is loaded as part of the route (e.g. /participants/123 or /participants/current) or based on the current JWT (e.g. /users/current), that entity **must** be provided by a middleware enricher (e.g. `enrichWithUserFromParams` in `userService.ts`).
   - That enricher is responsible for appropriate authorization checks.
 - Whenever another database entity is loaded, deleted, inserted, or updated (i.e. not based on the route or JWT), it **should** use a related query from an entity provided by a middleware enricher.
-- Whenever an endpoint makes use of user input (either in the URL or in the request body), it **must** use a Zod parser (e.g. `UpdateUserParser` in `usersRouter.ts`).
+- Whenever an endpoint makes use of user input (either in the URL or in the request body), it **must** use a Zod parser (e.g. `UpdateUserSchema` in `usersRouter.ts`).
   - If that parser inherits from another (e.g. `BusinessContactsDTO` in `businessContactsRouter.ts`), it **must** use an explicit include list - e.g. `.pick` (and not `.omit`) to ensure that the future addition of new fields in the parent parser won't automatically include it.
   - Care must be taken that only fields that the user is allowed to set/update are included in the parser.
 - Whenever an endpoint returns data for a participant other than the logged-in participant, the DTO returned **must** map the loaded data to a new object containing only the required fields (e.g. `GET /available` in `participantsRouter.ts`).

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -21,7 +21,7 @@ import {
   sendInviteEmailToNewUser,
 } from '../services/kcUsersService';
 import { LoggerService } from '../services/loggerService';
-import { SelfResendInvitationParser, UserService } from '../services/userService';
+import { SelfResendInvitationSchema, UserService } from '../services/userService';
 import { SelfResendInviteRequest, UserRequest } from '../services/usersService';
 
 @controller('/users')
@@ -77,7 +77,7 @@ export class UserController {
     @request() req: SelfResendInviteRequest,
     @response() res: Response
   ): Promise<void> {
-    const { email } = SelfResendInvitationParser.parse(req.body);
+    const { email } = SelfResendInvitationSchema.parse(req.body);
     const logger = this.loggerService.getLogger(req);
     const kcAdminClient = await getKcAdminClient();
     const user = await queryUsersByEmail(kcAdminClient, email);

--- a/src/api/middleware/participantsMiddleware.ts
+++ b/src/api/middleware/participantsMiddleware.ts
@@ -6,12 +6,12 @@ import { getTraceId } from '../helpers/loggingHelpers';
 import { ParticipantRequest } from '../services/participantsService';
 import { isUid2Support, isUserBelongsToParticipant } from './usersMiddleware';
 
-const idParser = z.object({
+const participantIdSchema = z.object({
   participantId: z.coerce.number(),
 });
 
 const enrichParticipant = async (req: ParticipantRequest, res: Response, next: NextFunction) => {
-  const { participantId } = idParser.parse(req.params);
+  const { participantId } = participantIdSchema.parse(req.params);
   const participant = await Participant.query().findById(participantId).withGraphFetched('types');
   if (!participant) {
     return res.status(404).send([{ message: 'The participant cannot be found.' }]);
@@ -21,7 +21,7 @@ const enrichParticipant = async (req: ParticipantRequest, res: Response, next: N
 };
 
 const verifyUserAccessToParticipant = async (req: ParticipantRequest, res: Response) => {
-  const { participantId } = idParser.parse(req.params);
+  const { participantId } = participantIdSchema.parse(req.params);
   const traceId = getTraceId(req);
   const userEmail = req.auth?.payload?.email as string;
   const isUserUid2Support = await isUid2Support(userEmail);

--- a/src/api/middleware/usersMiddleware.ts
+++ b/src/api/middleware/usersMiddleware.ts
@@ -60,16 +60,15 @@ export const enrichCurrentUser = async (req: UserRequest, res: Response, next: N
   return next();
 };
 
-const userIdParser = z.object({
+const userIdSchema = z.object({
   userId: z.coerce.number(),
 });
-
 export const verifyAndEnrichUser = async (
   req: UserParticipantRequest,
   res: Response,
   next: NextFunction
 ) => {
-  const { userId } = userIdParser.parse(req.params);
+  const { userId } = userIdSchema.parse(req.params);
   const { participant } = req;
   const traceId = getTraceId(req);
   const targetUser = await User.query().findById(userId).modify('withParticipants');

--- a/src/api/routers/participants/participantsAppIds.ts
+++ b/src/api/routers/participants/participantsAppIds.ts
@@ -20,11 +20,10 @@ export async function getParticipantAppNames(req: ParticipantRequest, res: Respo
   return res.status(200).json(participantSite.app_names ?? []);
 }
 
-const appNamesParser = z.object({ appNames: z.array(z.string()) });
-
+const appNamesSchema = z.object({ appNames: z.array(z.string()) });
 export async function setParticipantAppNames(req: UserParticipantRequest, res: Response) {
   const { participant, user } = req;
-  const { appNames } = appNamesParser.parse(req.body);
+  const { appNames } = appNamesSchema.parse(req.body);
   const traceId = getTraceId(req);
 
   if (!participant?.siteId) {

--- a/src/api/routers/participants/participantsDomainNames.ts
+++ b/src/api/routers/participants/participantsDomainNames.ts
@@ -20,11 +20,10 @@ export async function getParticipantDomainNames(req: ParticipantRequest, res: Re
   return res.status(200).json(participantSite.domain_names ?? []);
 }
 
-const domainNamesParser = z.object({ domainNames: z.array(z.string()) });
-
+const domainNamesSchema = z.object({ domainNames: z.array(z.string()) });
 export async function setParticipantDomainNames(req: UserParticipantRequest, res: Response) {
   const { participant, user } = req;
-  const { domainNames } = domainNamesParser.parse(req.body);
+  const { domainNames } = domainNamesSchema.parse(req.body);
   const traceId = getTraceId(req);
 
   if (!participant?.siteId) {

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -252,7 +252,7 @@ export function createParticipantsRouter() {
     }
   );
 
-  const apiKeyIdParser = z.object({
+  const apiKeyIdSchema = z.object({
     keyId: z.string(),
   });
   participantsRouter.get(
@@ -263,7 +263,7 @@ export function createParticipantsRouter() {
         return siteIdNotSetError(req, res);
       }
 
-      const { keyId } = apiKeyIdParser.parse(req.query);
+      const { keyId } = apiKeyIdSchema.parse(req.query);
       if (!keyId) {
         return res.status(400).send('Key id is not set');
       }
@@ -277,7 +277,7 @@ export function createParticipantsRouter() {
     }
   );
 
-  const apiKeyEditInputParser = z.object({
+  const apiKeyEditInputSchema = z.object({
     keyId: z.string(),
     newName: z.string(),
     newApiRoles: z.array(z.string()),
@@ -290,7 +290,7 @@ export function createParticipantsRouter() {
         return siteIdNotSetError(req, res);
       }
 
-      const { keyId, newName, newApiRoles } = apiKeyEditInputParser.parse(req.body);
+      const { keyId, newName, newApiRoles } = apiKeyEditInputSchema.parse(req.body);
 
       const editedKey = await getApiKey(participant.siteId, keyId);
       if (!editedKey) {
@@ -342,14 +342,14 @@ export function createParticipantsRouter() {
     }
   );
 
-  const apiKeyDeleteInputParser = z.object({
+  const apiKeyDeleteInputSchema = z.object({
     keyId: z.string(),
   });
   participantsRouter.delete(
     '/:participantId/apiKey',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { keyId } = apiKeyDeleteInputParser.parse(req.body);
+      const { keyId } = apiKeyDeleteInputSchema.parse(req.body);
 
       if (!participant?.siteId) {
         return siteIdNotSetError(req, res);
@@ -392,13 +392,12 @@ export function createParticipantsRouter() {
     }
   );
 
-  const apiKeyCreateInputParser = z.object({ name: z.string(), roles: z.array(z.string()) });
-
+  const apiKeyCreateInputSchema = z.object({ name: z.string(), roles: z.array(z.string()) });
   participantsRouter.post(
     '/:participantId/apiKey',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { name: keyName, roles: apiRoles } = apiKeyCreateInputParser.parse(req.body);
+      const { name: keyName, roles: apiRoles } = apiKeyCreateInputSchema.parse(req.body);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {
@@ -432,14 +431,14 @@ export function createParticipantsRouter() {
     }
   );
 
-  const sharingRelationParser = z.object({
+  const sharingRelationSchema = z.object({
     newParticipantSites: z.array(z.number()),
   });
   participantsRouter.post(
     '/:participantId/sharingPermission/add',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { newParticipantSites } = sharingRelationParser.parse(req.body);
+      const { newParticipantSites } = sharingRelationSchema.parse(req.body);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {
@@ -467,21 +466,19 @@ export function createParticipantsRouter() {
     }
   );
 
-  const keyPairParser = z.object({
+  const keyPairSchema = z.object({
     name: z.string(),
     disabled: z.boolean(),
     subscriptionId: z.string(),
   });
-
-  const addKeyPairParser = z.object({
+  const addKeyPairSchema = z.object({
     name: z.string(),
   });
-
   participantsRouter.post(
     '/:participantId/keyPair/add',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { name } = addKeyPairParser.parse(req.body);
+      const { name } = addKeyPairSchema.parse(req.body);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {
@@ -515,7 +512,7 @@ export function createParticipantsRouter() {
     '/:participantId/keyPair/update',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { name, subscriptionId, disabled } = keyPairParser.parse(req.body);
+      const { name, subscriptionId, disabled } = keyPairSchema.parse(req.body);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {
@@ -548,7 +545,7 @@ export function createParticipantsRouter() {
     '/:participantId/keyPair',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { name, subscriptionId } = keyPairParser.parse(req.body.keyPair);
+      const { name, subscriptionId } = keyPairSchema.parse(req.body.keyPair);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {
@@ -589,15 +586,14 @@ export function createParticipantsRouter() {
 
   participantsRouter.post('/:participantId/appNames', setParticipantAppNames);
 
-  const removeSharingRelationParser = z.object({
+  const removeSharingRelationSchema = z.object({
     sharingSitesToRemove: z.array(z.number()),
   });
-
   participantsRouter.post(
     '/:participantId/sharingPermission/delete',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { sharingSitesToRemove } = removeSharingRelationParser.parse(req.body);
+      const { sharingSitesToRemove } = removeSharingRelationSchema.parse(req.body);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {
@@ -625,14 +621,14 @@ export function createParticipantsRouter() {
     }
   );
 
-  const sharingTypesParser = z.object({
+  const sharingTypesSchema = z.object({
     types: z.array(ClientTypeEnum),
   });
   participantsRouter.post(
     '/:participantId/sharingPermission/shareWithTypes',
     async (req: UserParticipantRequest, res: Response) => {
       const { participant, user } = req;
-      const { types } = sharingTypesParser.parse(req.body);
+      const { types } = sharingTypesSchema.parse(req.body);
       const traceId = getTraceId(req);
 
       if (!participant?.siteId) {

--- a/src/api/routers/participants/participantsUsers.ts
+++ b/src/api/routers/participants/participantsUsers.ts
@@ -23,7 +23,6 @@ const userInvitationSchema = z.object({
   email: z.string(),
   jobFunction: z.nativeEnum(UserJobFunction),
 });
-
 export async function handleInviteUserToParticipant(req: UserParticipantRequest, res: Response) {
   try {
     const { participant, user } = req;

--- a/src/api/services/businessContactsService.ts
+++ b/src/api/services/businessContactsService.ts
@@ -9,17 +9,16 @@ export interface BusinessContactRequest extends Request {
   businessContact?: BusinessContact;
 }
 
-const contactIdParser = z.object({
+const contactIdSchema = z.object({
   contactId: z.string(),
 });
-
 export const hasBusinessContactAccess = async (
   req: BusinessContactRequest,
   res: Response,
   next: NextFunction
 ) => {
   const { participant } = req;
-  const { contactId } = contactIdParser.parse(req.params);
+  const { contactId } = contactIdSchema.parse(req.params);
   const businessContact = await BusinessContact.query().findById(contactId);
 
   if (!businessContact) {

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -234,20 +234,19 @@ export const updateParticipantTypes = async (
   }
 };
 
-const updateParticipantParser = z.object({
+const updateParticipantSchema = z.object({
   apiRoles: z.array(z.number()),
   participantTypes: z.array(z.number()),
   participantName: z.string(),
   crmAgreementNumber: z.string().nullable(),
 });
-
 export const updateParticipant = async (participant: Participant, req: UserParticipantRequest) => {
   const {
     apiRoles,
     participantTypes: participantTypeIds,
     participantName,
     crmAgreementNumber,
-  } = updateParticipantParser.parse(req.body);
+  } = updateParticipantSchema.parse(req.body);
   const { user } = req;
   const traceId = getTraceId(req);
 

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -24,13 +24,13 @@ export type DeletedUser = {
   deleted: boolean;
 };
 
-export const UpdateUserParser = z.object({
+const updateUserSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   jobFunction: z.nativeEnum(UserJobFunction),
 });
 
-export const SelfResendInvitationParser = z.object({ email: z.string() });
+export const SelfResendInvitationSchema = z.object({ email: z.string() });
 
 @injectable()
 export class UserService {
@@ -94,7 +94,7 @@ export class UserService {
   public async updateUser(req: UserParticipantRequest) {
     const { user, participant } = req;
     const requestingUser = await findUserByEmail(req.auth?.payload.email as string);
-    const data = UpdateUserParser.parse(req.body);
+    const data = updateUserSchema.parse(req.body);
     const traceId = getTraceId(req);
 
     const auditTrailInsertObject = constructAuditTrailObject(


### PR DESCRIPTION
Actioning feedback originally raised [here](https://github.com/IABTechLab/uid2-self-serve-portal/pull/516#discussion_r1742651141)

The convention here is to use PascalCase should be used for models or types that are intended to be reused across the application, while camelCase should be used for schemas that are defined within a specific, narrow scope, like a single function. 

Also we should refer to these zod objects as schemas, rather than parsers, which seems to follow convention (e.g. [zod docs](https://zod.dev/?id=basic-usage), [aws docs](https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parser/#key-features).