### PR TITLE
UID2-7554/7557/7559: SSP fast-uri fix + keycloak-image jackson/postgresql suppressions

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -25,4 +25,11 @@ CVE-2025-66293 exp:2026-09-29
 # reachable over the network. Fixable only by a future upstream Keycloak/RHEL base release.
 CVE-2026-54369 exp:2026-09-30
 CVE-2026-54371 exp:2026-09-30
+# jackson-core async parser maxNumberLength bypass (incomplete fix for GHSA-72hv-8253-57qq) -
+# bundled in keycloak-admin-cli in the Keycloak image; not reachable (synchronous ObjectMapper
+# only). See: UID2-7557
+GHSA-r7wm-3cxj-wff9 exp:2026-09-29
+# postgresql JDBC driver (Keycloak DB driver); connects only to our managed first-party Postgres.
+# See: UID2-7559
+CVE-2026-54291 exp:2026-09-29
 # --- end Keycloak residual ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -15284,9 +15284,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -15296,7 +15296,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",

--- a/package.json
+++ b/package.json
@@ -270,6 +270,6 @@
     "path-to-regexp@0": "0.1.13",
     "picomatch": "^2.3.2",
     "lodash": "^4.18.0",
-    "fast-uri": ">=3.1.2"
+    "fast-uri": "^3.1.4"
   }
 }


### PR DESCRIPTION
## SSP vulnerability remediation (this run)

Covers all HIGH findings surfaced for uid2-self-serve-portal — the `trivy fs` finding (fixed) and the two keycloak **image**-scan findings (suppressed).

**fast-uri — CVE-2026-13676, CVE-2026-16221 (UID2-7554)** — real fix: bump the existing override `fast-uri >=3.1.2` → `^3.1.4` (resolves 3.1.4). Lockfile regenerated.

**jackson-core — GHSA-r7wm-3cxj-wff9 (UID2-7557)** and **postgresql — CVE-2026-54291 (UID2-7559)** — both bundled inside `quay.io/keycloak/keycloak:26.6.4` (`Dockerfile_keycloak`), not independently patchable. Added to the existing Keycloak-residual block in `.trivyignore` (exp 2026-09-29). jackson-core async parser is not reachable (synchronous ObjectMapper only, per UID2-6670); postgresql is fixable only via a keycloak base-image bump (UID2-7390/7391).

Tickets: UID2-7554, UID2-7557, UID2-7559.
