### PR TITLE
Team Members User Role Management UI

### DIFF
--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -126,6 +126,7 @@ export class UserController {
 
     if (req.auth?.payload?.email === user?.email) {
       res.status(403).send([{ message: 'You do not have permission to remove yourself.' }]);
+      return;
     }
 
     await this.userService.removeUser(req);

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -13,6 +13,7 @@ import {
 
 import { TYPES } from '../constant/types';
 import { ParticipantStatus } from '../entities/Participant';
+import { UserRoleId } from '../entities/UserRole';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { getKcAdminClient } from '../keycloakAdminClient';
 import {
@@ -21,7 +22,11 @@ import {
   sendInviteEmailToNewUser,
 } from '../services/kcUsersService';
 import { LoggerService } from '../services/loggerService';
-import { SelfResendInvitationSchema, UserService } from '../services/userService';
+import {
+  SelfResendInvitationSchema,
+  UpdateUserRoleIdSchema,
+  UserService,
+} from '../services/userService';
 import { SelfResendInviteRequest, UserRequest } from '../services/usersService';
 
 @controller('/users')
@@ -135,6 +140,16 @@ export class UserController {
 
   @httpPatch('/:userId')
   public async updateUser(@request() req: UserRequest, @response() res: Response): Promise<void> {
+    const { user } = req;
+    const userRoleData = UpdateUserRoleIdSchema.parse(req.body);
+    if (req.auth?.payload?.email === user?.email && userRoleData.userRoleId !== UserRoleId.Admin) {
+      res
+        .status(403)
+        .send([
+          { message: 'You do not have permission to unassign the Admin role from yourself.' },
+        ]);
+      return;
+    }
     await this.userService.updateUser(req);
     res.sendStatus(200);
   }

--- a/src/api/entities/UserRole.ts
+++ b/src/api/entities/UserRole.ts
@@ -1,4 +1,5 @@
 import { BaseModel } from './BaseModel';
+import { ModelObjectOpt } from './ModelObjectOpt';
 
 export enum UserRoleId {
   Admin = 1,
@@ -13,3 +14,5 @@ export class UserRole extends BaseModel {
   declare id: number;
   declare roleName: string;
 }
+
+export type UserRoleDTO = ModelObjectOpt<UserRole>;

--- a/src/api/routers/participants/participantsUsers.ts
+++ b/src/api/routers/participants/participantsUsers.ts
@@ -9,6 +9,7 @@ import {
   performAsyncOperationWithAuditTrail,
 } from '../../services/auditTrailService';
 import { ParticipantRequest, UserParticipantRequest } from '../../services/participantsService';
+import { UpdateUserRoleIdSchema } from '../../services/userService';
 import {
   getAllUsersFromParticipantWithRoles,
   inviteUserToParticipant,
@@ -30,6 +31,7 @@ export async function handleInviteUserToParticipant(req: UserParticipantRequest,
   try {
     const { participant, user } = req;
     const userPartial = userInvitationSchema.parse(req.body);
+    const userRoleIdData = UpdateUserRoleIdSchema.parse(req.body);
     const traceId = getTraceId(req);
     const auditTrailInsertObject = constructAuditTrailObject(
       user!,
@@ -40,12 +42,13 @@ export async function handleInviteUserToParticipant(req: UserParticipantRequest,
         lastName: userPartial.lastName,
         email: userPartial.email,
         jobFunction: userPartial.jobFunction,
+        userRoleId: userRoleIdData.userRoleId,
       },
       participant!.id
     );
 
     await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {
-      await inviteUserToParticipant(userPartial, participant!, traceId);
+      await inviteUserToParticipant(userPartial, participant!, userRoleIdData.userRoleId, traceId);
     });
 
     return res.sendStatus(201);

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -114,7 +114,7 @@ export class UserService {
         firstName: userData.firstName,
         lastName: userData.lastName,
         jobFunction: userData.jobFunction,
-        userRoleIds: userRoleData.userRoleId,
+        userRoleId: userRoleData.userRoleId,
       },
       participant!.id
     );

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -26,7 +26,7 @@ const updateUserSchema = z.object({
   jobFunction: z.nativeEnum(UserJobFunction),
 });
 
-const updateUserRoleIdSchema = z.object({
+export const UpdateUserRoleIdSchema = z.object({
   userRoleId: z.nativeEnum(UserRoleId),
 });
 
@@ -102,7 +102,7 @@ export class UserService {
     const { user, participant } = req;
     const requestingUser = await findUserByEmail(req.auth?.payload.email as string);
     const userData = updateUserSchema.parse(req.body);
-    const userRoleData = updateUserRoleIdSchema.parse(req.body);
+    const userRoleData = UpdateUserRoleIdSchema.parse(req.body);
     const traceId = getTraceId(req);
 
     const auditTrailInsertObject = constructAuditTrailObject(

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 
 import { Participant, ParticipantDTO } from '../entities/Participant';
 import { User, UserDTO } from '../entities/User';
-import { UserRole, UserRoleDTO, UserRoleId } from '../entities/UserRole';
+import { UserRole, UserRoleDTO } from '../entities/UserRole';
 import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { SSP_WEB_BASE_URL } from '../envars';
 import { getKcAdminClient } from '../keycloakAdminClient';

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 
 import { Participant, ParticipantDTO } from '../entities/Participant';
 import { User, UserDTO } from '../entities/User';
-import { UserRole, UserRoleId } from '../entities/UserRole';
+import { UserRole, UserRoleDTO, UserRoleId } from '../entities/UserRole';
 import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { SSP_WEB_BASE_URL } from '../envars';
 import { getKcAdminClient } from '../keycloakAdminClient';
@@ -29,7 +29,7 @@ export interface SelfResendInviteRequest extends Request {
 
 export type UserWithIsApprover = UserDTO & { isApprover: boolean };
 export type UserWithCurrentParticipantRoleNames = UserDTO & {
-  currentParticipantUserRoleNames?: string[];
+  currentParticipantUserRoles?: UserRoleDTO[];
 };
 
 export type UserPartialDTO = Omit<UserDTO, 'id' | 'acceptedTerms'>;
@@ -97,11 +97,11 @@ const mapUsersWithParticipantRoles = async (users: User[], participantId: number
     const { userToParticipantRoles, ...rest } = user;
     return {
       ...rest,
-      currentParticipantUserRoleNames: user?.userToParticipantRoles
+      currentParticipantUserRoles: user?.userToParticipantRoles
         ?.filter((x) => x.participantId === participantId)
         .map((y) => {
           const role = userRoles.find((r) => r.id === y.userRoleId);
-          return role ? role.roleName : null;
+          return role ?? null;
         }),
     };
   });

--- a/src/web/components/Input/RadioInput.scss
+++ b/src/web/components/Input/RadioInput.scss
@@ -1,44 +1,45 @@
 .radio-group-root {
   display: flex;
-  gap: 10px;
+  gap: 1rem;
   margin-top: 0.5rem;
-}
 
-.radio-group-item {
-  width: 25px;
-  height: 25px;
-  margin-right: 11px;
-  padding: 0 !important;
-  border-radius: 100% !important;
-  border: 1px solid var(--theme-input-border) !important;
-}
-.radio-group-item:has(> .radio-group-indicator) {
-  background-color: var(--theme-radio-background);
-}
+  .radio-option {
+    display: flex;
+    align-items: center;
 
-.radio-group-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-.radio-group-indicator::after {
-  content: '';
-  display: block;
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background-color: white;
-}
+    .radio-group-item:has(> .radio-group-indicator) {
+      background-color: var(--theme-radio-background);
+    }
 
-.radio-option {
-  display: flex;
-  align-items: center;
+    .disabled {
+      background-color: var(--theme-disabled-button);
+      cursor: default;
+    }
 
-  .disabled {
-    background-color: var(--theme-disabled-button);
-    cursor: default;
+    .radio-group-item {
+      width: 25px;
+      height: 25px;
+      margin-right: 11px;
+      padding: 0;
+      border-radius: 100%;
+      border: 1px solid var(--theme-input-border);
+
+      .radio-group-indicator {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        position: relative;
+      }
+      .radio-group-indicator::after {
+        content: '';
+        display: block;
+        width: 11px;
+        height: 11px;
+        border-radius: 50%;
+        background-color: white;
+      }
+    }
   }
 }

--- a/src/web/components/TeamMember/TeamMember.tsx
+++ b/src/web/components/TeamMember/TeamMember.tsx
@@ -101,7 +101,9 @@ function TeamMember({
       <td>{person.email}</td>
       <td>{person.jobFunction}</td>
       <td>
-        <LabelRow labelNames={person.currentParticipantUserRoleNames ?? []} />
+        <LabelRow
+          labelNames={person.currentParticipantUserRoles?.map((role) => role.roleName) ?? []}
+        />
       </td>
       <td className='action'>
         <div className='action-cell'>

--- a/src/web/components/TeamMember/TeamMemberDialog.tsx
+++ b/src/web/components/TeamMember/TeamMemberDialog.tsx
@@ -1,6 +1,8 @@
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { UserDTO, UserJobFunction } from '../../../api/entities/User';
+import { UserJobFunction } from '../../../api/entities/User';
+import { UserRoleId } from '../../../api/entities/UserRole';
+import { UserWithCurrentParticipantRoleNames } from '../../../api/services/usersService';
 import {
   InviteTeamMemberForm,
   UpdateTeamMemberForm,
@@ -9,18 +11,19 @@ import {
 import { validateEmail } from '../../utils/textHelpers';
 import FormSubmitButton from '../Core/Buttons/FormSubmitButton';
 import { Dialog } from '../Core/Dialog/Dialog';
+import { RadioInput } from '../Input/RadioInput';
 import { SelectInput } from '../Input/SelectInput';
 import { TextInput } from '../Input/TextInput';
 import { validateUniqueTeamMemberEmail } from './TeamMemberHelper';
 
 type AddTeamMemberDialogProps = {
-  teamMembers: UserDTO[];
+  teamMembers: UserWithCurrentParticipantRoleNames[];
   onAddTeamMember: (form: InviteTeamMemberForm) => Promise<void>;
   onOpenChange: () => void;
   person?: never;
 };
 type UpdateTeamMemberDialogProps = {
-  teamMembers: UserDTO[];
+  teamMembers: UserWithCurrentParticipantRoleNames[];
   onUpdateTeamMember: (form: UpdateTeamMemberForm) => Promise<void>;
   onOpenChange: () => void;
   person: UserResponse;
@@ -33,15 +36,26 @@ const isUpdateTeamMemberDialogProps = (
 
 function TeamMemberDialog(props: TeamMemberDialogProps) {
   const formMethods = useForm<InviteTeamMemberForm>({
-    defaultValues: props.person as InviteTeamMemberForm,
+    defaultValues: {
+      firstName: props.person?.firstName,
+      lastName: props.person?.lastName,
+      email: props.person?.email,
+      jobFunction: props.person?.jobFunction,
+      userRoleId: props.person?.currentParticipantUserRoles?.[0]?.id ?? undefined,
+    },
   });
   const { handleSubmit } = formMethods;
   const editMode = !!props.person;
 
   const onSubmit = async (formData: InviteTeamMemberForm) => {
     if (isUpdateTeamMemberDialogProps(props)) {
-      const { firstName, lastName, jobFunction } = formData;
-      await props.onUpdateTeamMember({ firstName, lastName, jobFunction });
+      const { firstName, lastName, jobFunction, userRoleId } = formData;
+      await props.onUpdateTeamMember({
+        firstName,
+        lastName,
+        jobFunction,
+        userRoleId,
+      });
     } else {
       await props.onAddTeamMember(formData);
     }
@@ -89,6 +103,17 @@ function TeamMemberDialog(props: TeamMemberDialogProps) {
                 value: UserJobFunction[key],
               })
             )}
+          />
+          <RadioInput
+            inputName='userRoleId'
+            label='Role'
+            rules={{ required: 'Please specify a role.' }}
+            options={(Object.keys(UserRoleId) as Array<keyof typeof UserRoleId>)
+              .filter((key) => typeof UserRoleId[key] === 'number' && key !== 'UID2Support')
+              .map((key) => ({
+                optionLabel: key,
+                value: UserRoleId[key],
+              }))}
           />
           <FormSubmitButton>Save Team Member</FormSubmitButton>
         </form>

--- a/src/web/components/TeamMember/TeamMembersTable.tsx
+++ b/src/web/components/TeamMember/TeamMembersTable.tsx
@@ -46,7 +46,7 @@ function TeamMembersTableContent({
             <SortableTableHeader<UserResponse> sortKey='email' header='Email' />
             <SortableTableHeader<UserResponse> sortKey='jobFunction' header='Job Function' />
             <SortableTableHeader<UserResponse>
-              sortKey='currentParticipantUserRoleNames'
+              sortKey='currentParticipantUserRoles'
               header='Roles'
             />
             <th className='action'>Actions</th>

--- a/src/web/services/userAccount.ts
+++ b/src/web/services/userAccount.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { UserCreationPartial } from '../../api/entities/User';
 import {
   UserWithCurrentParticipantRoleNames,
-  UserWithIsApprover
+  UserWithIsApprover,
 } from '../../api/services/usersService';
 import { backendError } from '../utils/apiError';
 
@@ -20,6 +20,7 @@ export type InviteTeamMemberForm = {
   lastName: string;
   email: string;
   jobFunction: string;
+  userRoleId?: number;
 };
 
 export type UpdateTeamMemberForm = Omit<InviteTeamMemberForm, 'email'>;


### PR DESCRIPTION
- Ability to assign Admin or Operations role to users on the **Team Members** screen
- Prevent user from self-unassigning Admin role
- Improve style file


## Adding a new user

https://github.com/user-attachments/assets/6a59ee06-16a7-4305-987a-a53dd2f78a4f

## Adding an existing user to a different participant

https://github.com/user-attachments/assets/dfc50e48-2ff8-4d8f-9cd0-3a1cfd5d29fb


## Audit trail result for first participant

![image](https://github.com/user-attachments/assets/292430a8-da9e-4029-91b4-873a90f9cbd0)

Currently just shows the IDs, but I think we will display the actual user role names in a separate ticket


## Prevent user from self-unassigning Admin role


https://github.com/user-attachments/assets/770e148c-69d9-4739-92a2-6a302e83230e
