### PR TITLE
UID2-6742: upgrade Node.js 20 actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,6 +21,6 @@ jobs:
       - run: npm test
       - run: npm run build-api --if-present
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@sch-UID2-6742-update-node20-actions
         with:
           scan_type: 'fs'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,6 +21,6 @@ jobs:
       - run: npm test
       - run: npm run build-api --if-present
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@sch-UID2-6742-update-node20-actions
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:
           scan_type: 'fs'

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -11,7 +11,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -11,7 +11,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@sch-UID2-6742-update-node20-actions
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:
           scan_type: 'fs'

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@sch-UID2-6742-update-node20-actions
         with:
           scan_type: 'fs'

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -25,7 +25,7 @@ jobs:
     needs: incrementVersionNumber
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: npm ci
@@ -39,13 +39,13 @@ jobs:
         run: npm run build-api
 
       - name: Upload built API files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: api-dist
           path: api-dist/
 
       - name: Upload patched package.json
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: patched-package
           path: package.json
@@ -60,7 +60,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download built API files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -63,13 +63,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download built API files
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: api-dist
           path: api-dist/
 
       - name: Download patched package.json
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: patched-package
           path: .

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -39,13 +39,13 @@ jobs:
         run: npm run build-api
 
       - name: Upload built API files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-dist
           path: api-dist/
 
       - name: Upload patched package.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: patched-package
           path: package.json
@@ -85,7 +85,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image for API/UI
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: Dockerfile_ssportal

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -25,7 +25,7 @@ jobs:
     needs: incrementVersionNumber
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: npm ci
@@ -60,7 +60,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download built API files
         uses: actions/download-artifact@v4
@@ -78,7 +78,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -63,13 +63,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download built API files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: api-dist
           path: api-dist/
 
       - name: Download patched package.json
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: patched-package
           path: .

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -75,7 +75,7 @@ jobs:
           path: .
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   incrementVersionNumber:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@sch-UID2-6742-update-node20-actions
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v3
     with:
       release_type: ${{ inputs.release_type }}
       merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
@@ -92,7 +92,7 @@ jobs:
           push: true
           tags: ghcr.io/iabtechlab/uid2-ssportal:${{ needs.incrementVersionNumber.outputs.image_tag }}
       - name: Vulnerability scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@sch-UID2-6742-update-node20-actions
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:
           publish_vulnerabilities: true
           failure_severity: CRITICAL
@@ -101,7 +101,7 @@ jobs:
           scan_type: image
 
   publishForDBMigration:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@sch-UID2-6742-update-node20-actions
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v3
     needs: incrementVersionNumber
     with:
       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
@@ -114,7 +114,7 @@ jobs:
     secrets: inherit
 
   publishForKeycloak:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@sch-UID2-6742-update-node20-actions
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v3
     needs: incrementVersionNumber
     with:
       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   incrementVersionNumber:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v3
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@sch-UID2-6742-update-node20-actions
     with:
       release_type: ${{ inputs.release_type }}
       merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
@@ -92,7 +92,7 @@ jobs:
           push: true
           tags: ghcr.io/iabtechlab/uid2-ssportal:${{ needs.incrementVersionNumber.outputs.image_tag }}
       - name: Vulnerability scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@sch-UID2-6742-update-node20-actions
         with:
           publish_vulnerabilities: true
           failure_severity: CRITICAL
@@ -101,7 +101,7 @@ jobs:
           scan_type: image
 
   publishForDBMigration:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v3
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@sch-UID2-6742-update-node20-actions
     needs: incrementVersionNumber
     with:
       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
@@ -114,7 +114,7 @@ jobs:
     secrets: inherit
 
   publishForKeycloak:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v3
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@sch-UID2-6742-update-node20-actions
     needs: incrementVersionNumber
     with:
       new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}

--- a/.github/workflows/sync-sendgrid-template-action.yml
+++ b/.github/workflows/sync-sendgrid-template-action.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: SendGrid sync
         id: sendgrid_sync
         uses: nanopx/action-sendgrid-sync@296bf7c0b1a003037400895b6a109cf946115249 # 0.5.2

--- a/.github/workflows/sync-sendgrid-template-action.yml
+++ b/.github/workflows/sync-sendgrid-template-action.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: SendGrid sync
         id: sendgrid_sync
         uses: nanopx/action-sendgrid-sync@296bf7c0b1a003037400895b6a109cf946115249 # 0.5.2

--- a/.github/workflows/vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/vulnerability-scan-failure-notify.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   vulnerability-scan-failure-notify:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@sch-UID2-6742-update-node20-actions
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@v3
     secrets:
       SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK }}
     with:

--- a/.github/workflows/vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/vulnerability-scan-failure-notify.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   vulnerability-scan-failure-notify:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@v3
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@sch-UID2-6742-update-node20-actions
     secrets:
       SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK }}
     with:


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` / SHA `34e114876b` → `@v6` / SHA `de0fac2e`
- `docker/login-action@v3` / SHA `c94ce9fb` → `@v4` / SHA `4907a6dd`

Node.js 20 is deprecated on GitHub Actions runners; forced cutover **June 2, 2026**.

## Jira
https://thetradedesk.atlassian.net/browse/UID2-6742

🤖 Generated with [Claude Code](https://claude.com/claude-code)