### PR TITLE
UID2-7422: keep ssportal-migration at CRITICAL-only vuln floor

### DIFF
--- a/.github/workflows/release-self-serve-portal-image.yaml
+++ b/.github/workflows/release-self-serve-portal-image.yaml
@@ -111,6 +111,8 @@ jobs:
       docker_file: Dockerfile_ssportal_migration
       docker_image_name: iabtechlab/uid2-ssportal-migration
       docker_registry: ghcr.io
+      vulnerability_severity: CRITICAL
+      vulnerability_exception_ticket: https://thetradedesk.atlassian.net/browse/UID2-7422
     secrets: inherit
 
   publishForKeycloak:


### PR DESCRIPTION
## What

Wires a standing vulnerability exception for the `uid2-ssportal-migration` image so it stays at the `CRITICAL`-only Trivy failure floor, rather than moving to the new `CRITICAL,HIGH` default.

In the `publishForDBMigration` job of `.github/workflows/release-self-serve-portal-image.yaml`, adds to the migration image's `with:` block only: `vulnerability_severity: CRITICAL` plus a `vulnerability_exception_ticket` referencing the standing exception UID2-7422.

This is the reusable-workflow call path (`shared-publish-to-docker-versioned.yaml@v3`), so the input is `vulnerability_severity` (not the composite action's `failure_severity`). No other images' publish steps are touched.

## ⚠️ DO NOT MERGE until [uid2-shared-actions#246](https://github.com/IABTechLab/uid2-shared-actions/pull/246) lands and `@v3` is re-cut

The `vulnerability_severity` / `vulnerability_exception_ticket` inputs **do not exist on `@v3`** until that PR merges and the `v3` tag is re-cut. Merging this earlier will break the build with an unknown-input error.

## Why

The migration image is an internal, non-internet-facing one-shot job, so it carries a standing exception to remain at the `CRITICAL`-only floor rather than remediating HIGH. Rationale is tracked under UID2-7422.

Depends on / paired with: IABTechLab/uid2-shared-actions#246 (flips the publish path's failure floor to `CRITICAL,HIGH` by default and adds the build-time guard requiring both a severity override and a format-valid exception-ticket link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
