### PR TITLE
`ErrorView` styling adjustments

### DIFF
--- a/src/web/components/Core/ErrorView/ErrorView.scss
+++ b/src/web/components/Core/ErrorView/ErrorView.scss
@@ -1,14 +1,14 @@
 .error-content {
-  align-self: flex-start;
+  align-self: center;
   text-align: center;
   padding: 4.5rem 6.5rem;
-}
-.error-content .uid2-logo {
-  display: inline-block;
-}
 
-.error-content .uid2-logo-darkmode {
-  display: none;
+  .uid2-logo {
+    display: inline-block;
+  }
+  .uid2-logo-darkmode {
+    display: none;
+  }
 }
 
 .app.darkmode .error-content {

--- a/src/web/components/Core/ErrorView/ErrorView.tsx
+++ b/src/web/components/Core/ErrorView/ErrorView.tsx
@@ -4,6 +4,8 @@ import { useAsyncError } from 'react-router-dom';
 import { ApiError, getErrorHash } from '../../../utils/apiError';
 import { analyticsIdentifier, extractMessageFromAxiosError } from '../../../utils/errorHelpers';
 
+import './ErrorView.scss';
+
 type ErrorViewProps = Readonly<{
   message?: string;
   errorId?: string;

--- a/src/web/utils/errorHandler.tsx
+++ b/src/web/utils/errorHandler.tsx
@@ -3,8 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { ApiError } from './apiError';
 
-import './errorHandler.scss';
-
 interface ErrorState {
   errorId: string;
   errorHash?: string;


### PR DESCRIPTION
- Move the file to a better location
- Leverage scss to simplify
- align center instead of flex-start

## Manual testing
UX should remain unchanged, e.g. set your clientTypes to `[]` in admin and the you'll see the following: 

![image](https://github.com/user-attachments/assets/bb42f2a8-a6f3-41ec-b9c5-21b403db85ce)

![image](https://github.com/user-attachments/assets/9bd6a956-6a87-4a55-9464-417f01bbf815)

