### PR TITLE
UID2-7390: add recurring image scan for the Keycloak image

### DIFF
--- a/.github/workflows/vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/vulnerability-scan-failure-notify.yaml
@@ -21,3 +21,19 @@ jobs:
       SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK }}
     with:
       scan_type : fs
+
+  # The fs scan can't see inside the Keycloak image's Java base. Scan it on the same schedule by
+  # building it fresh from its Dockerfile (re-pulls the pinned base, so new base CVEs surface
+  # without a release). To cover another image later, add its Dockerfile to the matrix.
+  image-scan-failure-notify:
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile_keycloak
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@v3
+    secrets:
+      SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK }}
+    with:
+      scan_type : image
+      dockerfile : ${{ matrix.dockerfile }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -6,3 +6,17 @@ CVE-2026-25646 exp:2026-09-02
 # and the core libz library used by the JRE is unaffected. The zlib maintainer disputes this CVE.
 # See: UID2-6704
 CVE-2026-22184 exp:2026-09-09
+
+# --- Residual HIGH CVEs bundled in the upstream Keycloak image. Already on the latest stable
+# Keycloak, so only fixable by a future upstream release (not by us). Short expiry to auto-
+# resurface. Note: the portal Keycloak is internet-facing, so these are NOT network-mitigated.
+# See: UID2-7391 (Keycloak bump) / UID2-7390 (image scan)
+# jackson-databind
+CVE-2026-54513 exp:2026-09-29
+CVE-2026-54512 exp:2026-09-29
+# mssql-jdbc (Keycloak DB driver)
+CVE-2025-59250 exp:2026-09-29
+# java-21-openjdk, JVM-internal
+CVE-2026-22020 exp:2026-09-29
+CVE-2025-66293 exp:2026-09-29
+# --- end Keycloak residual ---


### PR DESCRIPTION
The scheduled vulnerability-scan workflow only ran an `fs` scan (repo package manifests), which can't see inside a container base image — so the Keycloak image's Java CVEs were never caught by a scheduled scan. The version fix is UID2-7391 / #827; this PR closes the detection gap.

**Two changes:**

1. **Recurring image scan.** Adds an `image-scan-failure-notify` job that scans the Keycloak image on the same schedule by calling the shared notify workflow with its new `dockerfile` input. That builds the image fresh from `Dockerfile_keycloak` (re-pulling the pinned base, so newly-disclosed base CVEs surface without a new release) and reuses the shared workflow's existing scan + Slack-notify + fail logic — no scan/notify logic duplicated here. Covering another image later is one matrix line.

2. **`.trivyignore` suppressions.** Suppresses the 5 residual HIGH CVEs bundled in the upstream Keycloak 26.6.4 image (jackson-databind ×2, mssql-jdbc, java-21-openjdk ×2) with a short expiry, so this scan settles to green and only fires on genuinely new HIGH CVEs. We're already on the latest stable Keycloak, so these are only fixable by a future upstream release. NB the portal Keycloak is internet-facing, so these are not network-mitigated — see the residual discussion on UID2-7391.

Scope is the Keycloak image only — the node-based images' dependencies are covered by the `fs` scan; their bundled devDependency CVEs are tracked separately in UID2-7393.

**Depends on** IABTechLab/uid2-shared-actions#244 (adds the `dockerfile` input), which must merge and re-tag `v3` before this runs green.

Verified locally: building `Dockerfile_keycloak` and running `trivy image --severity HIGH,CRITICAL --exit-code 1` exits non-zero (firing the Slack notify) and flags CVE-2026-4282 on the current image; after the UID2-7391 bump + these suppressions, the scan is green.