### PR TITLE
UID2-6913: Pin third-party GitHub Action refs to commit SHAs

### DIFF
--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -74,17 +74,17 @@ jobs:
           path: .
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image for API/UI
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: Dockerfile_ssportal

--- a/.github/workflows/sync-sendgrid-template-action.yml
+++ b/.github/workflows/sync-sendgrid-template-action.yml
@@ -15,14 +15,14 @@ jobs:
         uses: actions/checkout@v4
       - name: SendGrid sync
         id: sendgrid_sync
-        uses: nanopx/action-sendgrid-sync@0.5.2
+        uses: nanopx/action-sendgrid-sync@296bf7c0b1a003037400895b6a109cf946115249 # 0.5.2
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           sendgridApiKey: ${{ secrets.SENDGRID_API_KEY }}
           templatesDir: 'emailTemplates/'
           forceSyncAll: '${{ inputs.FORCE_SYNC_ALL }}'
       - name: Write template id mapping
-        uses: DamianReeves/write-file-action@master
+        uses: DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4 # master
         with:
           path: src/api/templateIdMapping.json
           contents: ${{ steps.sendgrid_sync.outputs.sendgridTemplateIdMapping }}
@@ -32,7 +32,7 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Commit & Push
-        uses: actions-js/push@master
+        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
## Summary
Pin third-party (non-GitHub-owned) action references to full-length commit SHAs to mitigate supply-chain attacks from mutable tags.

Only external actions are pinned in this PR (e.g. `docker/*`, `aws-actions/*`, `softprops/*`, etc.). GitHub-owned actions (`actions/*`) are not included in this change.

## Verification
Each SHA can be verified with:
```
git ls-remote https://github.com/<owner>/<repo> <tag>
```

## Test plan
- [ ] Verify CI passes with pinned refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)