### PR TITLE
names rather than ids in audit trail.  index on participantId in audit table

### DIFF
--- a/src/api/entities/AuditTrail.ts
+++ b/src/api/entities/AuditTrail.ts
@@ -4,9 +4,9 @@ import { BaseModel } from './BaseModel';
 import { ModelObjectOpt } from './ModelObjectOpt';
 
 export enum AuditAction {
-  Add = 'add',
-  Delete = 'delete',
-  Update = 'update',
+  Add = 'Add',
+  Delete = 'Delete',
+  Update = 'Update',
 }
 
 export enum AuditTrailEvents {

--- a/src/api/entities/UserRole.ts
+++ b/src/api/entities/UserRole.ts
@@ -7,6 +7,19 @@ export enum UserRoleId {
   UID2Support = 3,
 }
 
+export const getUserRoleById = (id: number) => {
+  switch (id) {
+    case 1:
+      return 'Admin';
+    case 2:
+      return 'Operations';
+    case 3:
+      return 'Support';
+    default:
+      return 'Invalid';
+  }
+};
+
 export class UserRole extends BaseModel {
   static get tableName() {
     return 'userRoles';

--- a/src/api/routers/participants/participantsApiKeys.ts
+++ b/src/api/routers/participants/participantsApiKeys.ts
@@ -77,6 +77,7 @@ export const handleAddApiKey = async (req: UserParticipantRequest, res: Response
     AuditTrailEvents.ManageApiKey,
     {
       action: AuditAction.Add,
+      siteId: participant.siteId,
       keyName,
       apiRoles,
     },

--- a/src/api/routers/participants/participantsApiKeys.ts
+++ b/src/api/routers/participants/participantsApiKeys.ts
@@ -77,7 +77,6 @@ export const handleAddApiKey = async (req: UserParticipantRequest, res: Response
     AuditTrailEvents.ManageApiKey,
     {
       action: AuditAction.Add,
-      siteId: participant.siteId,
       keyName,
       apiRoles,
     },

--- a/src/api/routers/participants/participantsApproval.ts
+++ b/src/api/routers/participants/participantsApproval.ts
@@ -1,11 +1,15 @@
 import { Response } from 'express';
 
+import { getRoleNamesByIds } from '../../../web/utils/apiRoles';
 import { AuditTrailEvents } from '../../entities/AuditTrail';
 import { ParticipantApprovalPartial, ParticipantStatus } from '../../entities/Participant';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { setSiteClientTypes } from '../../services/adminServiceClient';
-import { ParticipantApprovalResponse } from '../../services/adminServiceHelpers';
+import {
+  mapClientTypeIdsToAdminEnums,
+  ParticipantApprovalResponse,
+} from '../../services/adminServiceHelpers';
 import {
   constructAuditTrailObject,
   performAsyncOperationWithAuditTrail,
@@ -56,11 +60,10 @@ export const handleApproveParticipant = async (req: UserParticipantRequest, res:
     AuditTrailEvents.ApproveAccount,
     {
       oldName: participant?.name,
-      siteId: data.siteId!,
       newName: data.name,
-      oldTypeIds: participant?.types!.map((type) => type.id),
-      newTypeIds: data.types.map((type) => type.id),
-      apiRoles: data.apiRoles.map((role) => role.id),
+      oldTypeIds: mapClientTypeIdsToAdminEnums(participant?.types!.map((type) => type.id) ?? []),
+      newTypeIds: mapClientTypeIdsToAdminEnums(data.types.map((type) => type.id)),
+      apiRoles: getRoleNamesByIds(data.apiRoles.map((role) => role.id)),
     },
     participant!.id
   );

--- a/src/api/routers/participants/participantsApproval.ts
+++ b/src/api/routers/participants/participantsApproval.ts
@@ -61,6 +61,7 @@ export const handleApproveParticipant = async (req: UserParticipantRequest, res:
     {
       oldName: participant?.name,
       newName: data.name,
+      siteId: data.siteId!,
       oldTypeIds: mapClientTypeIdsToAdminEnums(participant?.types!.map((type) => type.id) ?? []),
       newTypeIds: mapClientTypeIdsToAdminEnums(data.types.map((type) => type.id)),
       apiRoles: getRoleNamesByIds(data.apiRoles.map((role) => role.id)),

--- a/src/api/routers/participants/participantsCreation.ts
+++ b/src/api/routers/participants/participantsCreation.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { z } from 'zod';
 
+import { getRoleNamesByIds } from '../../../web/utils/apiRoles';
 import { ApiRole } from '../../entities/ApiRole';
 import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import {
@@ -15,6 +16,7 @@ import { getTraceId } from '../../helpers/loggingHelpers';
 import { getKcAdminClient } from '../../keycloakAdminClient';
 import { addSite, getSiteList, setSiteClientTypes } from '../../services/adminServiceClient';
 import {
+  mapClientTypeIdsToAdminEnums,
   mapClientTypesToAdminEnums,
   SiteCreationRequest,
 } from '../../services/adminServiceHelpers';
@@ -126,9 +128,11 @@ async function createParticipant(
     {
       action: AuditAction.Add,
       siteId: parsedParticipantRequest.siteId!,
-      apiRoles: parsedParticipantRequest.apiRoles.map((role) => role.id),
+      apiRoles: getRoleNamesByIds(parsedParticipantRequest.apiRoles.map((role) => role.id)),
       participantName: parsedParticipantRequest.name,
-      participantTypes: parsedParticipantRequest.types.map((type) => type.id),
+      participantTypes: mapClientTypeIdsToAdminEnums(
+        parsedParticipantRequest.types.map((type) => type.id)
+      ),
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,

--- a/src/api/routers/participants/participantsUsers.ts
+++ b/src/api/routers/participants/participantsUsers.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { AuditAction, AuditTrailEvents } from '../../entities/AuditTrail';
 import { UserJobFunction } from '../../entities/User';
+import { getUserRoleById } from '../../entities/UserRole';
 import { getTraceId } from '../../helpers/loggingHelpers';
 import {
   constructAuditTrailObject,
@@ -42,7 +43,7 @@ export async function handleInviteUserToParticipant(req: UserParticipantRequest,
         lastName: userPartial.lastName,
         email: userPartial.email,
         jobFunction: userPartial.jobFunction,
-        userRoleId: userRoleIdData.userRoleId,
+        userRoleId: getUserRoleById(userRoleIdData.userRoleId),
       },
       participant!.id
     );

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -284,7 +284,6 @@ export const updateParticipant = async (participant: Participant, req: UserParti
   } = updateParticipantSchema.parse(req.body);
   const { user } = req;
   const traceId = getTraceId(req);
-  const updatedParticipantId = Number(req.params.participantId);
 
   const auditTrailInsertObject = constructAuditTrailObject(
     user!,
@@ -295,8 +294,7 @@ export const updateParticipant = async (participant: Participant, req: UserParti
       participantName,
       participantTypes: mapClientTypeIdsToAdminEnums(participantTypeIds),
       crmAgreementNumber,
-    },
-    updatedParticipantId
+    }
   );
 
   await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -2,6 +2,7 @@ import { Request } from 'express';
 import { TransactionOrKnex } from 'objection';
 import { z } from 'zod';
 
+import { getRoleNamesByIds } from '../../web/utils/apiRoles';
 import { ApiRole } from '../entities/ApiRole';
 import { AuditAction, AuditTrailEvents } from '../entities/AuditTrail';
 import {
@@ -16,7 +17,11 @@ import { User, UserDTO } from '../entities/User';
 import { SSP_WEB_BASE_URL } from '../envars';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { getSharingList, setSiteClientTypes, updateSharingList } from './adminServiceClient';
-import { ClientType, SharingListResponse } from './adminServiceHelpers';
+import {
+  ClientType,
+  mapClientTypeIdsToAdminEnums,
+  SharingListResponse,
+} from './adminServiceHelpers';
 import { findApproversByType, getApprovableParticipantTypeIds } from './approversService';
 import {
   constructAuditTrailObject,
@@ -285,9 +290,9 @@ export const updateParticipant = async (participant: Participant, req: UserParti
     AuditTrailEvents.ManageParticipant,
     {
       action: AuditAction.Update,
-      apiRoles,
+      apiRoles: getRoleNamesByIds(apiRoles),
       participantName,
-      participantTypes: participantTypeIds,
+      participantTypes: mapClientTypeIdsToAdminEnums(participantTypeIds),
       crmAgreementNumber,
     }
   );

--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -284,6 +284,7 @@ export const updateParticipant = async (participant: Participant, req: UserParti
   } = updateParticipantSchema.parse(req.body);
   const { user } = req;
   const traceId = getTraceId(req);
+  const updatedParticipantId = Number(req.params.participantId);
 
   const auditTrailInsertObject = constructAuditTrailObject(
     user!,
@@ -294,7 +295,8 @@ export const updateParticipant = async (participant: Participant, req: UserParti
       participantName,
       participantTypes: mapClientTypeIdsToAdminEnums(participantTypeIds),
       crmAgreementNumber,
-    }
+    },
+    updatedParticipantId
   );
 
   await performAsyncOperationWithAuditTrail(auditTrailInsertObject, traceId, async () => {

--- a/src/api/services/userService.ts
+++ b/src/api/services/userService.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { AuditAction, AuditTrailEvents } from '../entities/AuditTrail';
 import { ParticipantType } from '../entities/ParticipantType';
 import { UserJobFunction } from '../entities/User';
-import { UserRoleId } from '../entities/UserRole';
+import { getUserRoleById, UserRoleId } from '../entities/UserRole';
 import { UserToParticipantRole } from '../entities/UserToParticipantRole';
 import { getTraceId } from '../helpers/loggingHelpers';
 import { mapClientTypeToParticipantType } from '../helpers/siteConvertingHelpers';
@@ -114,7 +114,7 @@ export class UserService {
         firstName: userData.firstName,
         lastName: userData.lastName,
         jobFunction: userData.jobFunction,
-        userRoleId: userRoleData.userRoleId,
+        userRoleId: getUserRoleById(userRoleData.userRoleId),
       },
       participant!.id
     );

--- a/src/database/migrations/20241024212425_ImproveAuditTrailEfficiency.ts
+++ b/src/database/migrations/20241024212425_ImproveAuditTrailEfficiency.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // add index to participantId column
+  await knex.schema.alterTable('auditTrails', (table) => {
+    table.index('participantId');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('auditTrails', (table) => {
+    table.dropIndex('participantId');
+  });
+}

--- a/src/web/components/AuditTrail/AuditTrailRow.tsx
+++ b/src/web/components/AuditTrail/AuditTrailRow.tsx
@@ -16,10 +16,10 @@ function AuditTrailRow({ log }: AuditTrailProps) {
 
   return (
     <tr>
+      <td>{eventDate}</td>
       <td>{log.userEmail}</td>
       <td>{log.event.replace(/([a-z])([A-Z])/g, '$1 $2')}</td>
       <td className='event-data'>{formattedEventData}</td>
-      <td>{eventDate}</td>
       <td className='succeeded'>
         <FontAwesomeIcon
           className={log.succeeded ? 'icon_check' : 'icon_x'}

--- a/src/web/components/AuditTrail/AuditTrailRow.tsx
+++ b/src/web/components/AuditTrail/AuditTrailRow.tsx
@@ -16,7 +16,6 @@ function AuditTrailRow({ log }: AuditTrailProps) {
 
   return (
     <tr>
-      <td>{log.id}</td>
       <td>{log.userEmail}</td>
       <td>{log.event.replace(/([a-z])([A-Z])/g, '$1 $2')}</td>
       <td className='event-data'>{formattedEventData}</td>

--- a/src/web/components/AuditTrail/AuditTrailTable.tsx
+++ b/src/web/components/AuditTrail/AuditTrailTable.tsx
@@ -83,7 +83,6 @@ function AuditTrailTableComponent({ auditTrail }: AuditTrailTableProps) {
       <table className='audit-log-table'>
         <thead>
           <tr>
-            <th>ID</th>
             <SortableTableHeader<AuditTrailDTO> sortKey='userEmail' header='User' />
             <SortableTableHeader<AuditTrailDTO> sortKey='event' header='Event' />
             <th>Event Data</th>

--- a/src/web/components/AuditTrail/AuditTrailTable.tsx
+++ b/src/web/components/AuditTrail/AuditTrailTable.tsx
@@ -83,10 +83,10 @@ function AuditTrailTableComponent({ auditTrail }: AuditTrailTableProps) {
       <table className='audit-log-table'>
         <thead>
           <tr>
+            <SortableTableHeader<AuditTrailDTO> sortKey='updated_at' header='Date' />
             <SortableTableHeader<AuditTrailDTO> sortKey='userEmail' header='User' />
             <SortableTableHeader<AuditTrailDTO> sortKey='event' header='Event' />
             <th>Event Data</th>
-            <SortableTableHeader<AuditTrailDTO> sortKey='updated_at' header='Date' />
             <th>Succeeded</th>
           </tr>
         </thead>


### PR DESCRIPTION
names rather than ids in audit trail.  index on participantId in audit table.

This helps the audit trail to be more human-readble.