### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -17,6 +17,7 @@ jobs:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v3
     with:
       release_type: ${{ inputs.release_type }}
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit
 
   buildApi:


### PR DESCRIPTION
## Summary
Pass `merge_environment: 'ci-auto-merge'` on protected branches so the release workflow uses the UID2SourceAdmin PAT to bypass the PR review ruleset when auto-merging the version bump PR.