### PR TITLE
fix(security): upgrade axios to >=1.15.2 (CVE-2026-42033/42035/42043/42264)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/react": "^18.2.54",
         "@types/react-dom": "^18.2.18",
         "@types/validator": "^13.11.10",
-        "axios": ">=1.15.0",
+        "axios": ">=1.15.2",
         "body-parser": "^1.20.3",
         "braces": "^3.0.3",
         "clsx": "^1.2.1",
@@ -10836,11 +10836,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -15542,9 +15542,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^18.2.54",
     "@types/react-dom": "^18.2.18",
     "@types/validator": "^13.11.10",
-    "axios": ">=1.15.0",
+    "axios": ">=1.15.2",
     "body-parser": "^1.20.3",
     "braces": "^3.0.3",
     "clsx": "^1.2.1",


### PR DESCRIPTION
## Summary

Upgrades axios from >=1.15.0 to >=1.15.2 (resolves to 1.16.0).

Fixes four HIGH severity axios vulnerabilities:
- **CVE-2026-42033**: HTTP Transport Hijacking via Prototype Pollution
- **CVE-2026-42035**: Arbitrary HTTP header injection via prototype pollution
- **CVE-2026-42043**: Prototype pollution
- **CVE-2026-42264**: Prototype pollution read-side gadgets allowing credential exfiltration

axios is a direct production dependency making HTTP calls to UID2 APIs.

## Test plan

- [ ] CI vulnerability scan passes (axios 1.16.0 resolves all 4 CVEs)
- [ ] No functional regressions