### PR TITLE
UID2-7409: Keycloak 26.6.4 backend fixups (admin-client URL + JPA SPI flag)

### DIFF
--- a/Dockerfile_keycloak
+++ b/Dockerfile_keycloak
@@ -14,4 +14,4 @@ sed -i -E "s#http://localhost:[0-9]*#$SSP_WEB_HOST#g" opt/keycloak/data/import/r
 sed -i "s#__KEYCLOAK_OKTA_IDP_CLIENT_ID__#$KEYCLOAK_OKTA_IDP_CLIENT_ID#g" opt/keycloak/data/import/realm-export.json && \
 sed -i "s#__KEYCLOAK_OKTA_IDP_CLIENT_SECRET__#$KEYCLOAK_OKTA_IDP_CLIENT_SECRET#g" opt/keycloak/data/import/realm-export.json && \
 sed -i "s#__SSP_KK_CLIENT_SECRET__#$SSP_KK_SECRET#g" opt/keycloak/data/import/realm-export.json && \
-/opt/keycloak/bin/kc.sh start --hostname=$SSP_AUTH_HOST --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --health-enabled=true --metrics-enabled=true --spi-connections-jpa-legacy-migration-strategy=update
+/opt/keycloak/bin/kc.sh start --hostname=$SSP_AUTH_HOST --import-realm --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false --health-enabled=true --metrics-enabled=true --spi-connections-jpa-quarkus-migration-strategy=update

--- a/keycloak/start.sh
+++ b/keycloak/start.sh
@@ -22,4 +22,4 @@ exec /opt/keycloak/bin/kc.sh start-dev \
   --spi-theme-cache-templates=false \
   --health-enabled=true \
   --metrics-enabled=true \
-  --spi-connections-jpa-legacy-migration-strategy=update
+  --spi-connections-jpa-quarkus-migration-strategy=update

--- a/src/api/keycloakAdminClient.ts
+++ b/src/api/keycloakAdminClient.ts
@@ -17,8 +17,12 @@ export const getKcAdminClient = async () => {
 		}
   }
 
+	// Strip any trailing slash: keycloak-admin-client builds the token URL as
+	// `${baseUrl}/realms/...`, so a trailing slash yields a non-normalized `//realms/...`
+	// path that Keycloak 26.6.3+ rejects with `missingNormalization` (keycloak-js
+	// normalizes this for us on the frontend, but the admin client does not).
 	const kcClient = new KcAdminClientClass({
-    baseUrl: SSP_KK_AUTH_SERVER_URL,
+    baseUrl: SSP_KK_AUTH_SERVER_URL.replace(/\/+$/, ''),
     realmName: SSP_KK_REALM,
   });
 


### PR DESCRIPTION
Two backend fixups for the Keycloak 26.0.7 → 26.6.4 bump (UID2-7391). Jira: UID2-7409.

### 1. Strip trailing slash from Keycloak admin-client `baseUrl`
`keycloak-admin-client` builds the token URL as `${baseUrl}/realms/.../token`. With a trailing slash on `SSP_KK_AUTH_SERVER_URL` this becomes `//realms/...`, which Keycloak 26.6.3+ rejects with `missingNormalization` — 500ing every `client_credentials` admin call (accept T&C, invite, reset). `keycloak-js` already strips it (so login worked); this mirrors that server-side. The env-side fix is in [uid2-deployment#4069](https://github.com/UnifiedID2/uid2-deployment/pull/4069); this is defence-in-depth.

### 2. Fix ineffective JPA `migration-strategy` SPI flag
The Quarkus JPA provider id is `quarkus`, so `--spi-connections-jpa-**legacy**-migration-strategy` is silently ignored. No behavior change today (ignored value == default `update`), but a future `=manual` would also be ignored and auto-migrate anyway. Renamed to `quarkus` in `Dockerfile_keycloak` and `keycloak/start.sh`.

Not run locally (config + one-line string change); relying on CI.