### PR TITLE
Label components

### DIFF
--- a/src/web/components/ApiKeyManagement/ApiRolesCell.scss
+++ b/src/web/components/ApiKeyManagement/ApiRolesCell.scss
@@ -1,21 +1,5 @@
 .api-roles-cell {
-  display: flex;
-  .api-role-boxes {
-    display: flex;
-    font-size: 0.75rem;
-    line-height: 1.15;
-
-    > div {
-      background: var(--theme-api-roles-cell);
-      border-radius: 3px;
-      padding: 4px 8px;
-      margin-right: 8px;
-    }
-
-    .api-role-box {
-      display: flex;
-      gap: 5px;
-      color: var(--theme-api-roles-box);
-    }
+  .label {
+    background-color: var(--theme-api-roles-cell);
   }
 }

--- a/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
+++ b/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
@@ -11,17 +11,17 @@ type ApiRolesProps = {
   showRoleTooltip?: boolean;
 };
 function ApiRolesCell({ apiRoles, showRoleTooltip = false }: ApiRolesProps) {
-  const sortedRoles = sortApiRoles(apiRoles);
+  const sortedApiRoles = sortApiRoles(apiRoles);
 
   return (
     <div className='api-roles-cell'>
       <div className='label-row'>
-        {sortedRoles.map((role) => (
-          <div key={role.externalName}>
+        {sortedApiRoles.map((apiRole) => (
+          <div key={apiRole.externalName}>
             {showRoleTooltip ? (
-              <Tooltip trigger={<Label text={role.externalName} />}>{role.roleName}</Tooltip>
+              <Tooltip trigger={<Label text={apiRole.externalName} />}>{apiRole.roleName}</Tooltip>
             ) : (
-              <Label text={role.externalName} />
+              <Label text={apiRole.externalName} />
             )}
           </div>
         ))}

--- a/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
+++ b/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
@@ -1,12 +1,9 @@
 import { ApiRoleDTO } from '../../../api/entities/ApiRole';
 import { sortApiRoles } from '../../utils/apiRoles';
+import { Label } from '../Core/Labels/Label';
 import { Tooltip } from '../Core/Tooltip/Tooltip';
 
 import './ApiRolesCell.scss';
-
-function ApiRoleBox({ apiRole }: { apiRole: ApiRoleDTO }) {
-  return <div className='api-role-box'>{apiRole.externalName}</div>;
-}
 
 type ApiRolesProps = {
   apiRoles: ApiRoleDTO[];
@@ -15,13 +12,13 @@ type ApiRolesProps = {
 function ApiRolesCell({ apiRoles, showRoleTooltip = false }: ApiRolesProps) {
   return (
     <div className='api-roles-cell'>
-      <div className='api-role-boxes'>
+      <div className='label-row'>
         {sortApiRoles(apiRoles).map((role) => (
           <div key={role.externalName}>
             {showRoleTooltip ? (
-              <Tooltip trigger={<ApiRoleBox apiRole={role} />}>{role.roleName}</Tooltip>
+              <Tooltip trigger={<Label text={role.externalName} />}>{role.roleName}</Tooltip>
             ) : (
-              <ApiRoleBox apiRole={role} />
+              <Label text={role.externalName} />
             )}
           </div>
         ))}

--- a/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
+++ b/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
@@ -4,6 +4,7 @@ import { Label } from '../Core/Labels/Label';
 import { Tooltip } from '../Core/Tooltip/Tooltip';
 
 import './ApiRolesCell.scss';
+import '../Core/Labels/LabelRow.scss';
 
 type ApiRolesProps = {
   apiRoles: ApiRoleDTO[];

--- a/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
+++ b/src/web/components/ApiKeyManagement/ApiRolesCell.tsx
@@ -11,10 +11,12 @@ type ApiRolesProps = {
   showRoleTooltip?: boolean;
 };
 function ApiRolesCell({ apiRoles, showRoleTooltip = false }: ApiRolesProps) {
+  const sortedRoles = sortApiRoles(apiRoles);
+
   return (
     <div className='api-roles-cell'>
       <div className='label-row'>
-        {sortApiRoles(apiRoles).map((role) => (
+        {sortedRoles.map((role) => (
           <div key={role.externalName}>
             {showRoleTooltip ? (
               <Tooltip trigger={<Label text={role.externalName} />}>{role.roleName}</Tooltip>

--- a/src/web/components/Core/ErrorView/ErrorView.stories.tsx
+++ b/src/web/components/Core/ErrorView/ErrorView.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { ErrorView } from './ErrorView';
 
-import '../../../utils/errorHandler.scss';
+import './ErrorView.scss';
 
 const meta: Meta<typeof ErrorView> = {
   component: ErrorView,

--- a/src/web/components/Core/Labels/Label.scss
+++ b/src/web/components/Core/Labels/Label.scss
@@ -1,5 +1,4 @@
 .label {
-  // gap: 5px;
   background: var(--theme-label-background);
   font-size: 0.75rem;
   line-height: 1.15;

--- a/src/web/components/Core/Labels/Label.scss
+++ b/src/web/components/Core/Labels/Label.scss
@@ -1,0 +1,10 @@
+.label {
+  // gap: 5px;
+  background: var(--theme-label-background);
+  font-size: 0.75rem;
+  line-height: 1.15;
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin-right: 8px;
+  align-self: self-start;
+}

--- a/src/web/components/Core/Labels/Label.stories.tsx
+++ b/src/web/components/Core/Labels/Label.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Label } from './Label';
+
+const meta: Meta<typeof Label> = {
+  title: 'Shared Components/Label',
+  component: Label,
+};
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  args: {
+    text: 'My Label',
+  },
+};

--- a/src/web/components/Core/Labels/Label.tsx
+++ b/src/web/components/Core/Labels/Label.tsx
@@ -1,0 +1,9 @@
+import './Label.scss';
+
+export type LabelProps = Readonly<{
+  text: string;
+}>;
+
+export function Label({ text }: LabelProps) {
+  return <div className='label'>{text}</div>;
+}

--- a/src/web/components/Core/Labels/LabelRow.scss
+++ b/src/web/components/Core/Labels/LabelRow.scss
@@ -1,0 +1,5 @@
+.label-row {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+}

--- a/src/web/components/Core/Labels/LabelRow.stories.tsx
+++ b/src/web/components/Core/Labels/LabelRow.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { LabelRow } from './LabelRow';
+
+const meta: Meta<typeof LabelRow> = {
+  title: 'Shared Components/LabelRow',
+  component: LabelRow,
+};
+export default meta;
+type Story = StoryObj<typeof LabelRow>;
+
+export const Default: Story = {
+  args: {
+    labelNames: ['Label 1', 'Label 2', 'Label 3'],
+  },
+};

--- a/src/web/components/Core/Labels/LabelRow.tsx
+++ b/src/web/components/Core/Labels/LabelRow.tsx
@@ -1,0 +1,17 @@
+import { Label } from './Label';
+
+import './LabelRow.scss';
+
+export type LabelRowProps = Readonly<{
+  labelNames: string[];
+}>;
+
+export function LabelRow({ labelNames }: LabelRowProps) {
+  return (
+    <div className='label-row'>
+      {labelNames.map((labelName) => (
+        <Label text={labelName} key={labelName} />
+      ))}
+    </div>
+  );
+}

--- a/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
+++ b/src/web/components/ParticipantManagement/ApprovedParticipantItem.tsx
@@ -7,6 +7,7 @@ import { UserDTO } from '../../../api/entities/User';
 import { UpdateParticipantForm } from '../../services/participant';
 import ApiRolesCell from '../ApiKeyManagement/ApiRolesCell';
 import ActionButton from '../Core/Buttons/ActionButton';
+import { LabelRow } from '../Core/Labels/LabelRow';
 import EditParticipantDialog from './EditParticipantDialog';
 
 import './ParticipantManagementItem.scss';
@@ -30,17 +31,6 @@ export function ApprovedParticipantItem({
     setShowEditParticipantDialog(!showEditParticipantDialog);
   };
 
-  function getParticipantTypes(
-    currentParticipantTypes?: ApprovedParticipantProps['participant']['types']
-  ) {
-    if (!currentParticipantTypes) return null;
-    return currentParticipantTypes.map((pt) => (
-      <div className='participant-item-type-label' key={pt.typeName}>
-        {pt.typeName}
-      </div>
-    ));
-  }
-
   function getApproverDateString(dateApproved: Date | undefined) {
     let dateString: string = '';
     if (dateApproved) {
@@ -59,7 +49,7 @@ export function ApprovedParticipantItem({
     <tr className='participant-management-item'>
       <td>{participant.name}</td>
       <td>
-        <div className='participant-item-types'>{getParticipantTypes(participant.types)}</div>
+        <LabelRow labelNames={participant.types?.map((t) => t.typeName) ?? []} />
       </td>
       <td>
         <div className='approver-name'>{getApprover(participant.approver)}</div>

--- a/src/web/components/ParticipantManagement/ParticipantManagementItem.scss
+++ b/src/web/components/ParticipantManagement/ParticipantManagementItem.scss
@@ -1,24 +1,9 @@
 .participant-management-item {
   line-height: 2;
 
-  .participant-item-type-label {
-    background: var(--theme-label-background);
-    border-radius: 3px;
-    padding: 4px 8px;
-    margin-right: 8px;
-    color: black;
-  }
-
   .participant-item-logo {
     width: 50px;
     margin-right: 16px;
-  }
-
-  .participant-item-types {
-    display: flex;
-    align-items: center;
-    font-size: 0.75rem;
-    line-height: 1.15;
   }
 
   .participant-item-name-cell {

--- a/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
+++ b/src/web/components/ParticipantManagement/ParticipantRequestItem.tsx
@@ -6,6 +6,7 @@ import { ParticipantRequestDTO } from '../../../api/services/participantsService
 import { ParticipantApprovalFormDetails } from '../../services/participant';
 import { Dialog } from '../Core/Dialog/Dialog';
 import { InlineMessage } from '../Core/InlineMessages/InlineMessage';
+import { LabelRow } from '../Core/Labels/LabelRow';
 import ParticipantApprovalForm from './ParticipantApprovalForm';
 
 import './ParticipantManagementItem.scss';
@@ -26,17 +27,6 @@ export function ParticipantRequestItem({
   const [hasError, setHasError] = useState<boolean>(false);
   const [showApproveParticipantDialog, setShowApproveParticipantDialog] = useState(false);
 
-  function getParticipantTypes(
-    currentParticipantTypes?: ParticipantRequestProps['participantRequest']['types']
-  ) {
-    if (!currentParticipantTypes) return null;
-    return currentParticipantTypes.map((pt) => (
-      <div className='participant-item-type-label' key={pt.typeName}>
-        {pt.typeName}
-      </div>
-    ));
-  }
-
   const handleApprove = async (formData: ParticipantApprovalFormDetails) => {
     try {
       await onApprove(participant.id, formData);
@@ -55,7 +45,7 @@ export function ParticipantRequestItem({
         <div className='participant-name'>{participant.name}</div>
       </td>
       <td>
-        <div className='participant-item-types'>{getParticipantTypes(participant.types)}</div>
+        <LabelRow labelNames={participant.types?.map((t) => t.typeName) ?? []} />
       </td>
       <td>
         <div className='participant-item-name'>{participant.requestingUser.fullName}</div>

--- a/src/web/components/SharingPermission/ParticipantItem.scss
+++ b/src/web/components/SharingPermission/ParticipantItem.scss
@@ -22,13 +22,6 @@
   margin-right: 16px;
 }
 
-.participant-types {
-  display: flex;
-  align-items: center;
-  font-size: 0.625rem;
-  line-height: 0.75rem;
-}
-
 .participant-name-cell {
   display: flex;
   align-items: center;

--- a/src/web/components/SharingPermission/ParticipantItem.scss
+++ b/src/web/components/SharingPermission/ParticipantItem.scss
@@ -9,14 +9,6 @@
   }
 }
 
-.participant-type-label {
-  background: var(--theme-label-background);
-  border-radius: 3px;
-  padding: 4px 8px;
-  margin-right: 8px;
-  color: black;
-}
-
 .participant-logo {
   width: 50px;
   margin-right: 16px;

--- a/src/web/components/SharingPermission/ParticipantItem.tsx
+++ b/src/web/components/SharingPermission/ParticipantItem.tsx
@@ -3,6 +3,7 @@ import { ReactNode, useState } from 'react';
 import { SharingSiteDTO, SharingSiteWithSource } from '../../../api/helpers/siteConvertingHelpers';
 import { AdminSiteDTO, ClientTypeDescriptions } from '../../../api/services/adminServiceHelpers';
 import ActionButton from '../Core/Buttons/ActionButton';
+import { LabelRow } from '../Core/Labels/LabelRow';
 import { Tooltip } from '../Core/Tooltip/Tooltip';
 import { TriStateCheckbox } from '../Input/TriStateCheckbox';
 import { DeletePermissionDialog } from './DeletePermissionDialog';
@@ -16,11 +17,8 @@ import './ParticipantItem.scss';
 
 function getParticipantTypes(siteTypes?: AdminSiteDTO['clientTypes']) {
   if (!siteTypes) return null;
-  return siteTypes.map((pt) => (
-    <div className='participant-type-label' key={pt}>
-      {ClientTypeDescriptions[pt]}
-    </div>
-  ));
+  const labelNames = siteTypes.map((pt) => ClientTypeDescriptions[pt]);
+  return <LabelRow labelNames={labelNames} />;
 }
 
 type ParticipantItemSimpleProps = Readonly<{

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -8,6 +8,7 @@ import { UpdateTeamMemberForm, UserResponse } from '../../services/userAccount';
 import { handleErrorToast } from '../../utils/apiError';
 import ActionButton from '../Core/Buttons/ActionButton';
 import { InlineMessage } from '../Core/InlineMessages/InlineMessage';
+import { Label } from '../Core/Labels/Label';
 import { SuccessToast } from '../Core/Popups/Toast';
 import TeamMemberDialog from './TeamMemberDialog';
 import TeamMemberRemoveConfirmationDialog from './TeamMemberRemoveDialog';
@@ -89,7 +90,11 @@ function TeamMember({
       <td>
         <div className='name-cell'>
           {`${person.firstName} ${person.lastName}`}
-          {person.acceptedTerms || <div className='pending-label'>Pending</div>}
+          {person.acceptedTerms || (
+            <div className='pending-label'>
+              <Label text='Pending' />
+            </div>
+          )}
         </div>
       </td>
       <td>{person.email}</td>

--- a/src/web/components/TeamMember/TeamMembersTable.scss
+++ b/src/web/components/TeamMember/TeamMembersTable.scss
@@ -50,11 +50,10 @@
       display: flex;
       align-items: center;
       .pending-label {
-        background: var(--theme-label);
-        font-size: 0.625rem;
-        border-radius: 3px;
-        padding: 3px 8px;
         margin-left: 10px;
+        .label {
+          background-color: var(--theme-label);
+        }
       }
     }
   }


### PR DESCRIPTION
## Why
- We will soon be adding labels to show what roles each user has for the current participant. 
- We currently have labels in numerous places throughout the UI, but they each backed by divs with bespoke class names and styling.
- Now is a good time to consolidate these into a component, to allow for better re-usability.

## What
- Introduce `<Label>` and `<LabelRow>` components
- Use them instead of divs for API roles, Participant Types and Team Member (Pending) labels.
- Made the styling more uniform - i.e. increased the font size of the participant type labels to align with the others.

![image](https://github.com/user-attachments/assets/2f39b896-224b-4fb5-987e-9f070079266f)

![image](https://github.com/user-attachments/assets/2dac3d2f-5f23-4358-a008-2df937e6f98c)

![image](https://github.com/user-attachments/assets/52e8cabb-f828-4778-b6ae-a44af77edc5a)

![image](https://github.com/user-attachments/assets/0cf13365-aab9-4e70-909e-7d2fc51d3bcf)
