### PR TITLE
Participant Switcher UI

### DIFF
--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -39,6 +39,9 @@ export class UserService {
         userWithIsApprover.participants = allParticipants;
       }
     }
+    userWithIsApprover.participants = userWithIsApprover?.participants?.sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
     return userWithIsApprover;
   }
 

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -8,6 +8,7 @@ import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { mapClientTypeToParticipantType } from '../helpers/siteConvertingHelpers';
 import { getKcAdminClient } from '../keycloakAdminClient';
+import { isUid2Support } from '../middleware/usersMiddleware';
 import { getSite } from './adminServiceClient';
 import { getApiRoles } from './apiKeyService';
 import {
@@ -15,7 +16,7 @@ import {
   performAsyncOperationWithAuditTrail,
 } from './auditTrailService';
 import { removeApiParticipantMemberRole, updateUserProfile } from './kcUsersService';
-import { UserParticipantRequest } from './participantsService';
+import { getParticipantsApproved, UserParticipantRequest } from './participantsService';
 import { enrichUserWithIsApprover, findUserByEmail, UserRequest } from './usersService';
 
 const updateUserSchema = z.object({
@@ -32,6 +33,12 @@ export class UserService {
     const userEmail = req.auth?.payload?.email as string;
     const user = await findUserByEmail(userEmail);
     const userWithIsApprover = await enrichUserWithIsApprover(user!);
+    if (userWithIsApprover) {
+      if (await isUid2Support(userEmail)) {
+        const allParticipants = await getParticipantsApproved();
+        userWithIsApprover.participants = allParticipants;
+      }
+    }
     return userWithIsApprover;
   }
 

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -27,7 +27,7 @@ export interface SelfResendInviteRequest extends Request {
   email?: string;
 }
 
-export type UserWithIsApprover = User & { isApprover: boolean };
+export type UserWithIsApprover = UserDTO & { isApprover: boolean };
 
 export type UserPartialDTO = Omit<UserDTO, 'id' | 'acceptedTerms'>;
 

--- a/src/testHelpers/dataMocks.ts
+++ b/src/testHelpers/dataMocks.ts
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker';
+
+import { Participant, ParticipantDTO, ParticipantStatus } from '../api/entities/Participant';
+import { UserJobFunction } from '../api/entities/User';
+import { UserWithIsApprover } from '../api/services/usersService';
+
+export const createMockUser = (participants: Participant[]): UserWithIsApprover => {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+  const generatedEmail = faker.internet.email({
+    firstName,
+    lastName,
+  });
+
+  const user = {
+    id: faker.number.int(),
+    firstName,
+    lastName,
+    email: generatedEmail,
+    jobFunction: faker.helpers.arrayElement(Object.values(UserJobFunction)),
+    acceptedTerms: true,
+    isApprover: faker.datatype.boolean(),
+    participants,
+  };
+
+  return user;
+};
+
+export const createMockParticipant = (): ParticipantDTO => ({
+  id: faker.number.int(),
+  name: faker.company.name(),
+  status: ParticipantStatus.Approved,
+  allowSharing: true,
+  completedRecommendations: faker.datatype.boolean(),
+  crmAgreementNumber: '12345678',
+  users: [createMockUser([])],
+});

--- a/src/testHelpers/dataMocks.ts
+++ b/src/testHelpers/dataMocks.ts
@@ -33,5 +33,4 @@ export const createMockParticipant = (): ParticipantDTO => ({
   allowSharing: true,
   completedRecommendations: faker.datatype.boolean(),
   crmAgreementNumber: '12345678',
-  users: [createMockUser([])],
 });

--- a/src/testHelpers/testContextProvider.tsx
+++ b/src/testHelpers/testContextProvider.tsx
@@ -1,16 +1,57 @@
 import { ReactKeycloakProvider } from '@react-keycloak/web';
 import Keycloak from 'keycloak-js';
 import { PropsWithChildren } from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+
+import { ParticipantDTO } from '../api/entities/Participant';
+import { UserWithIsApprover } from '../api/services/usersService';
+import { CurrentUserContext, UserContextWithSetter } from '../web/contexts/CurrentUserProvider';
+import { ParticipantContext, ParticipantWithSetter } from '../web/contexts/ParticipantProvider';
 
 export const createTestKeycloakInstance = () => {
   return new Keycloak();
 };
 
-export function TestContextProvider({ children }: PropsWithChildren) {
+export const createUserContextValue = (user: UserWithIsApprover): UserContextWithSetter => ({
+  LoggedInUser: {
+    profile: {},
+    user,
+  },
+  loadUser: async () => {},
+});
+
+export const createParticipantContextValue = (participant: ParticipantDTO): ParticipantWithSetter => ({
+  participant,
+  setParticipant: () => {},
+});
+
+const defaultUserContext: UserContextWithSetter = {
+  LoggedInUser: null,
+  loadUser: async () => {},
+};
+
+const defaultParticipantContext: ParticipantWithSetter = {
+  participant: null,
+  setParticipant: () => {},
+};
+
+interface TestContextProviderProps extends PropsWithChildren {
+  participantContextValue?: ParticipantWithSetter;
+  userContextValue?: UserContextWithSetter;
+}
+
+export function TestContextProvider({
+  children,
+  participantContextValue,
+  userContextValue,
+}: TestContextProviderProps) {
   return (
     <ReactKeycloakProvider authClient={createTestKeycloakInstance()}>
-      <BrowserRouter>{children}</BrowserRouter>
+      <ParticipantContext.Provider value={participantContextValue ?? defaultParticipantContext}>
+        <CurrentUserContext.Provider value={userContextValue ?? defaultUserContext}>
+          <BrowserRouter>{children}</BrowserRouter>
+        </CurrentUserContext.Provider>
+      </ParticipantContext.Provider>
     </ReactKeycloakProvider>
   );
 }

--- a/src/testHelpers/testContextProvider.tsx
+++ b/src/testHelpers/testContextProvider.tsx
@@ -1,7 +1,7 @@
 import { ReactKeycloakProvider } from '@react-keycloak/web';
 import Keycloak from 'keycloak-js';
 import { PropsWithChildren } from 'react';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import { ParticipantDTO } from '../api/entities/Participant';
 import { UserWithIsApprover } from '../api/services/usersService';
@@ -20,7 +20,9 @@ export const createUserContextValue = (user: UserWithIsApprover): UserContextWit
   loadUser: async () => {},
 });
 
-export const createParticipantContextValue = (participant: ParticipantDTO): ParticipantWithSetter => ({
+export const createParticipantContextValue = (
+  participant: ParticipantDTO
+): ParticipantWithSetter => ({
   participant,
   setParticipant: () => {},
 });

--- a/src/web/components/Input/SelectDropdown.scss
+++ b/src/web/components/Input/SelectDropdown.scss
@@ -28,8 +28,8 @@
   &-checkbox-item {
     display: flex;
     justify-content: center;
-    gap: 10px;
-    margin: 10px 0;
+    height: 30px;
+    align-items: center;
     cursor: default;
     color: black;
   }

--- a/src/web/components/Navigation/ParticipantSwitcher.scss
+++ b/src/web/components/Navigation/ParticipantSwitcher.scss
@@ -17,7 +17,7 @@
   }
 
   .participant-name {
-    padding: 0 0 20px 0;
+    padding: 0 0 14px 0;
     font-weight: 600;
   }
 }

--- a/src/web/components/Navigation/ParticipantSwitcher.scss
+++ b/src/web/components/Navigation/ParticipantSwitcher.scss
@@ -1,0 +1,23 @@
+.participant-switcher {
+  .select-dropdown-content {
+    width: 200px;
+  }
+  .select-dropdown {
+    & > button {
+      border: none;
+      padding: 0 0 20px 0;
+      color: var(--theme-primary);
+    }
+  }
+
+  .select-dropdown-checkbox-item {
+    justify-content: flex-start;
+    padding-left: 10px;
+    height: 40px;
+  }
+
+  .participant-name {
+    padding: 0 0 20px 0;
+    font-weight: 600;
+  }
+}

--- a/src/web/components/Navigation/ParticipantSwitcher.spec.tsx
+++ b/src/web/components/Navigation/ParticipantSwitcher.spec.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Participant, ParticipantDTO } from '../../../api/entities/Participant';
+import { createMockParticipant, createMockUser } from '../../../testHelpers/dataMocks';
+import {
+  createParticipantContextValue,
+  createUserContextValue,
+  TestContextProvider,
+} from '../../../testHelpers/testContextProvider';
+import { UserContextWithSetter } from '../../contexts/CurrentUserProvider';
+import { ParticipantWithSetter } from '../../contexts/ParticipantProvider';
+import { ParticipantSwitcher } from './ParticipantSwitcher';
+
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockUseNavigate,
+}));
+
+const renderParticipantSwitcherWithContext = (
+  participantContextValue: ParticipantWithSetter,
+  userContextValue: UserContextWithSetter
+) => {
+  return render(
+    <TestContextProvider
+      participantContextValue={participantContextValue}
+      userContextValue={userContextValue}
+    >
+      <ParticipantSwitcher />
+    </TestContextProvider>
+  );
+};
+
+describe('Participant Switcher', () => {
+  let participantContextValue: ParticipantWithSetter;
+  let userContextValue: UserContextWithSetter;
+
+  describe('user only has access to one participant', () => {
+    let mockParticipant: ParticipantDTO;
+
+    beforeAll(() => {
+      mockParticipant = createMockParticipant();
+      participantContextValue = createParticipantContextValue(mockParticipant);
+      const mockUser = createMockUser([mockParticipant] as Participant[]);
+      userContextValue = createUserContextValue(mockUser);
+    });
+
+    it('displays participant name when user only has one participant', () => {
+      renderParticipantSwitcherWithContext(participantContextValue, userContextValue);
+
+      const participantName = screen.getByText(mockParticipant.name);
+      const participantSwitcherButton = screen.queryByRole('button', {
+        name: mockParticipant.name,
+      });
+      expect(participantName).toBeInTheDocument();
+      expect(participantSwitcherButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe('user has access to multiple participants', () => {
+    let mockParticipant1: ParticipantDTO;
+    let mockParticipant2: ParticipantDTO;
+
+    beforeAll(() => {
+      mockParticipant1 = createMockParticipant();
+      mockParticipant2 = createMockParticipant();
+      participantContextValue = createParticipantContextValue(mockParticipant1);
+      const mockUser = createMockUser([mockParticipant1, mockParticipant2] as Participant[]);
+      userContextValue = createUserContextValue(mockUser);
+    });
+
+    it('displays participant switcher when user has multiple participants', () => {
+      renderParticipantSwitcherWithContext(participantContextValue, userContextValue);
+
+      const participantSwitcherButton = screen.getByRole('button', {
+        name: mockParticipant1.name,
+      });
+      expect(participantSwitcherButton).toBeInTheDocument();
+    });
+    it('shows accessible participants in the dropdown', async () => {
+      const user = userEvent.setup();
+      renderParticipantSwitcherWithContext(participantContextValue, userContextValue);
+
+      const participantSwitcherButton = screen.getByRole('button', { name: mockParticipant1.name });
+      await user.click(participantSwitcherButton);
+
+      const participant1Option = screen.getByRole('menuitemcheckbox', {
+        name: mockParticipant1.name,
+      });
+      const participant2Option = screen.getByRole('menuitemcheckbox', {
+        name: mockParticipant2.name,
+      });
+      expect(participant1Option).toBeInTheDocument();
+      expect(participant2Option).toBeInTheDocument();
+    });
+    it('can switch to another participant', async () => {
+      const user = userEvent.setup();
+      renderParticipantSwitcherWithContext(participantContextValue, userContextValue);
+
+      const participantSwitcherButton = screen.getByRole('button', { name: mockParticipant1.name });
+      await user.click(participantSwitcherButton);
+      const participant2Option = screen.getByRole('menuitemcheckbox', {
+        name: mockParticipant2.name,
+      });
+      await user.click(participant2Option);
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        expect.stringContaining(`participant/${mockParticipant2.id}`)
+      );
+      const updatedParticipantSwitcherButton = screen.getByRole('button', {
+        name: mockParticipant2.name,
+      });
+      expect(updatedParticipantSwitcherButton).toBeInTheDocument();
+    });
+  });
+});

--- a/src/web/components/Navigation/ParticipantSwitcher.tsx
+++ b/src/web/components/Navigation/ParticipantSwitcher.tsx
@@ -9,7 +9,7 @@ import { SelectDropdown, SelectOption } from '../Input/SelectDropdown';
 import './ParticipantSwitcher.scss';
 
 export function ParticipantSwitcher() {
-  const { participant } = useContext(ParticipantContext);
+  const { participant, setParticipant } = useContext(ParticipantContext);
   const { LoggedInUser } = useContext(CurrentUserContext);
   const navigate = useNavigate();
   const location = useLocation();
@@ -27,6 +27,12 @@ export function ParticipantSwitcher() {
   const handleOnSelectedChange = (selectedParticipantId: SelectOption<number>) => {
     const newPath = getPathWithParticipant(location.pathname, selectedParticipantId.id);
     navigate(newPath);
+    const selectedParticipant = LoggedInUser?.user?.participants?.find(
+      (p) => p.id === selectedParticipantId.id
+    );
+    if (selectedParticipant) {
+      setParticipant(selectedParticipant);
+    }
   };
 
   const showDropdown = (LoggedInUser?.user?.participants?.length ?? 0) > 1;

--- a/src/web/components/Navigation/ParticipantSwitcher.tsx
+++ b/src/web/components/Navigation/ParticipantSwitcher.tsx
@@ -19,10 +19,9 @@ export function ParticipantSwitcher() {
       id: value.id,
       name: value.name,
     })) ?? [];
-  const sortedParticipantOptions = participantOptions.sort((a, b) => a.name.localeCompare(b.name));
-  const currentParticipantOption = sortedParticipantOptions.filter(
-    (x) => x.id === participant!.id
-  )[0];
+  const currentParticipantOption = participantOptions.find(
+    (option) => option.id === participant?.id
+  );
 
   const handleOnSelectedChange = (selectedParticipantId: SelectOption<number>) => {
     const newPath = getPathWithParticipant(location.pathname, selectedParticipantId.id);
@@ -42,11 +41,11 @@ export function ParticipantSwitcher() {
       {showDropdown ? (
         <SelectDropdown
           initialValue={currentParticipantOption}
-          options={sortedParticipantOptions}
+          options={participantOptions}
           onSelectedChange={handleOnSelectedChange}
         />
       ) : (
-        <div className='participant-name'>{participant!.name}</div>
+        participant && <div className='participant-name'>{participant.name}</div>
       )}
     </div>
   );

--- a/src/web/components/Navigation/ParticipantSwitcher.tsx
+++ b/src/web/components/Navigation/ParticipantSwitcher.tsx
@@ -1,0 +1,47 @@
+import { useContext } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { CurrentUserContext } from '../../contexts/CurrentUserProvider';
+import { ParticipantContext } from '../../contexts/ParticipantProvider';
+import { getPathWithParticipant } from '../../utils/urlHelpers';
+import { SelectDropdown, SelectOption } from '../Input/SelectDropdown';
+
+import './ParticipantSwitcher.scss';
+
+export function ParticipantSwitcher() {
+  const { participant } = useContext(ParticipantContext);
+  const { LoggedInUser } = useContext(CurrentUserContext);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const participantOptions: SelectOption<number>[] =
+    LoggedInUser?.user?.participants?.map((value) => ({
+      id: value.id,
+      name: value.name,
+    })) ?? [];
+  const sortedParticipantOptions = participantOptions.sort((a, b) => a.name.localeCompare(b.name));
+  const currentParticipantOption = sortedParticipantOptions.filter(
+    (x) => x.id === participant!.id
+  )[0];
+
+  const handleOnSelectedChange = (selectedParticipantId: SelectOption<number>) => {
+    const newPath = getPathWithParticipant(location.pathname, selectedParticipantId.id);
+    navigate(newPath);
+  };
+
+  const showDropdown = (LoggedInUser?.user?.participants?.length ?? 0) > 1;
+
+  return (
+    <div className='participant-switcher'>
+      {showDropdown ? (
+        <SelectDropdown
+          initialValue={currentParticipantOption}
+          options={sortedParticipantOptions}
+          onSelectedChange={handleOnSelectedChange}
+        />
+      ) : (
+        <div className='participant-name'>{participant!.name}</div>
+      )}
+    </div>
+  );
+}

--- a/src/web/components/Navigation/SideNav.tsx
+++ b/src/web/components/Navigation/SideNav.tsx
@@ -8,6 +8,7 @@ import { NavLink, useParams } from 'react-router-dom';
 import config from '../../../../package.json';
 import { PortalRoute } from '../../screens/routeUtils';
 import { getPathWithParticipant } from '../../utils/urlHelpers';
+import { ParticipantSwitcher } from './ParticipantSwitcher';
 
 import './SideNav.scss';
 
@@ -40,6 +41,8 @@ export function SideNav({ standardMenu, adminMenu }: SideNavProps) {
   return (
     <NavigationMenu className='side-nav'>
       <NavigationMenuList className='main-nav'>
+        <ParticipantSwitcher />
+        <div className='side-nav-divider' />
         {standardMenu
           .filter((m) => (m.location ?? 'default') === 'default')
           .map((m) => MenuItem(m))}

--- a/src/web/contexts/CurrentUserProvider.tsx
+++ b/src/web/contexts/CurrentUserProvider.tsx
@@ -6,7 +6,7 @@ import { Loading } from '../components/Core/Loading/Loading';
 import { GetLoggedInUserAccount, UserAccount } from '../services/userAccount';
 import { useAsyncThrowError } from '../utils/errorHandler';
 
-type UserContextWithSetter = {
+export type UserContextWithSetter = {
   LoggedInUser: UserAccount | null;
   loadUser: () => Promise<void>;
 };

--- a/src/web/contexts/ParticipantProvider.tsx
+++ b/src/web/contexts/ParticipantProvider.tsx
@@ -9,7 +9,7 @@ import { useAsyncThrowError } from '../utils/errorHandler';
 import { parseParticipantId } from '../utils/urlHelpers';
 import { CurrentUserContext } from './CurrentUserProvider';
 
-type ParticipantWithSetter = {
+export type ParticipantWithSetter = {
   participant: ParticipantDTO | null;
   setParticipant: (participant: ParticipantDTO) => void;
 };

--- a/src/web/utils/urlHelpers.ts
+++ b/src/web/utils/urlHelpers.ts
@@ -25,7 +25,7 @@ export const extractLocationFromPath = (path: string) => {
   return match ? match[1] : path.replace(/^\/?:?participantId\/?/, '');
 };
 
-export function getPathWithParticipant(path: string, participantId: string | undefined) {
+export function getPathWithParticipant(path: string, participantId: string | number | undefined) {
   const location = extractLocationFromPath(path);
   return `/participant/${participantId}/${location}`;
 }


### PR DESCRIPTION
- Update user service so that if user is UID2 support, then populate their participants with all approved participants
- New Participant Switcher UI component, largely driven off react context (rather than prop-drilling). Renders a dropdown if the user has access to multiple participants, otherwise it just displays the user's current participant name. Add this switcher to the side nav.
- First example of testing while mocking user and/or participant context. Expanded the existing `TestContextProvider` so one can optionally provide participant and user context values.

## User can only access one participant
![Screenshot 2024-09-16 163930](https://github.com/user-attachments/assets/3cb3715f-050f-40f7-970c-2a3ca9828284)

## User can access two participants

https://github.com/user-attachments/assets/8eb9bc3e-bcd3-4136-b4ba-203520986e0d

## User can access many participants

https://github.com/user-attachments/assets/328b9d6c-edac-4d1c-9c33-99023b76a9ea

## Future work
UX improvements like search in the dropdown
