### PR TITLE
removed the default validate status instances

### DIFF
--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -84,10 +84,7 @@ export const getSharingList = async (
 ): Promise<SharingListResponse> => {
   try {
     const response = await adminServiceClient.get<SharingListResponse>(
-      `/api/sharing/list/${siteId}`,
-      {
-        validateStatus: (status) => status >= 200 && status < 300,
-      }
+      `/api/sharing/list/${siteId}`
     );
     return response.data.allowed_sites
       ? response.data
@@ -116,9 +113,6 @@ export const updateSharingList = async (
         allowed_sites: siteList,
         allowed_types: typeList,
         hash,
-      },
-      {
-        validateStatus: (status) => status >= 200 && status < 300,
       }
     );
     return response.data.allowed_sites


### PR DESCRIPTION
What Changed:

- Removed the two instances of specifying validateStatus that match the default, so they are not necessary ( >= 200 && <= 300)

Test Plan:
- This only happens in two functions related to sharing.  Test that sharing still works fine in the portal 