### PR TITLE
Add more descriptions to api key and cstg pages to differentiate them

### DIFF
--- a/src/api/services/participantsService.ts
+++ b/src/api/services/participantsService.ts
@@ -27,7 +27,6 @@ import {
 } from './auditTrailService';
 import { createEmailService } from './emailService';
 import { EmailArgs } from './emailTypes';
-import { getAllUid2SupportUsers } from './uid2SupportService';
 
 export interface ParticipantRequest extends Request {
   participant?: Participant;

--- a/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
@@ -99,9 +99,10 @@ function ShowApiKeySecrets({ keySecrets, closeDialog }: ApiKeySecretsProps) {
     <div>
       <h1>API Key {keySecrets.name} Credentials</h1>
       <p>
-        Copy the key and secret, store them in a secure location, and do not share them. When you
-        close the window, these values are not saved and are no longer available to you. If they are
-        lost, you&apos;ll need to create a new key.
+        Copy the key and secret.{' '}
+        <b> You must store them in a secure location, and do not share them.</b> When you close the
+        window, these values are not saved and are no longer available to you. If they are lost,
+        you&apos;ll need to create a new key.
       </p>
       {secrets.map((secret) => (
         <div key={secret.valueName}>

--- a/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
@@ -99,10 +99,9 @@ function ShowApiKeySecrets({ keySecrets, closeDialog }: ApiKeySecretsProps) {
     <div>
       <h1>API Key {keySecrets.name} Credentials</h1>
       <p>
-        Copy the key and secret.{' '}
-        <b> You must store them in a secure location, and do not share them.</b> When you close the
-        window, these values are not saved and are no longer available to you. If they are lost,
-        you&apos;ll need to create a new key.
+        Copy the key and secret. <b> Store them in a safe location and do not share them.</b> When
+        you close the window, these values are not saved and are no longer available to you. If they
+        are lost, you&apos;ll need to create a new key.
       </p>
       {secrets.map((secret) => (
         <div key={secret.valueName}>

--- a/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
+++ b/src/web/components/ApiKeyManagement/KeyCreationDialog.tsx
@@ -99,7 +99,7 @@ function ShowApiKeySecrets({ keySecrets, closeDialog }: ApiKeySecretsProps) {
     <div>
       <h1>API Key {keySecrets.name} Credentials</h1>
       <p>
-        Copy the key and secret. <b> Store them in a safe location and do not share them.</b> When
+        Copy the key and secret. <b> Store them in a secure location and do not share them.</b> When
         you close the window, these values are not saved and are no longer available to you. If they
         are lost, you&apos;ll need to create a new key.
       </p>

--- a/src/web/components/Core/Tooltip/Tooltip.tsx
+++ b/src/web/components/Core/Tooltip/Tooltip.tsx
@@ -1,21 +1,30 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import clsx from 'clsx';
 import { ReactNode } from 'react';
 
 import './Tooltip.scss';
 
 type TooltipProps = Readonly<{
+  className?: string;
   children: ReactNode;
   trigger?: ReactNode;
   side?: 'top' | 'right' | 'bottom' | 'left';
   align?: 'center' | 'start' | 'end';
   delayDuration?: number;
 }>;
-export function Tooltip({ children, trigger, side, align, delayDuration }: TooltipProps) {
+export function Tooltip({
+  className,
+  children,
+  trigger,
+  side,
+  align,
+  delayDuration,
+}: TooltipProps) {
   const DEFAULT_DELAY_DURATION = 300;
 
   return (
-    <div className='tooltip'>
+    <div className={clsx('tooltip', className)}>
       <TooltipPrimitive.Provider delayDuration={delayDuration ?? DEFAULT_DELAY_DURATION}>
         <TooltipPrimitive.Root>
           <TooltipPrimitive.Trigger className='tooltip-trigger' type='button'>

--- a/src/web/components/KeyPairs/KeyPairsTable.scss
+++ b/src/web/components/KeyPairs/KeyPairsTable.scss
@@ -41,7 +41,7 @@
 
   .key-pair-header {
     display: flex;
-    gap: 5px;
+    gap: 10px;
 
     .key-pair-tool-tip {
       margin-top: 0.4rem;

--- a/src/web/components/KeyPairs/KeyPairsTable.scss
+++ b/src/web/components/KeyPairs/KeyPairsTable.scss
@@ -39,13 +39,13 @@
     }
   }
 
-  .subscription-id-header {
+  .key-pair-header {
     display: flex;
-    gap: 10px;
-  }
+    gap: 5px;
 
-  .key-pair-tool-tip {
-    margin-top: 0.4rem;
+    .key-pair-tool-tip {
+      margin-top: 0.4rem;
+    }
   }
 
   .key-pairs-table-header {
@@ -57,10 +57,6 @@
     &-right {
       display: flex;
       align-items: center;
-    }
-    .key-pairs-title {
-      display: flex;
-      gap: 10px;
     }
   }
 }

--- a/src/web/components/KeyPairs/KeyPairsTable.scss
+++ b/src/web/components/KeyPairs/KeyPairsTable.scss
@@ -39,6 +39,15 @@
     }
   }
 
+  .subscription-id-header {
+    display: flex;
+    gap: 10px;
+  }
+
+  .key-pair-tool-tip {
+    margin-top: 0.4rem;
+  }
+
   .key-pairs-table-header {
     display: flex;
     justify-content: space-between;
@@ -48,6 +57,10 @@
     &-right {
       display: flex;
       align-items: center;
+    }
+    .key-pairs-title {
+      display: flex;
+      gap: 10px;
     }
   }
 }

--- a/src/web/components/KeyPairs/KeyPairsTable.tsx
+++ b/src/web/components/KeyPairs/KeyPairsTable.tsx
@@ -4,6 +4,7 @@ import { SortableProvider, useSortable } from '../../contexts/SortableTableProvi
 import { AddKeyPairFormProps } from '../../services/keyPairService';
 import { SortableTableHeader } from '../Core/Tables/SortableTableHeader';
 import { TableNoDataPlaceholder } from '../Core/Tables/TableNoDataPlaceholder';
+import { Tooltip } from '../Core/Tooltip/Tooltip';
 import KeyPair from './KeyPair';
 import KeyPairDialog from './KeyPairDialog';
 import { OnKeyPairDisable } from './KeyPairDisableDialog';
@@ -42,8 +43,12 @@ function KeyPairsTableContent({
   return (
     <div className='key-pairs'>
       <div className='key-pairs-table-header'>
-        <div>
+        <div className='key-pairs-title'>
           <h2>Key Pairs</h2>
+          <Tooltip className='key-pair-tool-tip'>
+            A group term for the two values, Subscription ID and Public Key, which are used to
+            uniquely define a UID2 implementation that generates the token on the client side.
+          </Tooltip>
         </div>
 
         <div className='key-pairs-table-header-right'>
@@ -68,9 +73,21 @@ function KeyPairsTableContent({
             <SortableTableHeader<KeyPairModel>
               className='subscription-id'
               sortKey='subscriptionId'
-              header='Subscription ID'
+              header={
+                <div className='subscription-id-header'>
+                  <Tooltip>
+                    Identifies your site to the UID2 service. Can be shared publicly.
+                  </Tooltip>
+                  Subscription ID
+                </div>
+              }
             />
-            <th className='public-key'>Public Key</th>
+            <th>
+              <div className='subscription-id-header'>
+                <Tooltip>Used for encryption. Can be shared publicly.</Tooltip>
+                <div>Public Key</div>
+              </div>
+            </th>
             <SortableTableHeader<KeyPairModel>
               className='created'
               sortKey='created'

--- a/src/web/components/KeyPairs/KeyPairsTable.tsx
+++ b/src/web/components/KeyPairs/KeyPairsTable.tsx
@@ -70,22 +70,16 @@ function KeyPairsTableContent({
         <thead>
           <tr>
             <SortableTableHeader<KeyPairModel> className='name' sortKey='name' header='Name' />
-            <SortableTableHeader<KeyPairModel>
-              className='subscription-id'
-              sortKey='subscriptionId'
-              header={
-                <div className='key-pair-header'>
-                  <Tooltip>
-                    Identifies your site to the UID2 service. Can be shared publicly.
-                  </Tooltip>
-                  Subscription ID
-                </div>
-              }
-            />
             <th>
               <div className='key-pair-header'>
-                <Tooltip>Used for encryption. Can be shared publicly.</Tooltip>
+                Subscription ID
+                <Tooltip>Identifies your site to the UID2 service. Can be shared publicly.</Tooltip>
+              </div>
+            </th>
+            <th>
+              <div className='key-pair-header'>
                 Public Key
+                <Tooltip>Used for encryption. Can be shared publicly.</Tooltip>
               </div>
             </th>
             <SortableTableHeader<KeyPairModel>

--- a/src/web/components/KeyPairs/KeyPairsTable.tsx
+++ b/src/web/components/KeyPairs/KeyPairsTable.tsx
@@ -43,7 +43,7 @@ function KeyPairsTableContent({
   return (
     <div className='key-pairs'>
       <div className='key-pairs-table-header'>
-        <div className='key-pairs-title'>
+        <div className='key-pair-header'>
           <h2>Key Pairs</h2>
           <Tooltip className='key-pair-tool-tip'>
             A group term for the two values, Subscription ID and Public Key, which are used to
@@ -74,7 +74,7 @@ function KeyPairsTableContent({
               className='subscription-id'
               sortKey='subscriptionId'
               header={
-                <div className='subscription-id-header'>
+                <div className='key-pair-header'>
                   <Tooltip>
                     Identifies your site to the UID2 service. Can be shared publicly.
                   </Tooltip>
@@ -83,9 +83,9 @@ function KeyPairsTableContent({
               }
             />
             <th>
-              <div className='subscription-id-header'>
+              <div className='key-pair-header'>
                 <Tooltip>Used for encryption. Can be shared publicly.</Tooltip>
-                <div>Public Key</div>
+                Public Key
               </div>
             </th>
             <SortableTableHeader<KeyPairModel>

--- a/src/web/screens/apiKeyManagement.tsx
+++ b/src/web/screens/apiKeyManagement.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useContext, useState } from 'react';
-import { useRevalidator } from 'react-router-dom';
+import { NavLink, useRevalidator } from 'react-router-dom';
 import { defer, useLoaderData } from 'react-router-typesafe';
 
 import KeyCreationDialog from '../components/ApiKeyManagement/KeyCreationDialog';
@@ -90,6 +90,17 @@ function ApiKeyManagement() {
         </a>
         .
       </p>
+      <div>
+        The values you generate on this page are for client-server or server-side integrations.{' '}
+        <b>Store them securely and keep them secret.</b> For client-side integrations, go to the{' '}
+        <NavLink
+          to={`/participant/${participant?.id}/clientSideIntegration`}
+          className='outside-link'
+        >
+          Client-Side Integration
+        </NavLink>{' '}
+        page.
+      </div>
       <ScreenContentContainer>
         <Suspense fallback={<Loading />}>
           <AwaitTypesafe resolve={resolveAll({ apiKeys: data.apiKeys, apiRoles: data.apiRoles })}>

--- a/src/web/screens/apiKeyManagement.tsx
+++ b/src/web/screens/apiKeyManagement.tsx
@@ -92,14 +92,15 @@ function ApiKeyManagement() {
       </p>
       <div>
         The values you generate on this page are for client-server or server-side integrations.{' '}
-        <b>Store them securely and keep them secret.</b> For client-side integrations, go to the{' '}
+        <b>They must be stored securely and kept secret.</b> For an implementation option that
+        generates UID2 tokens on the client side, go to{' '}
         <NavLink
           to={`/participant/${participant?.id}/clientSideIntegration`}
           className='outside-link'
         >
           Client-Side Integration
-        </NavLink>{' '}
-        page.
+        </NavLink>
+        .
       </div>
       <ScreenContentContainer>
         <Suspense fallback={<Loading />}>

--- a/src/web/screens/apiKeyManagement.tsx
+++ b/src/web/screens/apiKeyManagement.tsx
@@ -79,7 +79,8 @@ function ApiKeyManagement() {
     <>
       <h1>API Keys</h1>
       <p className='heading-details'>
-        View and manage your API keys. For more information, see{' '}
+        View and manage your API keys for client-server or server-side integrations. For more
+        information, see{' '}
         <a
           target='_blank'
           className='outside-link'
@@ -91,9 +92,7 @@ function ApiKeyManagement() {
         .
       </p>
       <div>
-        The values you generate on this page are for client-server or server-side integrations.{' '}
-        <b>They must be stored securely and kept secret.</b> For an implementation option that
-        generates UID2 tokens on the client side, go to{' '}
+        For an implementation option that generates UID2 tokens on the client side, go to{' '}
         <NavLink
           to={`/participant/${participant?.id}/clientSideIntegration`}
           className='outside-link'

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -166,8 +166,7 @@ function ClientSideIntegration() {
         .
       </p>
       <div>
-        The values you generate on this page are public and do not need to be kept secret. For
-        client-server or server-side integrations, go to{' '}
+        For client-server or server-side integrations, go to{' '}
         <NavLink to={`/participant/${participant?.id}/apiKeys`} className='outside-link'>
           API Keys
         </NavLink>
@@ -186,8 +185,8 @@ function ClientSideIntegration() {
             {(loadedData) => (
               <>
                 <ClientSideCompletion
-                  domainNames={loadedData.domainNames}
                   appIds={loadedData.appIds}
+                  domainNames={loadedData.domainNames}
                   keyPairData={loadedData.keyPairs}
                 />
                 <KeyPairsTable

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useContext } from 'react';
-import { useRevalidator } from 'react-router-dom';
+import { NavLink, useRevalidator } from 'react-router-dom';
 import { defer, useLoaderData } from 'react-router-typesafe';
 
 import { ClientSideCompletion } from '../components/ClientSideCompletion/ClientSideCompletion';
@@ -165,6 +165,15 @@ function ClientSideIntegration() {
         </a>
         .
       </p>
+      <div>
+        The values you generate on this page are for client-side integrations. You do not need to
+        keep them secret. For client-server or server-side integrations, go to the{' '}
+        <NavLink to={`/participant/${participant?.id}/apiKeys`} className='outside-link'>
+          API Keys
+        </NavLink>{' '}
+        page.
+      </div>
+
       <ScreenContentContainer>
         <Suspense fallback={<Loading message='Loading client side integration data...' />}>
           <AwaitTypesafe

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -166,12 +166,12 @@ function ClientSideIntegration() {
         .
       </p>
       <div>
-        The values you generate on this page are for client-side integrations. You do not need to
-        keep them secret. For client-server or server-side integrations, go to the{' '}
+        The values you generate on this page are public and do not need to be kept secret. For
+        client-server or server-side integrations, go to{' '}
         <NavLink to={`/participant/${participant?.id}/apiKeys`} className='outside-link'>
           API Keys
-        </NavLink>{' '}
-        page.
+        </NavLink>
+        .
       </div>
 
       <ScreenContentContainer>

--- a/src/web/screens/clientSideIntegration.tsx
+++ b/src/web/screens/clientSideIntegration.tsx
@@ -185,8 +185,8 @@ function ClientSideIntegration() {
             {(loadedData) => (
               <>
                 <ClientSideCompletion
-                  appIds={loadedData.appIds}
                   domainNames={loadedData.domainNames}
+                  appIds={loadedData.appIds}
                   keyPairData={loadedData.keyPairs}
                 />
                 <KeyPairsTable


### PR DESCRIPTION
What Changed:

- Added definitions in info tooltip for key pairs, subscription id, public key
- Improve message when creating an API key so the user is aware the key needs to be kept secret
- Make it clear that API keys are for client-server and server-side
- Reference CSTG in API keys and vice versa