### PR TITLE
UID2-7307: fix form-data CVE-2026-12143 (HIGH) — upgrade to 4.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "express-oauth2-jwt-bearer": "^1.6.0",
         "express-prom-bundle": "^6.6.0",
         "express-winston": "^4.2.0",
-        "form-data": "^4.0.4",
+        "form-data": "^4.0.6",
         "fuse.js": "^6.6.2",
         "handlebars": "^4.7.9",
         "inter-ui": "^3.19.3",
@@ -15687,15 +15687,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -16288,9 +16288,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "express-oauth2-jwt-bearer": "^1.6.0",
     "express-prom-bundle": "^6.6.0",
     "express-winston": "^4.2.0",
-    "form-data": "^4.0.4",
+    "form-data": "^4.0.6",
     "fuse.js": "^6.6.2",
     "handlebars": "^4.7.9",
     "inter-ui": "^3.19.3",
@@ -244,7 +244,7 @@
     "svgo": "3.2.0",
     "resolve-url-loader": "5.0.0",
     "storybook": "$storybook",
-    "form-data": "^4.0.4",
+    "form-data": "^4.0.6",
     "glob": {
       ".": "^11.1.0",
       "minimatch": "^10.2.3"


### PR DESCRIPTION
## Summary

Fixes CVE-2026-12143 (HIGH): form-data multipart library vulnerability. Updates the direct dependency and npm override from `^4.0.4` to `^4.0.6`, ensuring `package-lock.json` resolves to the patched `4.0.6` release.

- **CVE**: [CVE-2026-12143](https://nvd.nist.gov/vuln/detail/CVE-2026-12143) — HIGH severity
- **Package**: form-data, affected: 4.0.4, fixed in: 4.0.6
- **Jira**: [UID2-7307](https://thetradedesk.atlassian.net/browse/UID2-7307)

## Test plan
- [ ] CI vulnerability scan passes (Trivy should no longer report CVE-2026-12143)
- [ ] Build and tests pass