### PR TITLE
Prevent uid2 support routes from always 401ing

### DIFF
--- a/src/api/routers/participants/participantsRouter.ts
+++ b/src/api/routers/participants/participantsRouter.ts
@@ -61,17 +61,15 @@ export function createParticipantsRouter() {
   );
   participantsRouter.get('/approved', isUid2SupportCheck, handleGetApprovedParticipants);
 
-  participantsRouter.use('/:participantId', enrichCurrentUser);
-
-  participantsRouter.put('/:participantId/approve', isUid2SupportCheck, handleApproveParticipant);
-  participantsRouter.put('/:participantId', isUid2SupportCheck, handleUpdateParticipant);
   participantsRouter.put('/', handleCreateParticipant);
 
-  participantsRouter.use('/:participantId', verifyAndEnrichParticipant);
+  participantsRouter.use('/:participantId', verifyAndEnrichParticipant, enrichCurrentUser);
 
   participantsRouter.get('/:participantId', handleGetParticipant);
   participantsRouter.get('/:participantId/apiRoles', handleGetParticipantApiRoles);
+  participantsRouter.put('/:participantId', handleUpdateParticipant);
   participantsRouter.put('/:participantId/completeRecommendations', handleCompleteRecommendations);
+  participantsRouter.put('/:participantId/approve', handleApproveParticipant);
 
   participantsRouter.post(
     '/:participantId/invite',


### PR DESCRIPTION
Ensure that the participant on the request still gets enriched, so that it does not result in 401 error

## Manual test: editing a participant no longer 401s

https://github.com/user-attachments/assets/f6891503-ea32-4ed6-bd64-e2654f131c94

