### PR TITLE
[UID2-6897] Fix CVE-2025-62718: Upgrade axios 1.13.5→1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/react": "^18.2.54",
         "@types/react-dom": "^18.2.18",
         "@types/validator": "^13.11.10",
-        "axios": "^1.13.5",
+        "axios": ">=1.15.0",
         "body-parser": "^1.20.3",
         "braces": "^3.0.3",
         "clsx": "^1.2.1",
@@ -10836,13 +10836,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -24676,9 +24676,12 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^18.2.54",
     "@types/react-dom": "^18.2.18",
     "@types/validator": "^13.11.10",
-    "axios": "^1.13.5",
+    "axios": ">=1.15.0",
     "body-parser": "^1.20.3",
     "braces": "^3.0.3",
     "clsx": "^1.2.1",


### PR DESCRIPTION
## Summary

Upgrades `axios` from `^1.13.5` to `>=1.15.0` to remediate **CVE-2025-62718** (CRITICAL).

**Vulnerability:** CVE-2025-62718 — axios NO_PROXY Hostname Normalization Bypass → SSRF
- Affected versions of axios had a flaw in `NO_PROXY` hostname normalization that could be bypassed by an attacker to perform Server-Side Request Forgery (SSRF), allowing requests to internal/restricted hosts that should have been blocked by proxy settings.
- Fixed in axios 1.15.0.

## Changes

- `package.json`: Updated `axios` dependency from `^1.13.5` to `>=1.15.0`
- `package-lock.json`: Regenerated to install axios 1.15.0

## Jira Ticket

[UID2-6897](https://thetradedesk.atlassian.net/browse/UID2-6897)

## Test Plan

- [x] `npm install` completes successfully with axios 1.15.0 installed
- [x] `npm audit` confirms CVE-2025-62718 is no longer flagged