### PR TITLE
UID2-7330: fix nodemailer GHSA-p6gq-j5cr-w38f (HIGH) — upgrade to 9.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "keycloak-js": "^26.0.7",
         "knex": "^2.5.1",
         "loglevel": "^1.9.1",
-        "nodemailer": "^7.0.11",
+        "nodemailer": "^9.0.1",
         "nodemailer-express-handlebars": "^6.1.0",
         "normalize.css": "^8.0.1",
         "objection": "^3.1.3",
@@ -22181,9 +22181,9 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="
     },
     "node_modules/nodemailer": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
-      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "keycloak-js": "^26.0.7",
     "knex": "^2.5.1",
     "loglevel": "^1.9.1",
-    "nodemailer": "^7.0.11",
+    "nodemailer": "^9.0.1",
     "nodemailer-express-handlebars": "^6.1.0",
     "normalize.css": "^8.0.1",
     "objection": "^3.1.3",


### PR DESCRIPTION
## Summary
- Upgrades `nodemailer` from `^7.0.11` to `^9.0.1` to fix [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) (HIGH severity)
- The vulnerability allows bypassing Nodemailer's message-level security protections via the `raw` option; our code never uses `raw` but a real fix is available and `nodemailer-express-handlebars` is compatible (`peerDep >= 6.0.0`)
- TypeScript compiles clean with v9; no API changes to `createTransport`/`sendMail` usage

## Test plan
- [ ] CI vulnerability scan passes (nodemailer GHSA-p6gq-j5cr-w38f no longer reported)
- [ ] Build and unit tests pass

Jira: [UID2-7330](https://thetradedesk.atlassian.net/browse/UID2-7330)

🤖 Generated with [Claude Code](https://claude.com/claude-code)