### PR TITLE
Local storage added to save most recent selected participant and dark mode setting

### DIFF
--- a/src/api/middleware/participantsMiddleware.ts
+++ b/src/api/middleware/participantsMiddleware.ts
@@ -20,7 +20,7 @@ export const verifyAndEnrichParticipant = async (
 
   const participant = await Participant.query().findById(participantId).withGraphFetched('types');
   if (!participant) {
-    return res.status(200).send([{ message: 'The participant cannot be found.' }]);
+    return res.status(404).send([{ message: 'The participant cannot be found.' }]);
   }
 
   if (!(await canUserAccessParticipant(userEmail, participantId, traceId))) {

--- a/src/api/middleware/participantsMiddleware.ts
+++ b/src/api/middleware/participantsMiddleware.ts
@@ -20,7 +20,7 @@ export const verifyAndEnrichParticipant = async (
 
   const participant = await Participant.query().findById(participantId).withGraphFetched('types');
   if (!participant) {
-    return res.status(404).send([{ message: 'The participant cannot be found.' }]);
+    return res.status(200).send([{ message: 'The participant cannot be found.' }]);
   }
 
   if (!(await canUserAccessParticipant(userEmail, participantId, traceId))) {

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -46,8 +46,13 @@ export function App() {
   }, [keycloak]);
 
   const setDarkMode = (darkMode: boolean) => {
-    if (darkMode) rootRef.current!.classList.add('darkmode');
-    else rootRef.current!.classList.remove('darkmode');
+    if (darkMode) {
+      rootRef.current!.classList.add('darkmode');
+      localStorage.setItem('isDarkMode', 'true');
+    } else {
+      rootRef.current!.classList.remove('darkmode');
+      localStorage.setItem('isDarkMode', 'false');
+    }
   };
 
   const fullName =

--- a/src/web/components/Navigation/ParticipantSwitcher.tsx
+++ b/src/web/components/Navigation/ParticipantSwitcher.tsx
@@ -19,8 +19,13 @@ export function ParticipantSwitcher() {
       id: value.id,
       name: value.name,
     })) ?? [];
+
+  const lastSelectedParticipantId = localStorage.getItem('lastSelectedParticipantId');
+  const currentParticipantOptionId = lastSelectedParticipantId
+    ? parseInt(lastSelectedParticipantId, 10)
+    : participant?.id;
   const currentParticipantOption = participantOptions.find(
-    (option) => option.id === participant?.id
+    (option) => option.id === currentParticipantOptionId
   );
 
   const handleOnSelectedChange = (selectedParticipantId: SelectOption<number>) => {
@@ -31,6 +36,7 @@ export function ParticipantSwitcher() {
     );
     if (selectedParticipant) {
       setParticipant(selectedParticipant);
+      localStorage.setItem('lastSelectedParticipantId', selectedParticipant.id.toString());
     }
   };
 

--- a/src/web/components/PortalHeader/PortalHeader.tsx
+++ b/src/web/components/PortalHeader/PortalHeader.tsx
@@ -44,7 +44,8 @@ export function PortalHeader({
     setMenuOpen(false);
   };
 
-  const [darkToggleState, setDarkToggleState] = useState(false);
+  const lastDarkState = localStorage.getItem('isDarkMode') === 'true';
+  const [darkToggleState, setDarkToggleState] = useState(lastDarkState);
   const onThemeToggle = () => {
     setDarkToggleState(!darkToggleState);
   };


### PR DESCRIPTION
What Changed:

1. Added a localStorage variable for the last selected participant id 
2. If there is no last selected participant id, it will just default to the participant id of the user logged in
3. Added a localStorage variable for the last selected dark mode setting

Test Plan:

Last selected partcipant id:

1. Log in and see that the selected participant is your participant 
2. Select another participant and make sure everything changes smooth (remember which participant you selected)
3. Log out
4. Log back in and confirm that the selected participant is the one you last chose

Last selected dark mode:
1. Log in and change the dark mode setting
2. Log out, log back in and confirm the dark mode setting is the one you had before logging out
3. Test for both light mode and dark mode 