### PR TITLE
UID2-7059: Fix CVE-2026-6321 & CVE-2026-6322 (fast-uri)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15242,9 +15242,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "serialize-javascript": "^7.0.3",
     "path-to-regexp@0": "0.1.13",
     "picomatch": "^2.3.2",
-    "lodash": "^4.18.0"
+    "lodash": "^4.18.0",
+    "fast-uri": ">=3.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Adds npm `overrides` for `fast-uri >=3.1.2` to address CVE-2026-6321 (path traversal) and CVE-2026-6322 (percent-encoded authority bypass), both HIGH severity
- Regenerates package-lock.json

Jira: https://thetradedesk.atlassian.net/browse/UID2-7059