### PR TITLE
Split up `participantsRouter` file

### DIFF
--- a/src/api/routers/participants/participantsApiKeys.ts
+++ b/src/api/routers/participants/participantsApiKeys.ts
@@ -1,0 +1,194 @@
+import { Response } from 'express';
+import { z } from 'zod';
+
+import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
+import { siteIdNotSetError } from '../../helpers/errorHelpers';
+import { getTraceId } from '../../helpers/loggingHelpers';
+import {
+  createApiKey,
+  disableApiKey,
+  getApiKeysBySite,
+  renameApiKey,
+  updateApiKeyRoles,
+} from '../../services/adminServiceClient';
+import { mapAdminApiKeysToApiKeyDTOs } from '../../services/adminServiceHelpers';
+import {
+  createdApiKeyToApiKeySecrets,
+  getApiKey,
+  getApiRoles,
+  validateApiRoles,
+} from '../../services/apiKeyService';
+import {
+  constructAuditTrailObject,
+  performAsyncOperationWithAuditTrail,
+} from '../../services/auditTrailService';
+import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
+
+export const handleGetParticipantApiKeys = async (req: ParticipantRequest, res: Response) => {
+  const { participant } = req;
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const adminApiKeys = await getApiKeysBySite(participant.siteId);
+  const enabledAdminApiKeys = adminApiKeys.filter((key) => !key.disabled);
+  const apiKeys = await mapAdminApiKeysToApiKeyDTOs(enabledAdminApiKeys);
+
+  return res.status(200).json(apiKeys);
+};
+
+const apiKeyIdSchema = z.object({
+  keyId: z.string(),
+});
+export const handleGetParticipantApiKey = async (req: ParticipantRequest, res: Response) => {
+  const { participant } = req;
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const { keyId } = apiKeyIdSchema.parse(req.query);
+  if (!keyId) {
+    return res.status(400).send('Key id is not set');
+  }
+
+  const apiKey = await getApiKey(participant.siteId, keyId);
+  if (!apiKey) {
+    return res.status(404).send('Could not find participants key with keyId');
+  }
+
+  return res.status(200).json(apiKey);
+};
+
+const apiKeyCreateInputSchema = z.object({ name: z.string(), roles: z.array(z.string()) });
+export const handleAddApiKey = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { name: keyName, roles: apiRoles } = apiKeyCreateInputSchema.parse(req.body);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+  if (!validateApiRoles(apiRoles, await getApiRoles(participant))) {
+    return res.status(400).send('Invalid API Permissions');
+  }
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ManageApiKey,
+    {
+      action: AuditAction.Add,
+      siteId: participant.siteId,
+      keyName,
+      apiRoles,
+    },
+    participant!.id
+  );
+
+  const key = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => {
+      return createApiKey(keyName, apiRoles, participant.siteId!);
+    }
+  );
+
+  return res.status(200).json(createdApiKeyToApiKeySecrets(key));
+};
+
+const apiKeyEditInputSchema = z.object({
+  keyId: z.string(),
+  newName: z.string(),
+  newApiRoles: z.array(z.string()),
+});
+export const handleUpdateApiKey = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const { keyId, newName, newApiRoles } = apiKeyEditInputSchema.parse(req.body);
+
+  const editedKey = await getApiKey(participant.siteId, keyId);
+  if (!editedKey) {
+    return res.status(404).send('SiteId was invalid');
+  }
+
+  const traceId = getTraceId(req);
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ManageApiKey,
+    {
+      action: AuditAction.Update,
+      siteId: participant.siteId,
+      keyId: editedKey.key_id,
+      keyName: editedKey.name,
+      newKeyName: newName,
+      apiRoles: editedKey.roles.map((role) => role.roleName),
+      newApiRoles,
+    },
+    participant!.id
+  );
+
+  await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
+    const participantRoles = await getApiRoles(participant);
+    const validRoles = editedKey.roles.concat(participantRoles);
+    if (!validateApiRoles(newApiRoles, validRoles)) {
+      return res.status(401).send('API Permissions are invalid');
+    }
+
+    if (!newName) {
+      return res.status(400).send('Name is invalid');
+    }
+
+    const apiKeyNameChanged = newName !== editedKey.name;
+    if (apiKeyNameChanged) {
+      await renameApiKey(editedKey.contact, newName);
+    }
+
+    const apiKeyRolesChanged =
+      editedKey.roles
+        .map((role) => role.roleName)
+        .sort()
+        .join(',') !== newApiRoles.sort().join(',');
+    if (apiKeyRolesChanged) {
+      await updateApiKeyRoles(editedKey.contact, newApiRoles);
+    }
+  });
+  return res.sendStatus(200);
+};
+
+const apiKeyDeleteInputSchema = z.object({
+  keyId: z.string(),
+});
+export const handleDeleteApiKey = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { keyId } = apiKeyDeleteInputSchema.parse(req.body);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+  const apiKey = await getApiKey(participant.siteId, keyId);
+  if (!apiKey) {
+    return res.status(404).send('SiteId was invalid');
+  }
+
+  const traceId = getTraceId(req);
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ManageApiKey,
+    {
+      action: AuditAction.Delete,
+      siteId: participant.siteId,
+      keyName: apiKey.name,
+      apiRoles: apiKey.roles.map((role) => role.roleName),
+      keyId: apiKey.key_id,
+    },
+    participant!.id
+  );
+
+  await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () =>
+    disableApiKey(apiKey.contact)
+  );
+
+  return res.sendStatus(200);
+};

--- a/src/api/routers/participants/participantsAppIds.ts
+++ b/src/api/routers/participants/participantsAppIds.ts
@@ -11,7 +11,7 @@ import {
 } from '../../services/auditTrailService';
 import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
 
-export async function getParticipantAppNames(req: ParticipantRequest, res: Response) {
+export async function handleGetParticipantAppNames(req: ParticipantRequest, res: Response) {
   const { participant } = req;
   if (!participant?.siteId) {
     return siteIdNotSetError(req, res);
@@ -21,7 +21,7 @@ export async function getParticipantAppNames(req: ParticipantRequest, res: Respo
 }
 
 const appNamesSchema = z.object({ appNames: z.array(z.string()) });
-export async function setParticipantAppNames(req: UserParticipantRequest, res: Response) {
+export async function handleSetParticipantAppNames(req: UserParticipantRequest, res: Response) {
   const { participant, user } = req;
   const { appNames } = appNamesSchema.parse(req.body);
   const traceId = getTraceId(req);

--- a/src/api/routers/participants/participantsApproval.ts
+++ b/src/api/routers/participants/participantsApproval.ts
@@ -1,0 +1,95 @@
+import { Response } from 'express';
+
+import { AuditTrailEvents } from '../../entities/AuditTrail';
+import { ParticipantApprovalPartial, ParticipantStatus } from '../../entities/Participant';
+import { getTraceId } from '../../helpers/loggingHelpers';
+import { getKcAdminClient } from '../../keycloakAdminClient';
+import { setSiteClientTypes } from '../../services/adminServiceClient';
+import { ParticipantApprovalResponse } from '../../services/adminServiceHelpers';
+import {
+  constructAuditTrailObject,
+  performAsyncOperationWithAuditTrail,
+} from '../../services/auditTrailService';
+import { assignApiParticipantMemberRole } from '../../services/kcUsersService';
+import {
+  getParticipantsApproved,
+  getParticipantsAwaitingApproval,
+  mapParticipantToApprovalRequest,
+  ParticipantRequest,
+  ParticipantRequestDTO,
+  sendParticipantApprovedEmail,
+  updateParticipantAndTypesAndApiRoles,
+  UserParticipantRequest,
+} from '../../services/participantsService';
+import { getAllUserFromParticipant } from '../../services/usersService';
+
+export const handleGetParticipantsAwaitingApproval = async (
+  req: ParticipantRequest,
+  res: Response
+) => {
+  const email = String(req.auth?.payload?.email);
+  const participantsAwaitingApproval = await getParticipantsAwaitingApproval(email);
+  const result: ParticipantRequestDTO[] = participantsAwaitingApproval.map(
+    mapParticipantToApprovalRequest
+  );
+  return res.status(200).json(result);
+};
+
+export const handleGetApprovedParticipants = async (_req: ParticipantRequest, res: Response) => {
+  const participants = await getParticipantsApproved();
+  const result = participants.sort((a, b) => a.name.localeCompare(b.name));
+  return res.status(200).json(result);
+};
+
+export const handleApproveParticipant = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const traceId = getTraceId(req);
+  const data = {
+    ...ParticipantApprovalPartial.parse(req.body),
+    status: ParticipantStatus.Approved,
+    approverId: user?.id,
+    dateApproved: new Date(),
+  };
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ApproveAccount,
+    {
+      oldName: participant?.name,
+      siteId: data.siteId!,
+      newName: data.name,
+      oldTypeIds: participant?.types!.map((type) => type.id),
+      newTypeIds: data.types.map((type) => type.id),
+      apiRoles: data.apiRoles.map((role) => role.id),
+    },
+    participant!.id
+  );
+
+  const users = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => {
+      const kcAdminClient = await getKcAdminClient();
+      const usersFromParticipant = await getAllUserFromParticipant(participant!);
+      // if there are no users, send email to the approver
+      const emailRecipient = usersFromParticipant.length > 0 ? usersFromParticipant : [user!];
+      await setSiteClientTypes(data);
+      await Promise.all(
+        usersFromParticipant.map((currentUser) =>
+          assignApiParticipantMemberRole(kcAdminClient, currentUser.email)
+        )
+      );
+
+      await updateParticipantAndTypesAndApiRoles(participant!, data);
+      await sendParticipantApprovedEmail(emailRecipient, traceId);
+
+      return usersFromParticipant;
+    }
+  );
+
+  const approvalResponse: ParticipantApprovalResponse = {
+    users,
+  };
+
+  return res.status(200).json(approvalResponse);
+};

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -176,7 +176,10 @@ export async function handleCreateParticipant(req: ParticipantRequest, res: Resp
   return res.sendStatus(200);
 }
 
-export const createParticipantFromRequest = async (req: ParticipantRequest, res: Response) => {
+export const handleCreateParticipantFromRequest = async (
+  req: ParticipantRequest,
+  res: Response
+) => {
   try {
     const traceId = getTraceId(req);
     const parsedRequest = ParticipantCreationPartial.parse(req.body);

--- a/src/api/routers/participants/participantsDomainNames.ts
+++ b/src/api/routers/participants/participantsDomainNames.ts
@@ -11,7 +11,7 @@ import {
 } from '../../services/auditTrailService';
 import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
 
-export async function getParticipantDomainNames(req: ParticipantRequest, res: Response) {
+export async function handleGetParticipantDomainNames(req: ParticipantRequest, res: Response) {
   const { participant } = req;
   if (!participant?.siteId) {
     return siteIdNotSetError(req, res);
@@ -21,7 +21,7 @@ export async function getParticipantDomainNames(req: ParticipantRequest, res: Re
 }
 
 const domainNamesSchema = z.object({ domainNames: z.array(z.string()) });
-export async function setParticipantDomainNames(req: UserParticipantRequest, res: Response) {
+export async function handleSetParticipantDomainNames(req: UserParticipantRequest, res: Response) {
   const { participant, user } = req;
   const { domainNames } = domainNamesSchema.parse(req.body);
   const traceId = getTraceId(req);

--- a/src/api/routers/participants/participantsKeyPairs.spec.ts
+++ b/src/api/routers/participants/participantsKeyPairs.spec.ts
@@ -8,7 +8,7 @@ import { Participant, ParticipantStatus } from '../../entities/Participant';
 import { SSP_ADMIN_SERVICE_BASE_URL } from '../../envars';
 import { KeyPairDTO } from '../../services/adminServiceHelpers';
 import { ParticipantRequest } from '../../services/participantsService';
-import { getParticipantKeyPairs } from './participantsKeyPairs';
+import { handleGetParticipantKeyPairs } from './participantsKeyPairs';
 
 const noKeyPairsSiteId = 10;
 const singleKeyPairSiteId = 11;
@@ -85,7 +85,7 @@ const handlers = [
 
 const server = setupServer(...handlers);
 
-describe('#getParticipantKeyPairs', () => {
+describe('Get participant key pairs', () => {
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
@@ -106,7 +106,7 @@ describe('#getParticipantKeyPairs', () => {
 
     const { res } = createResponseObject();
 
-    await getParticipantKeyPairs(participantRequest, res);
+    await handleGetParticipantKeyPairs(participantRequest, res);
 
     expect(res.status).toHaveBeenLastCalledWith(400);
   });
@@ -137,7 +137,7 @@ describe('#getParticipantKeyPairs', () => {
     res.status = jest.fn(() => res);
     const enabledKeys = keys.filter((key) => !key.disabled);
 
-    await getParticipantKeyPairs(participantRequest, res);
+    await handleGetParticipantKeyPairs(participantRequest, res);
 
     expect(res.status).toHaveBeenLastCalledWith(200);
     expect(res.json).toHaveBeenLastCalledWith(enabledKeys);

--- a/src/api/routers/participants/participantsKeyPairs.ts
+++ b/src/api/routers/participants/participantsKeyPairs.ts
@@ -1,11 +1,17 @@
 import { Response } from 'express';
+import { z } from 'zod';
 
+import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import { siteIdNotSetError } from '../../helpers/errorHelpers';
 import { getTraceId } from '../../helpers/loggingHelpers';
-import { getKeyPairsList } from '../../services/adminServiceClient';
-import { ParticipantRequest } from '../../services/participantsService';
+import { addKeyPair, getKeyPairsList, updateKeyPair } from '../../services/adminServiceClient';
+import {
+  constructAuditTrailObject,
+  performAsyncOperationWithAuditTrail,
+} from '../../services/auditTrailService';
+import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
 
-export async function getParticipantKeyPairs(req: ParticipantRequest, res: Response) {
+export const handleGetParticipantKeyPairs = async (req: ParticipantRequest, res: Response) => {
   const { participant } = req;
   if (!participant?.siteId) {
     return siteIdNotSetError(req, res);
@@ -14,4 +20,105 @@ export async function getParticipantKeyPairs(req: ParticipantRequest, res: Respo
   const traceId = getTraceId(req);
   const allKeyPairs = await getKeyPairsList(siteId, traceId);
   return res.status(200).json(allKeyPairs);
-}
+};
+
+const keyPairSchema = z.object({
+  name: z.string(),
+  disabled: z.boolean(),
+  subscriptionId: z.string(),
+});
+const addKeyPairSchema = z.object({
+  name: z.string(),
+});
+export const handleAddKeyPair = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { name } = addKeyPairSchema.parse(req.body);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const disabled = false;
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ManageKeyPair,
+    {
+      action: AuditAction.Add,
+      siteId: participant.siteId,
+      name,
+      disabled,
+    },
+    participant!.id
+  );
+
+  const keyPairs = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => addKeyPair(participant.siteId!, name)
+  );
+
+  return res.status(201).json(keyPairs);
+};
+
+export const handleUpdateKeyPair = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { name, subscriptionId, disabled } = keyPairSchema.parse(req.body);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ManageKeyPair,
+    {
+      action: AuditAction.Update,
+      siteId: participant.siteId,
+      name,
+      disabled,
+    },
+    participant!.id
+  );
+
+  const updatedKeyPair = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => updateKeyPair(subscriptionId, name)
+  );
+
+  return res.status(201).json(updatedKeyPair);
+};
+
+export const handleDeleteKeyPair = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { name, subscriptionId } = keyPairSchema.parse(req.body.keyPair);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const disabledDate = new Date().toISOString();
+  const disabledKeyPairName = `${name}-disabled-${disabledDate}`;
+  const disabled = true;
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.ManageKeyPair,
+    {
+      action: AuditAction.Delete,
+      siteId: participant.siteId,
+      name,
+      disabled,
+    },
+    participant!.id
+  );
+
+  await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () =>
+    updateKeyPair(subscriptionId, disabledKeyPairName, disabled)
+  );
+
+  return res.sendStatus(200);
+};

--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -1,675 +1,139 @@
-import { AxiosError } from 'axios';
 import express, { Response } from 'express';
-import { z } from 'zod';
 
 import { ApiRoleDTO } from '../../entities/ApiRole';
-import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
-import {
-  Participant,
-  ParticipantApprovalPartial,
-  ParticipantDTO,
-  ParticipantStatus,
-} from '../../entities/Participant';
-import { UserDTO } from '../../entities/User';
-import { siteIdNotSetError } from '../../helpers/errorHelpers';
-import { getTraceId } from '../../helpers/loggingHelpers';
-import { getKcAdminClient } from '../../keycloakAdminClient';
+import { Participant } from '../../entities/Participant';
 import { isApproverCheck } from '../../middleware/approversMiddleware';
 import { verifyAndEnrichParticipant } from '../../middleware/participantsMiddleware';
 import { enrichCurrentUser } from '../../middleware/usersMiddleware';
+import { getApiRoles } from '../../services/apiKeyService';
 import {
-  addKeyPair,
-  createApiKey,
-  disableApiKey,
-  getApiKeysBySite,
-  getSharingList,
-  renameApiKey,
-  setSiteClientTypes,
-  updateApiKeyRoles,
-  updateKeyPair,
-} from '../../services/adminServiceClient';
-import {
-  mapAdminApiKeysToApiKeyDTOs,
-  ParticipantApprovalResponse,
-} from '../../services/adminServiceHelpers';
-import {
-  createdApiKeyToApiKeySecrets,
-  getApiKey,
-  getApiRoles,
-  validateApiRoles,
-} from '../../services/apiKeyService';
-import {
-  constructAuditTrailObject,
-  performAsyncOperationWithAuditTrail,
-} from '../../services/auditTrailService';
-import { assignApiParticipantMemberRole } from '../../services/kcUsersService';
-import {
-  addSharingParticipants,
-  deleteSharingParticipants,
-  getParticipantsApproved,
-  getParticipantsAwaitingApproval,
   ParticipantRequest,
-  sendParticipantApprovedEmail,
   updateParticipant,
-  updateParticipantAndTypesAndApiRoles,
-  UpdateSharingTypes,
   UserParticipantRequest,
 } from '../../services/participantsService';
-import { getSignedParticipants } from '../../services/signedParticipantsService';
-import { getAllUserFromParticipant } from '../../services/usersService';
 import { createBusinessContactsRouter } from '../businessContactsRouter';
 import { createParticipantUsersRouter } from '../participantUsersRouter';
-import { getParticipantAppNames, setParticipantAppNames } from './participantsAppIds';
-import { createParticipantFromRequest, handleCreateParticipant } from './participantsCreation';
-import { getParticipantDomainNames, setParticipantDomainNames } from './participantsDomainNames';
-import { getParticipantKeyPairs } from './participantsKeyPairs';
-import { getParticipantUsers, handleInviteUserToParticipant } from './participantsUsers';
+import {
+  handleAddApiKey,
+  handleDeleteApiKey,
+  handleGetParticipantApiKey,
+  handleGetParticipantApiKeys,
+  handleUpdateApiKey,
+} from './participantsApiKeys';
+import { handleGetParticipantAppNames, handleSetParticipantAppNames } from './participantsAppIds';
+import {
+  handleApproveParticipant,
+  handleGetApprovedParticipants,
+  handleGetParticipantsAwaitingApproval,
+} from './participantsApproval';
+import {
+  handleCreateParticipant,
+  handleCreateParticipantFromRequest,
+} from './participantsCreation';
+import {
+  handleGetParticipantDomainNames,
+  handleSetParticipantDomainNames,
+} from './participantsDomainNames';
+import {
+  handleAddKeyPair,
+  handleDeleteKeyPair,
+  handleGetParticipantKeyPairs,
+  handleUpdateKeyPair,
+} from './participantsKeyPairs';
+import {
+  handleAddSharingPermission,
+  handleGetSharingPermission,
+  handleRemoveSharingPermission,
+  handleUpdateSharingTypes,
+} from './participantsSharingPermissions';
+import { handleGetSignedParticipants } from './participantsSigned';
+import { handleGetParticipantUsers, handleInviteUserToParticipant } from './participantsUsers';
 
-export type AvailableParticipantDTO = Required<Pick<ParticipantDTO, 'name' | 'siteId' | 'types'>>;
-
-export type ParticipantRequestDTO = Pick<
-  ParticipantDTO,
-  'id' | 'name' | 'siteId' | 'types' | 'status' | 'apiRoles'
-> & {
-  requestingUser: Pick<UserDTO, 'email'> &
-    Partial<Pick<UserDTO, 'jobFunction'>> & { fullName: string };
+const handleUpdateParticipant = async (req: UserParticipantRequest, res: Response) => {
+  const { participant } = req;
+  if (!participant) {
+    return res.status(404).send('Unable to find participant');
+  }
+  await updateParticipant(participant, req);
+  return res.sendStatus(200);
 };
 
-export const ClientTypeEnum = z.enum(['DSP', 'ADVERTISER', 'DATA_PROVIDER', 'PUBLISHER']);
+const handleGetParticipant = async (req: ParticipantRequest, res: Response) => {
+  const { participant } = req;
+  return res.status(200).json(participant);
+};
 
-function mapParticipantToApprovalRequest(participant: Participant): ParticipantRequestDTO {
-  // There should usually only be one user at this point - but if there are multiple, the first one is preferred.
-  const firstUser = participant.users?.sort((a, b) => a.id - b.id)[0];
-  return {
-    id: participant.id,
-    name: participant.name,
-    siteId: participant.siteId,
-    types: participant.types,
-    apiRoles: participant.apiRoles,
-    status: participant.status,
-    requestingUser: {
-      email: firstUser ? firstUser.email : '',
-      jobFunction: firstUser?.jobFunction,
-      fullName: firstUser
-        ? firstUser?.fullName()
-        : 'There is no user attached to this participant.',
-    },
-  };
-}
+const handleGetParticipantApiRoles = async (req: ParticipantRequest, res: Response) => {
+  const { participant } = req;
+  const apiRoles: ApiRoleDTO[] = await getApiRoles(participant!);
+  return res.status(200).json(apiRoles);
+};
+
+const handleCompleteRecommendations = async (req: ParticipantRequest, res: Response) => {
+  const { participant } = req;
+  const updatedParticipant = await Participant.query()
+    .patchAndFetchById(participant!.id, {
+      completedRecommendations: true,
+    })
+    .withGraphFetched('types');
+  return res.status(200).json(updatedParticipant);
+};
 
 export function createParticipantsRouter() {
   const participantsRouter = express.Router();
 
+  participantsRouter.get('/signed', handleGetSignedParticipants);
+  participantsRouter.post('/', handleCreateParticipantFromRequest);
+
   participantsRouter.get(
     '/awaitingApproval',
     isApproverCheck,
-    async (req: ParticipantRequest, res) => {
-      const email = String(req.auth?.payload?.email);
-      const participantsAwaitingApproval = await getParticipantsAwaitingApproval(email);
-      const result: ParticipantRequestDTO[] = participantsAwaitingApproval.map(
-        mapParticipantToApprovalRequest
-      );
-      return res.status(200).json(result);
-    }
+    handleGetParticipantsAwaitingApproval
   );
-
-  participantsRouter.get('/approved', isApproverCheck, async (req, res) => {
-    const participants = await getParticipantsApproved();
-    const result = participants.sort((a, b) => a.name.localeCompare(b.name));
-    return res.status(200).json(result);
-  });
-
-  participantsRouter.get('/signed', async (_req, res) => {
-    const signedParticipants = await getSignedParticipants();
-    const result = signedParticipants.sort((a, b) => a.name.localeCompare(b.name));
-    return res.status(200).json(result);
-  });
-
-  participantsRouter.post('/', createParticipantFromRequest);
+  participantsRouter.get('/approved', isApproverCheck, handleGetApprovedParticipants);
 
   participantsRouter.use('/:participantId', enrichCurrentUser);
 
-  participantsRouter.put(
-    '/:participantId/approve',
-    isApproverCheck,
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const traceId = getTraceId(req);
-      const data = {
-        ...ParticipantApprovalPartial.parse(req.body),
-        status: ParticipantStatus.Approved,
-        approverId: user?.id,
-        dateApproved: new Date(),
-      };
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ApproveAccount,
-        {
-          oldName: participant?.name,
-          siteId: data.siteId!,
-          newName: data.name,
-          oldTypeIds: participant?.types!.map((type) => type.id),
-          newTypeIds: data.types.map((type) => type.id),
-          apiRoles: data.apiRoles.map((role) => role.id),
-        },
-        participant!.id
-      );
-
-      const users = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => {
-          const kcAdminClient = await getKcAdminClient();
-          const usersFromParticipant = await getAllUserFromParticipant(participant!);
-          // if there are no users, send email to the approver
-          const emailRecipient = usersFromParticipant.length > 0 ? usersFromParticipant : [user!];
-          await setSiteClientTypes(data);
-          await Promise.all(
-            usersFromParticipant.map((currentUser) =>
-              assignApiParticipantMemberRole(kcAdminClient, currentUser.email)
-            )
-          );
-
-          await updateParticipantAndTypesAndApiRoles(participant!, data);
-          await sendParticipantApprovedEmail(emailRecipient, traceId);
-
-          return usersFromParticipant;
-        }
-      );
-
-      const approvalResponse: ParticipantApprovalResponse = {
-        users,
-      };
-
-      return res.status(200).json(approvalResponse);
-    }
-  );
-
-  participantsRouter.put(
-    '/:participantId',
-    isApproverCheck,
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant } = req;
-
-      if (!participant) {
-        return res.status(404).send('Unable to find participant');
-      }
-
-      await updateParticipant(participant, req);
-
-      return res.sendStatus(200);
-    }
-  );
-
+  participantsRouter.put('/:participantId/approve', isApproverCheck, handleApproveParticipant);
+  participantsRouter.put('/:participantId', isApproverCheck, handleUpdateParticipant);
   participantsRouter.put('/', handleCreateParticipant);
 
   participantsRouter.use('/:participantId', verifyAndEnrichParticipant);
 
-  participantsRouter.get('/:participantId', async (req: ParticipantRequest, res: Response) => {
-    const { participant } = req;
-
-    return res.status(200).json(participant);
-  });
-
+  participantsRouter.get('/:participantId', handleGetParticipant);
+  participantsRouter.get('/:participantId/apiRoles', handleGetParticipantApiRoles);
   participantsRouter.post('/:participantId/invite', handleInviteUserToParticipant);
+  participantsRouter.put('/:participantId/completeRecommendations', handleCompleteRecommendations);
 
-  participantsRouter.get(
-    '/:participantId/sharingPermission',
-    async (req: ParticipantRequest, res: Response) => {
-      const { participant } = req;
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-      const traceId = getTraceId(req);
-      try {
-        const sharingList = await getSharingList(participant.siteId, traceId);
-        return res.status(200).json(sharingList);
-      } catch (err) {
-        if (err instanceof AxiosError && err.response?.status === 404) {
-          return res
-            .status(404)
-            .send({ message: 'This site does not have a keyset.', missingKeyset: true });
-        }
-        throw err;
-      }
-    }
-  );
-
-  participantsRouter.get(
-    '/:participantId/apiKeys',
-    async (req: ParticipantRequest, res: Response) => {
-      const { participant } = req;
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const adminApiKeys = await getApiKeysBySite(participant.siteId);
-      const enabledAdminApiKeys = adminApiKeys.filter((key) => !key.disabled);
-      const apiKeys = await mapAdminApiKeysToApiKeyDTOs(enabledAdminApiKeys);
-
-      return res.status(200).json(apiKeys);
-    }
-  );
-
-  const apiKeyIdSchema = z.object({
-    keyId: z.string(),
-  });
-  participantsRouter.get(
-    '/:participantId/apiKey',
-    async (req: ParticipantRequest, res: Response) => {
-      const { participant } = req;
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const { keyId } = apiKeyIdSchema.parse(req.query);
-      if (!keyId) {
-        return res.status(400).send('Key id is not set');
-      }
-
-      const apiKey = await getApiKey(participant.siteId, keyId);
-      if (!apiKey) {
-        return res.status(404).send('Could not find participants key with keyId');
-      }
-
-      return res.status(200).json(apiKey);
-    }
-  );
-
-  const apiKeyEditInputSchema = z.object({
-    keyId: z.string(),
-    newName: z.string(),
-    newApiRoles: z.array(z.string()),
-  });
-  participantsRouter.put(
-    '/:participantId/apiKey',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const { keyId, newName, newApiRoles } = apiKeyEditInputSchema.parse(req.body);
-
-      const editedKey = await getApiKey(participant.siteId, keyId);
-      if (!editedKey) {
-        return res.status(404).send('SiteId was invalid');
-      }
-
-      const traceId = getTraceId(req);
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ManageApiKey,
-        {
-          action: AuditAction.Update,
-          siteId: participant.siteId,
-          keyId: editedKey.key_id,
-          keyName: editedKey.name,
-          newKeyName: newName,
-          apiRoles: editedKey.roles.map((role) => role.roleName),
-          newApiRoles,
-        },
-        participant!.id
-      );
-
-      await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
-        const participantRoles = await getApiRoles(participant);
-        const validRoles = editedKey.roles.concat(participantRoles);
-        if (!validateApiRoles(newApiRoles, validRoles)) {
-          return res.status(401).send('API Permissions are invalid');
-        }
-
-        if (!newName) {
-          return res.status(400).send('Name is invalid');
-        }
-
-        const apiKeyNameChanged = newName !== editedKey.name;
-        if (apiKeyNameChanged) {
-          await renameApiKey(editedKey.contact, newName);
-        }
-
-        const apiKeyRolesChanged =
-          editedKey.roles
-            .map((role) => role.roleName)
-            .sort()
-            .join(',') !== newApiRoles.sort().join(',');
-        if (apiKeyRolesChanged) {
-          await updateApiKeyRoles(editedKey.contact, newApiRoles);
-        }
-      });
-      return res.sendStatus(200);
-    }
-  );
-
-  const apiKeyDeleteInputSchema = z.object({
-    keyId: z.string(),
-  });
-  participantsRouter.delete(
-    '/:participantId/apiKey',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { keyId } = apiKeyDeleteInputSchema.parse(req.body);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-      const apiKey = await getApiKey(participant.siteId, keyId);
-      if (!apiKey) {
-        return res.status(404).send('SiteId was invalid');
-      }
-
-      const traceId = getTraceId(req);
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ManageApiKey,
-        {
-          action: AuditAction.Delete,
-          siteId: participant.siteId,
-          keyName: apiKey.name,
-          apiRoles: apiKey.roles.map((role) => role.roleName),
-          keyId: apiKey.key_id,
-        },
-        participant!.id
-      );
-
-      await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () =>
-        disableApiKey(apiKey.contact)
-      );
-
-      return res.sendStatus(200);
-    }
-  );
-
-  participantsRouter.get(
-    '/:participantId/apiRoles',
-    async (req: ParticipantRequest, res: Response) => {
-      const { participant } = req;
-
-      const apiRoles: ApiRoleDTO[] = await getApiRoles(participant!);
-
-      return res.status(200).json(apiRoles);
-    }
-  );
-
-  const apiKeyCreateInputSchema = z.object({ name: z.string(), roles: z.array(z.string()) });
-  participantsRouter.post(
-    '/:participantId/apiKey',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { name: keyName, roles: apiRoles } = apiKeyCreateInputSchema.parse(req.body);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-      if (!validateApiRoles(apiRoles, await getApiRoles(participant))) {
-        return res.status(400).send('Invalid API Permissions');
-      }
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ManageApiKey,
-        {
-          action: AuditAction.Add,
-          siteId: participant.siteId,
-          keyName,
-          apiRoles,
-        },
-        participant!.id
-      );
-
-      const key = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => {
-          return createApiKey(keyName, apiRoles, participant.siteId!);
-        }
-      );
-
-      return res.status(200).json(createdApiKeyToApiKeySecrets(key));
-    }
-  );
-
-  const sharingRelationSchema = z.object({
-    newParticipantSites: z.array(z.number()),
-  });
-  participantsRouter.post(
-    '/:participantId/sharingPermission/add',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { newParticipantSites } = sharingRelationSchema.parse(req.body);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.UpdateSharingPermissions,
-        {
-          action: AuditAction.Add,
-          sharingPermissions: newParticipantSites,
-          siteId: participant.siteId,
-        },
-        participant!.id
-      );
-
-      const sharingParticipants = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => addSharingParticipants(participant.siteId!, newParticipantSites, traceId)
-      );
-
-      return res.status(200).json(sharingParticipants);
-    }
-  );
-
-  const keyPairSchema = z.object({
-    name: z.string(),
-    disabled: z.boolean(),
-    subscriptionId: z.string(),
-  });
-  const addKeyPairSchema = z.object({
-    name: z.string(),
-  });
-  participantsRouter.post(
-    '/:participantId/keyPair/add',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { name } = addKeyPairSchema.parse(req.body);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const disabled = false;
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ManageKeyPair,
-        {
-          action: AuditAction.Add,
-          siteId: participant.siteId,
-          name,
-          disabled,
-        },
-        participant!.id
-      );
-
-      const keyPairs = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => addKeyPair(participant.siteId!, name)
-      );
-
-      return res.status(201).json(keyPairs);
-    }
-  );
-
-  participantsRouter.post(
-    '/:participantId/keyPair/update',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { name, subscriptionId, disabled } = keyPairSchema.parse(req.body);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ManageKeyPair,
-        {
-          action: AuditAction.Update,
-          siteId: participant.siteId,
-          name,
-          disabled,
-        },
-        participant!.id
-      );
-
-      const updatedKeyPair = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => updateKeyPair(subscriptionId, name)
-      );
-
-      return res.status(201).json(updatedKeyPair);
-    }
-  );
-
-  participantsRouter.delete(
-    '/:participantId/keyPair',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { name, subscriptionId } = keyPairSchema.parse(req.body.keyPair);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const disabledDate = new Date().toISOString();
-      const disabledKeyPairName = `${name}-disabled-${disabledDate}`;
-      const disabled = true;
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.ManageKeyPair,
-        {
-          action: AuditAction.Delete,
-          siteId: participant.siteId,
-          name,
-          disabled,
-        },
-        participant!.id
-      );
-
-      await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () =>
-        updateKeyPair(subscriptionId, disabledKeyPairName, disabled)
-      );
-
-      return res.sendStatus(200);
-    }
-  );
-
-  participantsRouter.get('/:participantId/keyPairs', getParticipantKeyPairs);
-
-  participantsRouter.get('/:participantId/domainNames', getParticipantDomainNames);
-
-  participantsRouter.post('/:participantId/domainNames', setParticipantDomainNames);
-
-  participantsRouter.get('/:participantId/appNames', getParticipantAppNames);
-
-  participantsRouter.post('/:participantId/appNames', setParticipantAppNames);
-
-  const removeSharingRelationSchema = z.object({
-    sharingSitesToRemove: z.array(z.number()),
-  });
-  participantsRouter.post(
-    '/:participantId/sharingPermission/delete',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { sharingSitesToRemove } = removeSharingRelationSchema.parse(req.body);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.UpdateSharingPermissions,
-        {
-          action: AuditAction.Delete,
-          sharingPermissions: sharingSitesToRemove,
-          siteId: participant.siteId,
-        },
-        participant!.id
-      );
-
-      const sharingParticipants = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => deleteSharingParticipants(participant.siteId!, sharingSitesToRemove, traceId)
-      );
-
-      return res.status(200).json(sharingParticipants);
-    }
-  );
-
-  const sharingTypesSchema = z.object({
-    types: z.array(ClientTypeEnum),
-  });
+  participantsRouter.get('/:participantId/sharingPermission', handleGetSharingPermission);
+  participantsRouter.post('/:participantId/sharingPermission/add', handleAddSharingPermission);
   participantsRouter.post(
     '/:participantId/sharingPermission/shareWithTypes',
-    async (req: UserParticipantRequest, res: Response) => {
-      const { participant, user } = req;
-      const { types } = sharingTypesSchema.parse(req.body);
-      const traceId = getTraceId(req);
-
-      if (!participant?.siteId) {
-        return siteIdNotSetError(req, res);
-      }
-
-      const auditTrailInsertObject = constructAuditTrailObject(
-        user!,
-        AuditTrailEvents.UpdateSharingTypes,
-        {
-          siteId: participant.siteId,
-          allowedTypes: types,
-        },
-        participant!.id
-      );
-
-      const sharingParticipants = await performAsyncOperationWithAuditTrail(
-        auditTrailInsertObject,
-        traceId,
-        async () => UpdateSharingTypes(participant.siteId!, types, traceId)
-      );
-
-      return res.status(200).json(sharingParticipants);
-    }
+    handleUpdateSharingTypes
+  );
+  participantsRouter.post(
+    '/:participantId/sharingPermission/delete',
+    handleRemoveSharingPermission
   );
 
-  participantsRouter.put(
-    '/:participantId/completeRecommendations',
-    async (req: ParticipantRequest, res: Response) => {
-      const { participant } = req;
-      const updatedParticipant = await Participant.query()
-        .patchAndFetchById(participant!.id, {
-          completedRecommendations: true,
-        })
-        .withGraphFetched('types');
-      return res.status(200).json(updatedParticipant);
-    }
-  );
+  participantsRouter.get('/:participantId/apiKeys', handleGetParticipantApiKeys);
+  participantsRouter.get('/:participantId/apiKey', handleGetParticipantApiKey);
+  participantsRouter.put('/:participantId/apiKey', handleUpdateApiKey);
+  participantsRouter.post('/:participantId/apiKey', handleAddApiKey);
+  participantsRouter.delete('/:participantId/apiKey', handleDeleteApiKey);
 
-  participantsRouter.get('/:participantId/users', getParticipantUsers);
+  participantsRouter.get('/:participantId/keyPairs', handleGetParticipantKeyPairs);
+  participantsRouter.post('/:participantId/keyPair/add', handleAddKeyPair);
+  participantsRouter.post('/:participantId/keyPair/update', handleUpdateKeyPair);
+  participantsRouter.delete('/:participantId/keyPair', handleDeleteKeyPair);
 
+  participantsRouter.get('/:participantId/domainNames', handleGetParticipantDomainNames);
+  participantsRouter.post('/:participantId/domainNames', handleSetParticipantDomainNames);
+
+  participantsRouter.get('/:participantId/appNames', handleGetParticipantAppNames);
+  participantsRouter.post('/:participantId/appNames', handleSetParticipantAppNames);
+
+  participantsRouter.get('/:participantId/users', handleGetParticipantUsers);
   const participantUsersRouter = createParticipantUsersRouter();
   participantsRouter.use('/:participantId/users', participantUsersRouter);
 

--- a/src/api/routers/participants/participantsSharingPermissions.ts
+++ b/src/api/routers/participants/participantsSharingPermissions.ts
@@ -1,0 +1,135 @@
+import { AxiosError } from 'axios';
+import { Response } from 'express';
+import { z } from 'zod';
+
+import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
+import { siteIdNotSetError } from '../../helpers/errorHelpers';
+import { getTraceId } from '../../helpers/loggingHelpers';
+import { getSharingList } from '../../services/adminServiceClient';
+import {
+  constructAuditTrailObject,
+  performAsyncOperationWithAuditTrail,
+} from '../../services/auditTrailService';
+import {
+  addSharingParticipants,
+  deleteSharingParticipants,
+  ParticipantRequest,
+  UpdateSharingTypes,
+  UserParticipantRequest,
+} from '../../services/participantsService';
+
+export const handleGetSharingPermission = async (req: ParticipantRequest, res: Response) => {
+  const { participant } = req;
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+  const traceId = getTraceId(req);
+  try {
+    const sharingList = await getSharingList(participant.siteId, traceId);
+    return res.status(200).json(sharingList);
+  } catch (err) {
+    if (err instanceof AxiosError && err.response?.status === 404) {
+      return res
+        .status(404)
+        .send({ message: 'This site does not have a keyset.', missingKeyset: true });
+    }
+    throw err;
+  }
+};
+
+const sharingRelationSchema = z.object({
+  newParticipantSites: z.array(z.number()),
+});
+export const handleAddSharingPermission = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { newParticipantSites } = sharingRelationSchema.parse(req.body);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.UpdateSharingPermissions,
+    {
+      action: AuditAction.Add,
+      sharingPermissions: newParticipantSites,
+      siteId: participant.siteId,
+    },
+    participant!.id
+  );
+
+  const sharingParticipants = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => addSharingParticipants(participant.siteId!, newParticipantSites, traceId)
+  );
+
+  return res.status(200).json(sharingParticipants);
+};
+
+const removeSharingRelationSchema = z.object({
+  sharingSitesToRemove: z.array(z.number()),
+});
+export const handleRemoveSharingPermission = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { sharingSitesToRemove } = removeSharingRelationSchema.parse(req.body);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.UpdateSharingPermissions,
+    {
+      action: AuditAction.Delete,
+      sharingPermissions: sharingSitesToRemove,
+      siteId: participant.siteId,
+    },
+    participant!.id
+  );
+
+  const sharingParticipants = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => deleteSharingParticipants(participant.siteId!, sharingSitesToRemove, traceId)
+  );
+
+  return res.status(200).json(sharingParticipants);
+};
+
+export const ClientTypeEnum = z.enum(['DSP', 'ADVERTISER', 'DATA_PROVIDER', 'PUBLISHER']);
+
+const sharingTypesSchema = z.object({
+  types: z.array(ClientTypeEnum),
+});
+export const handleUpdateSharingTypes = async (req: UserParticipantRequest, res: Response) => {
+  const { participant, user } = req;
+  const { types } = sharingTypesSchema.parse(req.body);
+  const traceId = getTraceId(req);
+
+  if (!participant?.siteId) {
+    return siteIdNotSetError(req, res);
+  }
+
+  const auditTrailInsertObject = constructAuditTrailObject(
+    user!,
+    AuditTrailEvents.UpdateSharingTypes,
+    {
+      siteId: participant.siteId,
+      allowedTypes: types,
+    },
+    participant!.id
+  );
+
+  const sharingParticipants = await performAsyncOperationWithAuditTrail(
+    auditTrailInsertObject,
+    traceId,
+    async () => UpdateSharingTypes(participant.siteId!, types, traceId)
+  );
+
+  return res.status(200).json(sharingParticipants);
+};

--- a/src/api/routers/participants/participantsSigned.ts
+++ b/src/api/routers/participants/participantsSigned.ts
@@ -1,0 +1,10 @@
+import { Response } from 'express';
+
+import { ParticipantRequest } from '../../services/participantsService';
+import { getSignedParticipants } from '../../services/signedParticipantsService';
+
+export const handleGetSignedParticipants = async (_req: ParticipantRequest, res: Response) => {
+  const signedParticipants = await getSignedParticipants();
+  const result = signedParticipants.sort((a, b) => a.name.localeCompare(b.name));
+  return res.status(200).json(result);
+};

--- a/src/api/routers/participants/participantsUsers.spec.ts
+++ b/src/api/routers/participants/participantsUsers.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../testHelpers/apiTestHelpers';
 import { User } from '../../entities/User';
 import { ParticipantRequest } from '../../services/participantsService';
-import { getParticipantUsers } from './participantsUsers';
+import { handleGetParticipantUsers } from './participantsUsers';
 
 describe('#getParticipantUsers', () => {
   test('return empty list when no users', async () => {
@@ -20,7 +20,7 @@ describe('#getParticipantUsers', () => {
 
     const { res } = createResponseObject();
 
-    await getParticipantUsers(participantRequest, res);
+    await handleGetParticipantUsers(participantRequest, res);
 
     expect(res.status).toHaveBeenLastCalledWith(200);
     expect(res.json).toHaveBeenLastCalledWith([]);
@@ -43,7 +43,7 @@ describe('#getParticipantUsers', () => {
     const participantRequest = {
       participant: relatedParticipant,
     } as ParticipantRequest;
-    await getParticipantUsers(participantRequest, res);
+    await handleGetParticipantUsers(participantRequest, res);
 
     expect(json).toHaveBeenCalled();
 
@@ -70,7 +70,7 @@ describe('#getParticipantUsers', () => {
     const participantRequest = {
       participant: relatedParticipant,
     } as ParticipantRequest;
-    await getParticipantUsers(participantRequest, res);
+    await handleGetParticipantUsers(participantRequest, res);
 
     expect(json).toHaveBeenCalled();
 

--- a/src/api/routers/participants/participantsUsers.ts
+++ b/src/api/routers/participants/participantsUsers.ts
@@ -11,7 +11,7 @@ import {
 import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
 import { getAllUserFromParticipant, inviteUserToParticipant } from '../../services/usersService';
 
-export async function getParticipantUsers(req: ParticipantRequest, res: Response) {
+export async function handleGetParticipantUsers(req: ParticipantRequest, res: Response) {
   const { participant } = req;
   const users = await getAllUserFromParticipant(participant!);
   return res.status(200).json(users);

--- a/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantApprovalForm.tsx
@@ -5,8 +5,8 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { ParticipantRequestDTO } from '../../../api/routers/participants/participantsRouter';
 import { SiteDTO } from '../../../api/services/adminServiceHelpers';
+import { ParticipantRequestDTO } from '../../../api/services/participantsService';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { useSiteList } from '../../services/site';
 import { sortApiRoles } from '../../utils/apiRoles';

--- a/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { ParticipantRequestDTO } from '../../../api/routers/participants/participantsRouter';
+import { ParticipantRequestDTO } from '../../../api/services/participantsService';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { Dialog } from '../Core/Dialog/Dialog';
 import { InlineMessage } from '../Core/InlineMessages/InlineMessage';

--- a/src/web/components/ParticipantManagement/ParticipantRequestsTable.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestsTable.tsx
@@ -1,6 +1,6 @@
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { ParticipantTypeDTO } from '../../../api/entities/ParticipantType';
-import { ParticipantRequestDTO } from '../../../api/routers/participants/participantsRouter';
+import { ParticipantRequestDTO } from '../../../api/services/participantsService';
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { TableNoDataPlaceholder } from '../Core/Tables/TableNoDataPlaceholder';
 import { ParticipantRequestItem } from './ParticipantRequestItem';

--- a/src/web/services/participant.ts
+++ b/src/web/services/participant.ts
@@ -6,13 +6,13 @@ import { ApiRoleDTO } from '../../api/entities/ApiRole';
 import { BusinessContactSchema } from '../../api/entities/BusinessContact';
 import { ParticipantCreationPartial, ParticipantDTO } from '../../api/entities/Participant';
 import { SignedParticipantDTO } from '../../api/entities/SignedParticipant';
-import { ParticipantRequestDTO } from '../../api/routers/participants/participantsRouter';
 import {
   ApiKeyDTO,
   ClientType,
   ParticipantApprovalResponse,
   SharingListResponse,
 } from '../../api/services/adminServiceHelpers';
+import { ParticipantRequestDTO } from '../../api/services/participantsService';
 import { backendError } from '../utils/apiError';
 import { InviteTeamMemberForm, UserPayload } from './userAccount';
 


### PR DESCRIPTION
- Split up the `participantsRouter.ts` file based on domain/feature
- Logically group the routes, ensuring the correct middleware still gets run
- Refactoring only - no functional changes

## Why?
- We are about to change how permissions work, so this makes it easier to make those changes. i.e. it is easier to identify which middleware needs run against certain endpoints.