### PR TITLE
Developer experience improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
     environment:
       ACCEPT_EULA: 'yes'
       MSSQL_SA_PASSWORD: 'D3velopmentP0'
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P D3velopmentP0 -Q 'SELECT 1'"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
   keycloak:
     container_name: uid2_selfserve_keycloak
     image: quay.io/keycloak/keycloak:24.0.0
@@ -32,7 +37,8 @@ services:
       - 18080:8080
       - 19990:9990
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     command:
       - start-dev
       - --import-realm

--- a/src/api/middleware/metrics.ts
+++ b/src/api/middleware/metrics.ts
@@ -14,9 +14,12 @@ type Options = {
 };
 
 const captureAllRoutes = ({ urlPatternMaker }: Options, app: express.Express, logger: Logger) => {
-  const allRoutes = listEndpoints(app).filter((route) => route.path !== '/*' && route.path !== '*');
+  const allRoutes = listEndpoints(app);
+  const filteredRoutes = allRoutes.filter(
+    (route) => route.path !== '/*' && route.path !== '*' && !route.path.includes(' ')
+  );
 
-  return allRoutes.map((route) => {
+  return filteredRoutes.map((route) => {
     const path = route.path.endsWith('/') ? route.path.replace(/\/$/, '') : route.path;
 
     logger.log('debug', `Route found: ${route.path} - ${JSON.stringify(route)}`);


### PR DESCRIPTION
- Set up a proper dependency for keycloak on the db, so that keycloak only starts when the db is definitely up. It will make it slightly slower to start up but will be more reliable.
- Filter out paths with whitespace for metrics, to stop the API from logging the following error: `unable to capture route for prom-metrics: Error: argument must not contain whitespace`

## Manual testing
1. Run `./run_portal.ps1
2. Notice that the keycloak container only starts when the database is healthy.

https://github.com/user-attachments/assets/b79a2aff-bfef-44bc-998d-1a8757573db1

