### PR TITLE
UID2-7557/7559: suppress keycloak-image jackson-core + postgresql HIGH CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -25,4 +25,11 @@ CVE-2025-66293 exp:2026-09-29
 # reachable over the network. Fixable only by a future upstream Keycloak/RHEL base release.
 CVE-2026-54369 exp:2026-09-30
 CVE-2026-54371 exp:2026-09-30
+# jackson-core async parser maxNumberLength bypass (incomplete fix for GHSA-72hv-8253-57qq) -
+# bundled in keycloak-admin-cli in the Keycloak image; not reachable (synchronous ObjectMapper
+# only). See: UID2-7557
+GHSA-r7wm-3cxj-wff9 exp:2026-09-29
+# postgresql JDBC driver (Keycloak DB driver); connects only to our managed first-party Postgres.
+# See: UID2-7559
+CVE-2026-54291 exp:2026-09-29
 # --- end Keycloak residual ---


### PR DESCRIPTION
## Vulnerability suppression — SSP Keycloak image

Two HIGH findings surfaced by the SSP **image** scan, both bundled inside `quay.io/keycloak/keycloak:26.6.4` (`Dockerfile_keycloak`) and not independently patchable by us. Added to the existing Keycloak-residual block in `.trivyignore` (exp 2026-09-29).

- **jackson-core `GHSA-r7wm-3cxj-wff9`** (in `keycloak-admin-cli`): async-parser `maxNumberLength` bypass, incomplete fix for GHSA-72hv-8253-57qq. Not reachable — synchronous `ObjectMapper` only (same rationale as UID2-6670 / UID2-7557).
- **postgresql `CVE-2026-54291`** (Keycloak’s bundled JDBC driver, fixed 42.7.12): only fixable via a Keycloak base-image bump (tracked under UID2-7391/7390); the driver connects only to our managed first-party Postgres.

Tickets: UID2-7557 (jackson-core), UID2-7559 (postgresql).