### PR TITLE
Audit trail table improvements

### DIFF
--- a/src/web/components/AuditTrail/AuditTrail.scss
+++ b/src/web/components/AuditTrail/AuditTrail.scss
@@ -9,7 +9,7 @@
     }
 
     td {
-      padding: 15px 20px 15px;
+      padding: 15px 20px 15px 0;
 
       &.succeeded {
         width: 5%;

--- a/src/web/components/AuditTrail/AuditTrailTable.tsx
+++ b/src/web/components/AuditTrail/AuditTrailTable.tsx
@@ -105,7 +105,7 @@ function AuditTrailTableComponent({ auditTrail }: AuditTrailTableProps) {
           <span>There are no audit logs.</span>
         </TableNoDataPlaceholder>
       )}
-      {searchedAuditRows.length > rowsPerPage && (
+      {!!searchedAuditRows.length && (
         <PagingTool
           numberTotalRows={searchedAuditRows.length}
           initialPageNumber={pageNumber}


### PR DESCRIPTION
- Remove the left-right padding on contents of the table
- Ensure the paging tool renders as long as there are rows to display. This addresses an edge case where:
   - the number of audit rows is between 50 and 100
   - the user selects the 100 rows per page option
   - the paging tool disappears 