### PR TITLE
Fix domain extraction to allow multi-tenant domain names to be passed

### DIFF
--- a/src/web/components/ClientSideTokenGeneration/CstgAddDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDialog.tsx
@@ -62,9 +62,23 @@ function CstgAddDialog({
     if (newCstgValues.length === 0) {
       handleError(`The ${formattedCstgValueType}s entered already exist.`);
     } else if (cstgValueType === CstgValueType.Domain) {
+      const publicSuffixDomains: string[] = [];
       newCstgValues.forEach((newDomain, index) => {
-        newCstgValues[index] = extractTopLevelDomain(newDomain);
+        const topLevelDomain = extractTopLevelDomain(newDomain);
+        if (topLevelDomain) {
+          newCstgValues[index] = topLevelDomain;
+        } else {
+          publicSuffixDomains.push(newDomain);
+        }
       });
+      if (publicSuffixDomains.length > 0) {
+        handleError(
+          `The following domains are public suffixes and not allowed: ${formatStringsWithSeparator(
+            publicSuffixDomains
+          )}`
+        );
+        return;
+      }
       // filter for uniqueness (e.g. 2 different domains entered could have the same root-level domain)
       const dedupedRootLevelDomains = deduplicateStrings(newCstgValues);
       const invalidDomains = await onAddCstgValues(dedupedRootLevelDomains, deleteExistingList);

--- a/src/web/components/ClientSideTokenGeneration/CstgAddDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgAddDialog.tsx
@@ -65,10 +65,10 @@ function CstgAddDialog({
       const publicSuffixDomains: string[] = [];
       newCstgValues.forEach((newDomain, index) => {
         const topLevelDomain = extractTopLevelDomain(newDomain);
-        if (topLevelDomain) {
-          newCstgValues[index] = topLevelDomain;
-        } else {
+        if (topLevelDomain === 'publicSuffix') {
           publicSuffixDomains.push(newDomain);
+        } else {
+          newCstgValues[index] = topLevelDomain;
         }
       });
       if (publicSuffixDomains.length > 0) {

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
@@ -53,15 +53,14 @@ function CstgEditDialog({
 
     if (cstgValueType === CstgValueType.Domain) {
       const topLevelDomain = extractTopLevelDomain(updatedCstgValue);
-      if (topLevelDomain) {
-        updatedCstgValue =  topLevelDomain;
-      } else {
+      if (topLevelDomain === 'publicSuffix') {
         setError('root.serverError', {
           type: '400',
           message: `The ${formattedCstgValueType} is a public suffix and not allowed.`,
         });
         return;
       }
+      updatedCstgValue = topLevelDomain;
     }
     if (updatedCstgValue === originalCstgValue) {
       onOpenChange();

--- a/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
+++ b/src/web/components/ClientSideTokenGeneration/CstgEditDialog.tsx
@@ -52,9 +52,17 @@ function CstgEditDialog({
     const originalCstgValue = cstgValue;
 
     if (cstgValueType === CstgValueType.Domain) {
-      updatedCstgValue = extractTopLevelDomain(updatedCstgValue);
+      const topLevelDomain = extractTopLevelDomain(updatedCstgValue);
+      if (topLevelDomain) {
+        updatedCstgValue =  topLevelDomain;
+      } else {
+        setError('root.serverError', {
+          type: '400',
+          message: `The ${formattedCstgValueType} is a public suffix and not allowed.`,
+        });
+        return;
+      }
     }
-
     if (updatedCstgValue === originalCstgValue) {
       onOpenChange();
     } else if (existingCstgValues.includes(updatedCstgValue)) {
@@ -62,6 +70,7 @@ function CstgEditDialog({
         type: '400',
         message: `The ${formattedCstgValueType} already exists.`,
       });
+      return;
     }
     if (cstgValueType === CstgValueType.MobileAppId) {
       if (!validateAppId(updatedCstgValue)) {

--- a/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
@@ -37,14 +37,14 @@ export const formatCstgValueType = (valueType: CstgValueType) => {
   }
 };
 
-export const extractTopLevelDomain = (domainName: string): string | null => {
+export const extractTopLevelDomain = (domainName: string): string => {
   const topLevelDomainInfo = parse(domainName, { allowPrivateDomains: true });
   if (topLevelDomainInfo.domain) {
     return topLevelDomainInfo.domain;
   }
   // Return null if it's a public suffix
   if (topLevelDomainInfo.isPrivate) {
-    return null;
+    return 'publicSuffix';
   }
   return domainName;
 };

--- a/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
@@ -37,10 +37,14 @@ export const formatCstgValueType = (valueType: CstgValueType) => {
   }
 };
 
-export const extractTopLevelDomain = (domainName: string) => {
+export const extractTopLevelDomain = (domainName: string): string | null => {
   const topLevelDomainInfo = parse(domainName, { allowPrivateDomains: true });
   if (topLevelDomainInfo.domain) {
     return topLevelDomainInfo.domain;
+  }
+  // Return null if it's a public suffix
+  if (topLevelDomainInfo.isPrivate) {
+    return null;
   }
   return domainName;
 };

--- a/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
@@ -38,9 +38,9 @@ export const formatCstgValueType = (valueType: CstgValueType) => {
 };
 
 export const extractTopLevelDomain = (domainName: string) => {
-  const topLevelDomain = parse(domainName).domain;
-  if (topLevelDomain && topLevelDomain !== domainName) {
-    return topLevelDomain;
+  const topLevelDomainInfo = parse(domainName, { allowPrivateDomains: true });
+  if (topLevelDomainInfo.domain) {
+    return topLevelDomainInfo.domain;
   }
   return domainName;
 };

--- a/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
+++ b/src/web/components/ClientSideTokenGeneration/CstgHelper.ts
@@ -42,7 +42,6 @@ export const extractTopLevelDomain = (domainName: string): string => {
   if (topLevelDomainInfo.domain) {
     return topLevelDomainInfo.domain;
   }
-  // Return null if it's a public suffix
   if (topLevelDomainInfo.isPrivate) {
     return 'publicSuffix';
   }


### PR DESCRIPTION
Previously, multi-tenant domains (i.e., .vercel.app, .github.io) failed to pass validation because our exctraction logic didn't account for private suffixes which has to be explicitly required. 