### PR TITLE
Do not show UI tour with updates for new users

### DIFF
--- a/src/web/components/SiteTour/tourHelpers.spec.ts
+++ b/src/web/components/SiteTour/tourHelpers.spec.ts
@@ -4,7 +4,7 @@ import { createMockParticipant, createMockUser } from '../../../testHelpers/data
 import { createUserContextValue } from '../../../testHelpers/testContextProvider';
 import { compareVersions } from './tourHelpers';
 import { tourSteps } from './tourSteps';
-import { GetTourSteps,tourStorageKey } from './tourStorage';
+import { GetTourSteps, tourStorageKey } from './tourStorage';
 
 describe('testing tour storage helper functions', () => {
   const mockParticipant = createMockParticipant();
@@ -29,7 +29,7 @@ describe('testing tour storage helper functions', () => {
     mockUser.currentParticipantUserRoles = [{ id: UserRoleId.Admin, roleName: 'Admin' }];
     mockUser.participants = [mockParticipant, mockParticipant2] as Participant[];
     mockParticipant.currentUserRoleIds = [UserRoleId.Admin];
-    localStorage.removeItem(tourStorageKey);
+    localStorage.setItem(tourStorageKey, JSON.stringify({ seenForVersions: ['0.1.0'] }));
 
     const steps = GetTourSteps(mockLoggedInUser, mockParticipant);
 

--- a/src/web/components/SiteTour/tourStorage.spec.ts
+++ b/src/web/components/SiteTour/tourStorage.spec.ts
@@ -58,4 +58,9 @@ describe('Tour tests', () => {
     const steps = GetTourSteps(mockLoggedInUser, mockParticipant, mockTourData);
     expect(steps).not.toContainEqual(mockTourData[0]);
   });
+  test('When user is logging in for the first time, no steps are returned', () => {
+    localStorage.removeItem(tourStorageKey);
+    const steps = GetTourSteps(mockLoggedInUser, mockParticipant, mockTourData);
+    expect(steps).toHaveLength(0);
+  });
 });

--- a/src/web/components/SiteTour/tourStorage.ts
+++ b/src/web/components/SiteTour/tourStorage.ts
@@ -43,6 +43,11 @@ export function GetTourSteps(
 ): VersionedTourStep[] {
   // search seen steps for the highest version number
   const storedVersions = getTourData().seenForVersions;
+  // if there are no seen version, this is the users first time in the portal
+  // new features don't make sense to show in this case
+  if (storedVersions.length === 0) {
+    return [];
+  }
   // Sort in reverse order - highest first
   storedVersions.sort((first, second) => compareVersions(second, first));
   const highestSeenVersion = storedVersions.length > 0 ? storedVersions[0] : '0.0.0';

--- a/src/web/components/SiteTour/tourStorage.ts
+++ b/src/web/components/SiteTour/tourStorage.ts
@@ -43,7 +43,7 @@ export function GetTourSteps(
 ): VersionedTourStep[] {
   // search seen steps for the highest version number
   const storedVersions = getTourData().seenForVersions;
-  // if there are no seen version, this is the users first time in the portal
+  // if there are no seen versions, this is the users first time in the portal
   // new features don't make sense to show in this case
   if (storedVersions.length === 0) {
     markTourAsSeen();

--- a/src/web/components/SiteTour/tourStorage.ts
+++ b/src/web/components/SiteTour/tourStorage.ts
@@ -46,6 +46,7 @@ export function GetTourSteps(
   // if there are no seen version, this is the users first time in the portal
   // new features don't make sense to show in this case
   if (storedVersions.length === 0) {
+    markTourAsSeen();
     return [];
   }
   // Sort in reverse order - highest first


### PR DESCRIPTION
What Changed:
- Added a check for local storage to see if user has nothing in their local storage, then do not show the UI tour since they will be a new user and everything is new to them 

*Note: this check relies on local storage, meaning if a user logs in on a different device or happens to clear their local storage, they would not see the tour steps, but I think it's safe to assume the case is rare where they would log in on a different device or clear their local storage and be needing to see new features for the first time*

Test Plan:
- Create an account and log in as that user for the first time (make sure there is nothing in local storage for tour data from your normal user)
- Make sure you don't see the UI tour 
