### PR TITLE
Delete api keys with plus sign

### DIFF
--- a/src/api/services/adminServiceClient.ts
+++ b/src/api/services/adminServiceClient.ts
@@ -226,7 +226,7 @@ export const disableApiKey = async (contact: string, traceId: TraceId): Promise<
   const client = createTracedClient(traceId);
   await client.post('/api/client/disable', null, {
     params: {
-      contact,
+      contact: encodeURIComponent(contact),
     },
   });
 };


### PR DESCRIPTION
Make sure Api Keys that include '+' are translated correctly when making api calls