### PR TITLE
UID2-7444: Fix SSP login⇄logout trap for newly-invited users

### DIFF
--- a/src/web/screens/logout.test.tsx
+++ b/src/web/screens/logout.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react';
+
+import * as keycloakMocks from '../../testHelpers/keycloakMocks';
+import * as KeycloakProvider from '../contexts/KeycloakProvider';
+import { LogoutRoute } from './logout';
+
+// Needed to enable spying on useKeycloak
+jest.mock('../contexts/KeycloakProvider', () => ({
+  __esModule: true,
+  ...jest.requireActual('../contexts/KeycloakProvider'),
+}));
+
+describe('Logout', () => {
+  let kcMock: jest.SpyInstance;
+  let logoutSpy: jest.Mock;
+
+  beforeEach(() => {
+    logoutSpy = jest.fn(() => Promise.resolve());
+    const mockKeycloak = keycloakMocks.mockAuthenticatedKeycloak();
+    // Override logout on the Keycloak-typed object rather than rebuilding it via spread, which
+    // would drop the class's method members and no longer satisfy the Keycloak type.
+    mockKeycloak.keycloak.logout = logoutSpy;
+    kcMock = jest.spyOn(KeycloakProvider, 'useKeycloak').mockImplementation(() => ({
+      ...mockKeycloak,
+      authenticated: true,
+    }));
+  });
+
+  afterEach(() => {
+    kcMock.mockRestore();
+  });
+
+  // Regression test for UID2-7444: an invitee's email redirects to /logout, a PrivateRoute.
+  // Since ee45cbd3, PrivateRoute sends unauthenticated users back to log into their current
+  // path, so calling keycloak.logout() with no redirectUri (which then defaults to /logout)
+  // traps the user: /logout logs them out, PrivateRoute redirects them to log in again, and
+  // logging in lands them right back on /logout. Passing redirectUri: window.location.origin
+  // sends them to the site root instead, breaking the cycle while preserving the UID2-1579
+  // session-teardown behavior.
+  it('logs out to the site root so it does not loop back to /logout', () => {
+    render(LogoutRoute.element);
+
+    expect(logoutSpy).toHaveBeenCalledWith({ redirectUri: window.location.origin });
+    expect(logoutSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web/screens/logout.tsx
+++ b/src/web/screens/logout.tsx
@@ -6,7 +6,13 @@ import './home.scss';
 
 function Logout() {
   const { keycloak } = useKeycloak();
-  keycloak?.logout();
+  // Send the browser to the site root after logout. With no redirectUri, keycloak-js defaults
+  // the post-logout redirect to the current URL, so once the Keycloak server tears down the
+  // session it sends the browser back to /logout — now unauthenticated — where PrivateRoute
+  // redirects it to log into its current path. Invitees whose invite email redirects here
+  // then get trapped bouncing between login and /logout (UID2-7444). The origin lets them log
+  // in fresh, preserving the UID2-1579 session-teardown intent.
+  keycloak?.logout({ redirectUri: window.location.origin });
   return <h1>Logging out...</h1>;
 }
 export const LogoutRoute: PortalRoute = {


### PR DESCRIPTION
A newly-invited SSP user who accepts their invite gets stuck bouncing
between login and logout, never reaching the portal.

The invite email redirects to /logout on purpose (UID2-1579: tear down
any stale inviting-account session and force a fresh login). /logout
renders inside a PrivateRoute, and its Logout screen calls
keycloak.logout() with no redirectUri. keycloak-js then defaults the
post-logout redirect to the current URL, so once the Keycloak server
tears down the session it sends the browser back to /logout — now
unauthenticated.

This was harmless until ee45cbd3 ("Pass kc_idp_hint to Keycloak login
when present in URL", 2026-03-09), which changed PrivateRoute's post-login
redirect from the site root to the current path (origin + pathname +
search) so deep links and kc_idp_hint survive login. Correct for real
pages, but on /logout it creates a trap: after logout the browser lands
back on /logout unauthenticated, PrivateRoute redirects the user to log
in, and logging in returns them right back to /logout.

Fix: pass redirectUri: window.location.origin to keycloak.logout() so the
browser lands on the site root after logout, breaking the cycle. Scoped to
/logout, so ee45cbd3's deep-link behavior is preserved everywhere else, and
UID2-1579's session teardown still runs — only where logout returns changes.

Add a regression test asserting Logout calls keycloak.logout with
redirectUri set to the origin.
