### PR TITLE
Ensure response status is only set once

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,3 +2,6 @@
 # for more details
 # e.g. 
 # CVE-2022-3996
+
+# https://atlassian.thetradedesk.com/jira/browse/UID2-4091
+CVE-2024-45296

--- a/src/api/middleware/participantsMiddleware.ts
+++ b/src/api/middleware/participantsMiddleware.ts
@@ -4,41 +4,29 @@ import { z } from 'zod';
 import { Participant } from '../entities/Participant';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { ParticipantRequest } from '../services/participantsService';
-import { isUid2Support, isUserBelongsToParticipant } from './usersMiddleware';
+import { canUserAccessParticipant } from './usersMiddleware';
 
 const participantIdSchema = z.object({
   participantId: z.coerce.number(),
 });
-
-const enrichParticipant = async (req: ParticipantRequest, res: Response, next: NextFunction) => {
-  const { participantId } = participantIdSchema.parse(req.params);
-  const participant = await Participant.query().findById(participantId).withGraphFetched('types');
-  if (!participant) {
-    return res.status(404).send([{ message: 'The participant cannot be found.' }]);
-  }
-  req.participant = participant;
-  return next();
-};
-
-const verifyUserAccessToParticipant = async (req: ParticipantRequest, res: Response) => {
-  const { participantId } = participantIdSchema.parse(req.params);
-  const traceId = getTraceId(req);
-  const userEmail = req.auth?.payload?.email as string;
-  const isUserUid2Support = await isUid2Support(userEmail);
-
-  const canUserAccessParticipant =
-    isUserUid2Support || (await isUserBelongsToParticipant(userEmail, participantId, traceId));
-
-  if (!canUserAccessParticipant) {
-    return res.status(403).send([{ message: 'You do not have permission to that participant.' }]);
-  }
-};
-
 export const verifyAndEnrichParticipant = async (
   req: ParticipantRequest,
   res: Response,
   next: NextFunction
 ) => {
-  await verifyUserAccessToParticipant(req, res);
-  await enrichParticipant(req, res, next);
+  const { participantId } = participantIdSchema.parse(req.params);
+  const traceId = getTraceId(req);
+  const userEmail = req.auth?.payload?.email as string;
+
+  const participant = await Participant.query().findById(participantId).withGraphFetched('types');
+  if (!participant) {
+    return res.status(404).send([{ message: 'The participant cannot be found.' }]);
+  }
+
+  if (!(await canUserAccessParticipant(userEmail, participantId, traceId))) {
+    res.status(403).send([{ message: 'You do not have access to that participant.' }]);
+  }
+
+  req.participant = participant;
+  return next();
 };

--- a/src/api/middleware/tests/participantsMiddleware.spec.ts
+++ b/src/api/middleware/tests/participantsMiddleware.spec.ts
@@ -100,7 +100,7 @@ describe('Participant Middleware Tests', () => {
 
     expect(res.status).toHaveBeenCalledWith(403);
     expect(res.send).toHaveBeenCalledWith([
-      { message: 'You do not have permission to that participant.' },
+      { message: 'You do not have access to that participant.' },
     ]);
   });
 });

--- a/src/api/middleware/usersMiddleware.ts
+++ b/src/api/middleware/usersMiddleware.ts
@@ -39,7 +39,7 @@ export const isUserBelongsToParticipant = async (
   return false;
 };
 
-const canUserAccessParticipant = async (
+export const canUserAccessParticipant = async (
   requestingUserEmail: string,
   participantId: number,
   traceId: string


### PR DESCRIPTION
## Before
If a user tried to access a participant that they did not have access to, our API would error with `Error: Cannot set headers after they are sent to the client`.

## After
In the above scenario, the API now appropriately responds with 403 or 404