### PR TITLE
UID2-6956: Fix invite email not sent to internal/SSO users

### DIFF
--- a/src/api/services/usersService.spec.ts
+++ b/src/api/services/usersService.spec.ts
@@ -1,0 +1,182 @@
+import { jest } from '@jest/globals';
+import { Knex } from 'knex';
+
+// jest.unstable_mockModule is NOT hoisted in ESM mode (unlike jest.mock()), so all imports that
+// transitively load the mocked modules must be dynamic (placed after the mock registrations).
+
+const mockSendEmail = jest.fn();
+const mockGetKcAdminClient = jest.fn(() => ({}));
+const mockDoesUserExistInKeycloak = jest.fn();
+const mockCreateNewUser = jest.fn(() => ({ id: 'kc-user-id' }));
+const mockSendInviteEmailToNewUser = jest.fn();
+const mockAssignApiParticipantMemberRole = jest.fn();
+
+jest.unstable_mockModule('./kcUsersService', () => ({
+  doesUserExistInKeycloak: mockDoesUserExistInKeycloak,
+  createNewUser: mockCreateNewUser,
+  sendInviteEmailToNewUser: mockSendInviteEmailToNewUser,
+  assignApiParticipantMemberRole: mockAssignApiParticipantMemberRole,
+}));
+
+jest.unstable_mockModule('../keycloakAdminClient', () => ({
+  getKcAdminClient: mockGetKcAdminClient,
+}));
+
+jest.unstable_mockModule('./emailService', () => ({
+  createEmailService: jest.fn(() => ({ sendEmail: mockSendEmail })),
+}));
+
+// Dynamic imports must come AFTER jest.unstable_mockModule registrations so that when these
+// modules are loaded they pick up the mocked dependencies (emailService, kcUsersService, etc.)
+const { TestConfigure } = await import('../../database/TestSelfServeDatabase');
+const { createParticipant, createUser } = await import('../../testHelpers/apiTestHelpers');
+const { inviteUserToParticipant } = await import('./usersService');
+const { UserJobFunction } = await import('../entities/User');
+const { UserRoleId } = await import('../entities/UserRole');
+
+const traceId = { traceId: 'test-trace-id', uidTraceId: 'test-uid-trace-id' };
+
+const internalUserPartial = {
+  email: 'engineer@unifiedid.com',
+  firstName: 'Internal',
+  lastName: 'User',
+  jobFunction: UserJobFunction.Engineering,
+};
+
+const externalUserPartial = {
+  email: 'user@external.com',
+  firstName: 'External',
+  lastName: 'User',
+  jobFunction: UserJobFunction.DA,
+};
+
+describe('inviteUserToParticipant', () => {
+  let knex: Knex;
+
+  beforeEach(async () => {
+    knex = await TestConfigure();
+    jest.clearAllMocks();
+  });
+
+  describe('user already exists in portal DB (existing user path)', () => {
+    it('sends invite email to an existing internal user added to a new org', async () => {
+      // Replicates the reported bug: internal user invited to Platform Support Org
+      // receives no notification because addAndInviteUserToParticipant had an
+      // isUid2Internal guard that blocked sendInviteEmailToExistingUser.
+      const participant = await createParticipant(knex, { name: 'Platform Support' });
+      const existingOtherParticipant = await createParticipant(knex, {});
+      await createUser({
+        email: internalUserPartial.email,
+        participantToRoles: [{ participantId: existingOtherParticipant.id }],
+      });
+
+      await inviteUserToParticipant(internalUserPartial, participant, UserRoleId.Admin, traceId);
+
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: internalUserPartial.email,
+          template: 'inviteExistingUserToParticipant',
+          templateData: expect.objectContaining({ participantName: 'Platform Support' }),
+        }),
+        traceId
+      );
+      expect(mockSendInviteEmailToNewUser).not.toHaveBeenCalled();
+    });
+
+    it('sends invite email to an existing external user added to a new org', async () => {
+      const participant = await createParticipant(knex, { name: 'Acme Corp' });
+      const existingOtherParticipant = await createParticipant(knex, {});
+      await createUser({
+        email: externalUserPartial.email,
+        participantToRoles: [{ participantId: existingOtherParticipant.id }],
+      });
+
+      await inviteUserToParticipant(externalUserPartial, participant, UserRoleId.Admin, traceId);
+
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: externalUserPartial.email,
+          template: 'inviteExistingUserToParticipant',
+        }),
+        traceId
+      );
+      expect(mockSendInviteEmailToNewUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('user does not exist in portal DB (new user path)', () => {
+    it('sends KC password-setup email to a brand-new external user not in Keycloak', async () => {
+      const participant = await createParticipant(knex, {});
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockDoesUserExistInKeycloak as any).mockResolvedValue(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockCreateNewUser as any).mockResolvedValue({ id: 'new-kc-id' });
+
+      await inviteUserToParticipant(externalUserPartial, participant, UserRoleId.Admin, traceId);
+
+      expect(mockSendInviteEmailToNewUser).toHaveBeenCalled();
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it('sends invite email (not KC password email) to an internal SSO user who exists in Keycloak but not the portal', async () => {
+      // Replicates the bug: an SSO user who has never accessed the portal is invited.
+      // Before the fix, inviteUserToParticipant always called createAndInviteKeycloakUser
+      // regardless of KC existence, which sent no email for internal users (isUid2Internal guard).
+      // After the fix, it checks KC first and sends sendInviteEmailToExistingUser instead.
+      const participant = await createParticipant(knex, { name: 'Platform Support' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockDoesUserExistInKeycloak as any).mockResolvedValue(true);
+
+      await inviteUserToParticipant(internalUserPartial, participant, UserRoleId.Admin, traceId);
+
+      expect(mockSendInviteEmailToNewUser).not.toHaveBeenCalled();
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: internalUserPartial.email,
+          template: 'inviteExistingUserToParticipant',
+          templateData: expect.objectContaining({ participantName: 'Platform Support' }),
+        }),
+        traceId
+      );
+      expect(mockAssignApiParticipantMemberRole).toHaveBeenCalled();
+    });
+
+    it('sends invite email (not KC password email) to an external user who already exists in Keycloak', async () => {
+      const participant = await createParticipant(knex, { name: 'Acme Corp' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockDoesUserExistInKeycloak as any).mockResolvedValue(true);
+
+      await inviteUserToParticipant(externalUserPartial, participant, UserRoleId.Admin, traceId);
+
+      expect(mockSendInviteEmailToNewUser).not.toHaveBeenCalled();
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: externalUserPartial.email,
+          template: 'inviteExistingUserToParticipant',
+        }),
+        traceId
+      );
+    });
+
+    it('sends invite email to a brand-new internal user not yet in Keycloak', async () => {
+      // createAndInviteKeycloakUser skips KC email for internal users (isUid2Internal guard),
+      // so sendInviteEmailToExistingUser must fire as the fallback notification.
+      const participant = await createParticipant(knex, { name: 'Platform Support' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockDoesUserExistInKeycloak as any).mockResolvedValue(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockCreateNewUser as any).mockResolvedValue({ id: 'new-kc-id' });
+
+      await inviteUserToParticipant(internalUserPartial, participant, UserRoleId.Admin, traceId);
+
+      expect(mockSendInviteEmailToNewUser).not.toHaveBeenCalled();
+      expect(mockSendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: internalUserPartial.email,
+          template: 'inviteExistingUserToParticipant',
+        }),
+        traceId
+      );
+    });
+  });
+});

--- a/src/api/services/usersService.ts
+++ b/src/api/services/usersService.ts
@@ -13,6 +13,7 @@ import { EmailArgs } from './emailTypes';
 import {
   assignApiParticipantMemberRole,
   createNewUser,
+  doesUserExistInKeycloak,
   sendInviteEmailToNewUser,
 } from './kcUsersService';
 
@@ -168,9 +169,7 @@ const addAndInviteUserToParticipant = async (
     participantId: participant.id,
     userRoleId,
   });
-  if (!isUid2Internal(existingUser.email)) {
-    sendInviteEmailToExistingUser(participant.name, existingUser, traceId);
-  }
+  sendInviteEmailToExistingUser(participant.name, existingUser, traceId);
 };
 
 const createUserInPortal = async (
@@ -207,8 +206,19 @@ export const inviteUserToParticipant = async (
     }
   } else {
     const { firstName, lastName, email } = userPartial;
-    await createAndInviteKeycloakUser(firstName, lastName, email);
+    const kcAdminClient = await getKcAdminClient();
+    const isExistingKcUser = await doesUserExistInKeycloak(kcAdminClient, email);
+    if (!isExistingKcUser) {
+      await createAndInviteKeycloakUser(firstName, lastName, email);
+    } else {
+      await assignApiParticipantMemberRole(kcAdminClient, email);
+    }
     const newUser = await createUserInPortal(userPartial, participant!.id, userRoleId);
+    // KC-existing users (e.g. SSO users) and internal users don't receive the KC password-setup
+    // email from createAndInviteKeycloakUser, so send the "invited to org" email instead.
+    if (isExistingKcUser || isUid2Internal(email)) {
+      sendInviteEmailToExistingUser(participant.name, newUser, traceId);
+    }
     return newUser;
   }
 };


### PR DESCRIPTION
## Summary

Fixes [UID2-6956](https://thetradedesk.atlassian.net/browse/UID2-6956): Internal (SSO) users invited to a participant org were not receiving any invite notification.

Two bugs fixed in `inviteUserToParticipant` (`src/api/services/usersService.ts`):

- **`addAndInviteUserToParticipant`** had an `isUid2Internal` guard that silently dropped `sendInviteEmailToExistingUser` for `@unifiedid.com` / `@thetradedesk.com` users. Internal users now receive the "You have been invited to join X in the UID2 Portal" email the same as external users.

- **`else` branch (user not in portal DB)** always called `createAndInviteKeycloakUser` regardless of whether the user already existed in Keycloak (e.g. SSO-federated employees). This mirrors the correct pattern already used in `participantsCreation.ts`. The branch now calls `doesUserExistInKeycloak` first:
  - KC-existing users: receive the invite email + KC member role assigned (no redundant account creation)
  - Brand-new external users: receive the Keycloak `UPDATE_PASSWORD` email as before (unchanged)
  - Brand-new internal users (not yet in KC): `createAndInviteKeycloakUser` skips the KC email via `isUid2Internal`, so `sendInviteEmailToExistingUser` fires as fallback

## Test plan

- [ ] New file `src/api/services/usersService.spec.ts` with 6 unit tests covering all combinations:
  - Existing internal portal user invited to new org → invite email sent ✓ (was broken)
  - Existing external portal user invited to new org → invite email sent ✓
  - Brand-new external user, not in KC → KC password-setup email ✓
  - Internal SSO user in KC but not portal → invite email, not KC email ✓ (was broken)
  - External KC-existing user, not in portal → invite email ✓
  - Brand-new internal user, not in KC → invite email as fallback ✓ (was broken)
- [ ] `npm run test-api` — all 6 new tests pass; pre-existing failures are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)