### PR TITLE
UID2-7336: bump undici to patch CVE-2026-12151 (DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "tldts": "^6.1.8",
         "typescript": "^5.4.5",
         "typescript-cookie": "^1.0.6",
-        "undici": "^6.24.0",
+        "undici": "^6.27.0",
         "url-pattern": "^1.0.3",
         "utility-types": "^3.11.0",
         "uuid": "^9.0.1",
@@ -30315,9 +30315,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "tldts": "^6.1.8",
     "typescript": "^5.4.5",
     "typescript-cookie": "^1.0.6",
-    "undici": "^6.24.0",
+    "undici": "^6.27.0",
     "url-pattern": "^1.0.3",
     "utility-types": "^3.11.0",
     "uuid": "^9.0.1",


### PR DESCRIPTION
## What
Bumps the direct dependency `undici` from `^6.24.0` to `^6.27.0` and regenerates `package-lock.json` (undici 6.24.1 → 6.27.0). Only undici lines change in the lockfile.

## Why
Trivy flagged **CVE-2026-12151** (HIGH severity) — undici 6.24.1 denial of service via unbounded memory growth in the WebSocket client. Fixed in 6.27.0 / 7.28.0 / 8.5.0; we stay on the 6.x line to avoid the breaking changes in 7.x/8.x.

## Impact
undici is only used in `src/api/jest.polyfills.ts`, where it provides `fetch`/`Headers`/`FormData`/`Request`/`Response` globals for the Jest test environment. The repo never uses undici's WebSocket client, so the vulnerable code path is not reachable in production. This is a hygiene fix to clear the scan finding; the bump is a safe same-major upgrade.
