### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,9 +10,9 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -11,7 +11,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:

--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -25,7 +25,7 @@ jobs:
     needs: incrementVersionNumber
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install dependencies
         run: npm ci
@@ -39,13 +39,13 @@ jobs:
         run: npm run build-api
 
       - name: Upload built API files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: api-dist
           path: api-dist/
 
       - name: Upload patched package.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: patched-package
           path: package.json
@@ -60,32 +60,32 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download built API files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: api-dist
           path: api-dist/
 
       - name: Download patched package.json
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: patched-package
           path: .
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image for API/UI
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile_ssportal

--- a/.github/workflows/sync-sendgrid-template-action.yml
+++ b/.github/workflows/sync-sendgrid-template-action.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: SendGrid sync
         id: sendgrid_sync
         uses: nanopx/action-sendgrid-sync@296bf7c0b1a003037400895b6a109cf946115249 # 0.5.2


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**Intentionally out of scope**

<code class="notranslate">.github/workflows/sync-sendgrid-template-action.yml</code> still references three actions on deprecated Node runtimes that this PR doesn't bump as they don't have a Node 24 replacement:


Line | Action | Runtime
-- | -- | --
:18 | nanopx/action-sendgrid-sync@0.5.2 | node12
:25 | DamianReeves/write-file-action # master | node20
:35 | actions-js/push # master | node20

