### PR TITLE
Fix add api-participant-member role when readding user

### DIFF
--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -194,6 +194,9 @@ export const inviteUserToParticipant = async (
   const existingUser = await findUserByEmail(userPartial.email);
   if (existingUser) {
     await addAndInviteUserToParticipant(existingUser, participant, userRoleId, traceId);
+
+    const kcAdminClient = await getKcAdminClient();
+    await assignApiParticipantMemberRole(kcAdminClient, existingUser.email);
   } else {
     const { firstName, lastName, email } = userPartial;
     await createAndInviteKeycloakUser(firstName, lastName, email);

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -194,6 +194,7 @@ export const inviteUserToParticipant = async (
   const existingUser = await findUserByEmail(userPartial.email);
   if (existingUser) {
     await addAndInviteUserToParticipant(existingUser, participant, userRoleId, traceId);
+    // role needs to be readded if existingUser does not currently belong to any participants
     if (existingUser.participants?.length === 0) {
       const kcAdminClient = await getKcAdminClient();
       await assignApiParticipantMemberRole(kcAdminClient, existingUser.email);

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -194,9 +194,10 @@ export const inviteUserToParticipant = async (
   const existingUser = await findUserByEmail(userPartial.email);
   if (existingUser) {
     await addAndInviteUserToParticipant(existingUser, participant, userRoleId, traceId);
-
-    const kcAdminClient = await getKcAdminClient();
-    await assignApiParticipantMemberRole(kcAdminClient, existingUser.email);
+    if (existingUser.participants?.length === 0) {
+      const kcAdminClient = await getKcAdminClient();
+      await assignApiParticipantMemberRole(kcAdminClient, existingUser.email);
+    }
   } else {
     const { firstName, lastName, email } = userPartial;
     await createAndInviteKeycloakUser(firstName, lastName, email);


### PR DESCRIPTION
What Changed:
- Add api-participant-member role to user if they already exist but did not belong to any participants 

Test Plan:
- Delete a team member from their only participant.  Check that user in your local Keycloak console and observe that the role is not in the list of roles and that logging in as that user does not access the portal.  Then add the team member back to a participant and check that the role was added back and the user once again has portal access.