### PR TITLE
UID2-7391: bump Keycloak 26.0.7 → 26.6.4 (fixes 14 HIGH auth CVEs)

### DIFF
--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.0.7
+FROM quay.io/keycloak/keycloak:26.6.4
 
 ENV KC_TRANSACTION_XA_ENABLED 'false'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       retries: 5
   keycloak:
     container_name: uid2_selfserve_keycloak
-    image: quay.io/keycloak/keycloak:26.0.7
+    image: quay.io/keycloak/keycloak:26.6.4
     environment:
       KC_DB: mssql
       KC_DB_URL: jdbc:sqlserver://database:1433;DatabaseName=keycloak;encrypt=true;trustServerCertificate=true;


### PR DESCRIPTION
Bumps the Keycloak IdP base image `26.0.7 → 26.6.4` (latest stable) in `Dockerfile_keycloak` and `docker-compose.yml`, clearing a set of HIGH-severity Keycloak CVEs present in 26.0.7.

**Verified on 26.6.4:** the realm imports cleanly, the custom theme loads, the existing SPI startup flags are accepted with no errors or deprecation warnings, and the rebuilt image scans clean of the targeted CVEs.

Scoped to just the version bump. The recurring image scan that surfaces this class of CVE, and the `.trivyignore` suppressions for the residual upstream-bundled CVEs that remain in 26.6.4, are in UID2-7390 / #826.