### PR TITLE
Fix participant no access when single participant

### DIFF
--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -31,7 +31,7 @@ function AppContent() {
     return <ErrorView message='You do not have access to any participants.' />;
   }
   if (location.pathname !== '/account/create' && LoggedInUser && !participant) {
-    return <NoParticipantAccessView />;
+    return <NoParticipantAccessView user={LoggedInUser?.user} />;
   }
 
   const showUpdatesTour =

--- a/src/web/components/Navigation/NoParticipantAccessView.tsx
+++ b/src/web/components/Navigation/NoParticipantAccessView.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { UserWithParticipantRoles } from '../../../api/services/usersService';
-import { getPathWithParticipant } from '../../utils/urlHelpers';
+import { getPathWithParticipant, parseParticipantId } from '../../utils/urlHelpers';
 import { ParticipantSwitcher } from './ParticipantSwitcher';
 
 import './NoParticipantAccessView.scss';
@@ -15,11 +15,11 @@ export function NoParticipantAccessView({ user }: NoParticipantAccessViewProps) 
   const location = useLocation();
 
   const onBackToParticipant = () => {
-    let participantId;
-    if (user?.participants) {
+    let participantId = parseParticipantId(
+      localStorage.getItem('lastSelectedParticipantId') ?? undefined
+    );
+    if (!participantId && user?.participants && user?.participants.length > 0) {
       participantId = user.participants[0].id;
-    } else {
-      participantId = localStorage.getItem('lastSelectedParticipantId');
     }
     if (participantId) {
       const newPath = getPathWithParticipant(location.pathname, participantId);

--- a/src/web/components/Navigation/NoParticipantAccessView.tsx
+++ b/src/web/components/Navigation/NoParticipantAccessView.tsx
@@ -1,17 +1,26 @@
 import { ParticipantSwitcher } from './ParticipantSwitcher';
 
 import './NoParticipantAccessView.scss';
+import { UserWithParticipantRoles } from '../../../api/services/usersService';
 
-export function NoParticipantAccessView() {
+type NoParticipantAccessViewProps = Readonly<{
+  user: UserWithParticipantRoles | null;
+}>;
+
+export function NoParticipantAccessView({ user }: NoParticipantAccessViewProps) {
   return (
     <div className='no-participant-access-container'>
       <p className='no-access-text instructions'>You do not have access to this participant.</p>
       <p className='use-switcher-text instructions'>
         Use the dropdown below to navigate to a participant you have access to.
       </p>
-      <div className='switcher'>
-        <ParticipantSwitcher noInitialValue />
-      </div>
+      {(user?.participants?.length ?? 0) > 1 ? (
+        <div className='switcher'>
+          <ParticipantSwitcher noInitialValue />
+        </div>
+      ) : (
+        <div></div>
+      )}
     </div>
   );
 }

--- a/src/web/components/Navigation/NoParticipantAccessView.tsx
+++ b/src/web/components/Navigation/NoParticipantAccessView.tsx
@@ -1,25 +1,51 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { UserWithParticipantRoles } from '../../../api/services/usersService';
+import { getPathWithParticipant } from '../../utils/urlHelpers';
 import { ParticipantSwitcher } from './ParticipantSwitcher';
 
 import './NoParticipantAccessView.scss';
-import { UserWithParticipantRoles } from '../../../api/services/usersService';
 
 type NoParticipantAccessViewProps = Readonly<{
   user: UserWithParticipantRoles | null;
 }>;
 
 export function NoParticipantAccessView({ user }: NoParticipantAccessViewProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const onBackToParticipant = () => {
+    let participantId;
+    if (user?.participants) {
+      participantId = user.participants[0].id;
+    } else {
+      participantId = localStorage.getItem('lastSelectedParticipantId');
+    }
+    if (participantId) {
+      const newPath = getPathWithParticipant(location.pathname, participantId);
+      navigate(newPath);
+    }
+  };
+
   return (
     <div className='no-participant-access-container'>
       <p className='no-access-text instructions'>You do not have access to this participant.</p>
-      <p className='use-switcher-text instructions'>
-        Use the dropdown below to navigate to a participant you have access to.
-      </p>
+
       {(user?.participants?.length ?? 0) > 1 ? (
-        <div className='switcher'>
-          <ParticipantSwitcher noInitialValue />
-        </div>
+        <>
+          <p className='use-switcher-text instructions'>
+            Use the dropdown below to navigate to a participant you have access to.
+          </p>
+          <div className='switcher'>
+            <ParticipantSwitcher noInitialValue />
+          </div>
+        </>
       ) : (
-        <div></div>
+        <div>
+          <button className='small-button' type='button' onClick={onBackToParticipant}>
+            Back to Your Participant
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Quick bug fix to show something different than the Participant Switcher if the user navigates to a participant they don't have access to, but only belong to one participant.

Test Plan:

- Make sure navigation with the switcher still works when a user has multiple participans
- Update your user to only have access to one participant and check the UX when navigating to a participant in the URL that doesn't exist or they don't have access to (example: http://localhost:3000/participant/123333/home)